### PR TITLE
Fix/bounding box vs axis clip

### DIFF
--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -42,6 +42,8 @@ export default class RayMarchedAtlasVolume {
     // need?
     this.volume = volume;
 
+    // note that these bounds are the clipped region of interest,
+    // and not always the whole volume
     this.bounds = {
       bmin: new Vector3(-0.5, -0.5, -0.5),
       bmax: new Vector3(0.5, 0.5, 0.5),

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -52,7 +52,10 @@ export default class RayMarchedAtlasVolume {
     this.cubeMesh = new Mesh(this.cube);
     this.cubeMesh.name = "Volume";
 
-    this.boxHelper = new Box3Helper(new Box3(this.bounds.bmin, this.bounds.bmax), new Color(0xffff00));
+    this.boxHelper = new Box3Helper(
+      new Box3(new Vector3(-0.5, -0.5, -0.5), new Vector3(0.5, 0.5, 0.5)),
+      new Color(0xffff00)
+    );
     this.boxHelper.updateMatrixWorld();
     this.boxHelper.visible = false;
 


### PR DESCRIPTION
There is a scenario in which calling setAxisClip can modify the drawn bounding box inappropriately.  
This is because the bounding box BoxHelper object was initialized with references to the `bounds` vectors, and it really should not be using those refs but have its own independent bounds.

This scenario is easily reproducible in website-3d-cell-viewer when you switch from 3d to XY view mode right after loading the volume.
The ui update causes the axis sliders to be re-rendered, which also triggers a call to setAxisClip, which was updating the ref described above.
