### PR TITLE
add support for more tiff formats

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,44 @@
+name: github pages
+
+env:
+  NODE_VERSION: "14.x"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{env.NODE_VERSION}}
+
+      - name: Cache dependencies
+
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm ci
+      - run: npm run gh-build
+      - name: Prepare tag
+        id: prepare_tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_NAME="${GITHUB_REF##refs/tags/}"
+          echo "::set-output name=tag_name::${TAG_NAME}"
+          echo "::set-output name=deploy_tag_name::deploy-${TAG_NAME}"
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./volumeviewer
+          tag_name: ${{ steps.prepare_tag.outputs.deploy_tag_name }}
+          tag_message: "Deployment to gh-pages to test new viewer ${{ steps.prepare_tag.outputs.tag_name }}"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build-demo": "webpack --config webpack.demo.js",
     "clean": "rimraf es/",
     "format": "prettier --write src/**/*.js",
+    "gh-build": "webpack --config webpack.dev.js",
     "dev": "webpack serve --config webpack.dev.js",
     "start": "webpack serve --config webpack.dev.js",
     "react-example": "webpack serve --config react-example/webpack.react.js",

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -23,8 +23,8 @@ function convertChannel(
       }
     }
   } else {
-    let chmin = 65535; //metadata.channels[i].window.min;
-    let chmax = 0; //metadata.channels[i].window.max;
+    let chmin = channelData[0][0][0];
+    let chmax = channelData[0][0][0];
     // find min and max (only of data we are sampling?)
     for (let z = 0; z < nz; z += downsampleZ) {
       for (let j = 0; j < xy; ++j) {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -10,15 +10,13 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, "volumeviewer"),
     filename: "volume-viewer-ui.bundle.js",
-    publicPath: "/volumeviewer/",
   },
   devtool: "source-map",
   devServer: {
-    open: ["volumeviewer/"],
+    open: ["/"],
     port: 9020,
     static: [
       {
-        publicPath: "/volumeviewer/",
         staticOptions: {
           dotfiles: "allow",
         },


### PR DESCRIPTION
@colobas was having trouble loading some TIFFs because they were using pixel formats that had not been implemented in this loader yet.

Here's the code to try to handle any of a variety of pixel formats.
( Fixes #55 ). This is not well tested yet.

Current restrictions:
No pixel formats > 32bit are implemented.
No RGB pixel formats are implemented; the code expects one sample per pixel.

Note that at load time, pixel data is re-fitted to an internal storage format of 8bit unsigned int.  This is intentional for fast interactive display.

One small edit was made to the Zarr loader to fix the selection of min and max values.