### PR TITLE
feature/add background color setter

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
     <p style="margin:2px;">
         <button id="showBoundingBox">Bounds</button>
         <input type="color" id="boundingBoxColor" value="#ffff00">
+        <input type="color" id="backgroundColor" value="#000000">
         <button id="flipXBtn">FlipX</button>
         <button id="flipYBtn">FlipY</button>
         <button id="flipZBtn">FlipZ</button>

--- a/public/index.ts
+++ b/public/index.ts
@@ -66,6 +66,7 @@ const myState: State = {
 
   showBoundingBox: false,
   boundingBoxColor: [255, 255, 0],
+  backgroundColor: [0, 0, 0],
   flipX: 1,
   flipY: 1,
   flipZ: 1,
@@ -1033,18 +1034,23 @@ function main() {
     myState.showBoundingBox = !myState.showBoundingBox;
     view3D.setShowBoundingBox(myState.volume, myState.showBoundingBox);
   });
+
+  // convert value to rgb array
+  function hexToRgb(hex, last: [number, number, number]): [number, number, number] {
+    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return result
+      ? [parseInt(result[1], 16) / 255.0, parseInt(result[2], 16) / 255.0, parseInt(result[3], 16) / 255.0]
+      : last;
+  }
   const boundsColorBtn = document.getElementById("boundingBoxColor");
   boundsColorBtn?.addEventListener("change", (event: Event) => {
-    // convert value to rgb array
-    function hexToRgb(hex, last: [number, number, number]): [number, number, number] {
-      const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-      return result
-        ? [parseInt(result[1], 16) / 255.0, parseInt(result[2], 16) / 255.0, parseInt(result[3], 16) / 255.0]
-        : last;
-    }
-
     myState.boundingBoxColor = hexToRgb((event.target as HTMLInputElement)?.value, myState.boundingBoxColor);
     view3D.setBoundingBoxColor(myState.volume, myState.boundingBoxColor);
+  });
+  const backgroundColorBtn = document.getElementById("backgroundColor");
+  backgroundColorBtn?.addEventListener("change", (event: Event) => {
+    myState.backgroundColor = hexToRgb((event.target as HTMLInputElement)?.value, myState.backgroundColor);
+    view3D.setBackgroundColor(myState.backgroundColor);
   });
 
   const flipXBtn = document.getElementById("flipXBtn");

--- a/public/types.ts
+++ b/public/types.ts
@@ -51,6 +51,8 @@ export interface State {
   showBoundingBox: boolean;
   boundingBoxColor: [number, number, number];
 
+  backgroundColor: [number, number, number];
+
   flipX: number;
   flipY: number;
   flipZ: number;

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -1,4 +1,5 @@
 import {
+  Color,
   DataTexture,
   RedFormat,
   UnsignedByteType,
@@ -156,9 +157,13 @@ export default class FusedChannelData {
     }
     renderer.setRenderTarget(this.fuseRenderTarget);
     renderer.autoClearColor = true;
+    const prevClearColor = new Color();
+    renderer.getClearColor(prevClearColor);
+    const prevClearAlpha = renderer.getClearAlpha();
     renderer.setClearColor(0x000000, 0);
     renderer.render(this.fuseScene, this.quadCamera);
     renderer.setRenderTarget(null);
+    renderer.setClearColor(prevClearColor, prevClearAlpha);
     // "dirty flag"
     this.fuseRequested = null;
   }

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -5,6 +5,7 @@ import {
   FloatType,
   Matrix4,
   Mesh,
+  NormalBlending,
   OrthographicCamera,
   PerspectiveCamera,
   PlaneBufferGeometry,
@@ -293,6 +294,8 @@ export default class PathTracedVolume {
       fragmentShader: this.screenOutputShader.fragmentShader,
       depthWrite: false,
       depthTest: false,
+      blending: NormalBlending,
+      transparent: true,
     });
 
     this.denoiseShaderUniforms = denoiseShaderUniforms();
@@ -302,6 +305,8 @@ export default class PathTracedVolume {
       fragmentShader: denoiseFragmentShaderSrc,
       depthWrite: false,
       depthTest: false,
+      blending: NormalBlending,
+      transparent: true,
     });
 
     this.screenOutputMaterial.uniforms.tTexture0.value = this.pathTracingRenderTarget.texture;

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -247,6 +247,7 @@ export class View3d {
     const hexColor = new Color().fromArray(color).getHex();
     this.backgroundColor = hexColor;
     this.canvas3d.renderer.setClearColor(hexColor, 1);
+    this.redraw();
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -244,9 +244,7 @@ export class View3d {
   }
 
   setBackgroundColor(color: [number, number, number]): void {
-    const colorObj = new Color().fromArray(color);
-    const hexColor = colorObj.getHex();
-    this.canvas3d.getCanvas().style.backgroundColor = "#" + colorObj.getHexString();
+    const hexColor = new Color().fromArray(color).getHex();
     this.backgroundColor = hexColor;
     this.canvas3d.renderer.setClearColor(hexColor, 1);
   }

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -1,4 +1,4 @@
-import { AmbientLight, Vector3, Object3D, SpotLight, DirectionalLight, Euler, Scene } from "three";
+import { AmbientLight, Vector3, Object3D, SpotLight, DirectionalLight, Euler, Scene, Color } from "three";
 
 import { ThreeJsPanel } from "./ThreeJsPanel";
 import lightSettings from "./constants/lights";
@@ -241,6 +241,14 @@ export class View3d {
       this.image.setBoundingBoxColor(color);
     }
     this.redraw();
+  }
+
+  setBackgroundColor(color: [number, number, number]): void {
+    const colorObj = new Color().fromArray(color);
+    const hexColor = colorObj.getHex();
+    this.canvas3d.getCanvas().style.backgroundColor = "#" + colorObj.getHexString();
+    this.backgroundColor = hexColor;
+    this.canvas3d.renderer.setClearColor(hexColor, 1);
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -20,7 +20,7 @@ export interface View3dOptions {
 export class View3d {
   private canvas3d: ThreeJsPanel;
   private scene: Scene;
-  private backgroundColor: number;
+  private backgroundColor: Color;
   private pixelSamplingRate: number;
   private exposure: number;
   private volumeRenderMode: number;
@@ -50,7 +50,7 @@ export class View3d {
     this.canvas3d = new ThreeJsPanel(parentElement, options.useWebGL2);
     this.redraw = this.redraw.bind(this);
     this.scene = new Scene();
-    this.backgroundColor = 0x000000;
+    this.backgroundColor = new Color(0x000000);
     this.lights = [];
 
     this.pixelSamplingRate = 0.75;
@@ -244,9 +244,9 @@ export class View3d {
   }
 
   setBackgroundColor(color: [number, number, number]): void {
-    const hexColor = new Color().fromArray(color).getHex();
-    this.backgroundColor = hexColor;
-    this.canvas3d.renderer.setClearColor(hexColor, 1);
+    const c = new Color().fromArray(color);
+    this.backgroundColor = c;
+    this.canvas3d.setClearColor(c, 1);
     this.redraw();
   }
 
@@ -399,7 +399,7 @@ export class View3d {
     this.currentScale = new Vector3(0.5, 0.5, 0.5);
 
     // background color
-    this.canvas3d.renderer.setClearColor(this.backgroundColor, 1.0);
+    this.canvas3d.setClearColor(this.backgroundColor, 1.0);
 
     this.lights = [new Light(SKY_LIGHT), new Light(AREA_LIGHT)];
 


### PR DESCRIPTION
Adds the method `view3d.setBackgroundColor`.

This function both calls `renderer.setClearColor` (tied to the already existing `view3d.backgroundColor` property but in practice seems to only matter for the first frame) and sets the canvas element's `style.backgroundColor`. Should it do only one or the other, or something else?