### PR TITLE
Fix/type tweaks

### DIFF
--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -48,8 +48,8 @@ export default class Histogram {
   private bins: Uint32Array;
   private dataMin: number;
   private dataMax: number;
-  private maxBin: number;
   private nonzeroPixelCount: number;
+  public maxBin: number;
 
   constructor(data: Uint8Array) {
     // no more than 2^32 pixels of any one intensity in the data!?!?!

--- a/src/MeshVolume.ts
+++ b/src/MeshVolume.ts
@@ -119,7 +119,7 @@ export default class MeshVolume {
     // no op
   }
 
-  setAxisClip(axis: number, minval: number, maxval: number, _isOrthoAxis: boolean): void {
+  setAxisClip(axis: "x" | "y" | "z", minval: number, maxval: number, _isOrthoAxis: boolean): void {
     this.bounds.bmax[axis] = maxval;
     this.bounds.bmin[axis] = minval;
     this.updateClipFromBounds();

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -566,7 +566,7 @@ export default class PathTracedVolume {
   }
 
   // -0.5 .. 0.5
-  setAxisClip(axis: number, minval: number, maxval: number, _isOrthoAxis: boolean): void {
+  setAxisClip(axis: "x" | "y" | "z", minval: number, maxval: number, _isOrthoAxis: boolean): void {
     this.bounds.bmax[axis] = maxval;
     this.bounds.bmin[axis] = minval;
     const physicalSize = this.volume.normalizedPhysicalSize;

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -208,7 +208,7 @@ export default class RayMarchedAtlasVolume {
     this.setUniform("maxProject", isMaxProject ? 1 : 0);
   }
 
-  public setAxisClip(axis: number, minval: number, maxval: number, isOrthoAxis: boolean): void {
+  public setAxisClip(axis: "x" | "y" | "z", minval: number, maxval: number, isOrthoAxis: boolean): void {
     this.bounds.bmax[axis] = maxval;
     this.bounds.bmin[axis] = minval;
 

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -507,7 +507,7 @@ export class View3d {
    * @param {number=} oh Ignored.
    * @param {Object=} eOpts Ignored.
    */
-  resize(comp: HTMLElement | null, w: number, h: number, ow?: number, oh?: number, eOpts?: unknown): void {
+  resize(comp: HTMLElement | null, w?: number, h?: number, ow?: number, oh?: number, eOpts?: unknown): void {
     w = w || this.parentEl.offsetWidth;
     h = h || this.parentEl.offsetHeight;
     this.canvas3d.resize(comp, w, h, ow, oh, eOpts);
@@ -661,7 +661,7 @@ export class View3d {
    * @param {number} maxval 0..1, should be greater than minval
    * @param {boolean} isOrthoAxis is this an orthographic projection or just a clipping of the range for perspective view
    */
-  setAxisClip(volume: Volume, axis: number, minval: number, maxval: number, isOrthoAxis: boolean): void {
+  setAxisClip(volume: Volume, axis: "x" | "y" | "z", minval: number, maxval: number, isOrthoAxis: boolean): void {
     if (this.image) {
       this.image.setAxisClip(axis, minval, maxval, isOrthoAxis);
     }

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -135,7 +135,7 @@ export default class Volume {
   private currentScale: Vector3;
   private physicalSize: Vector3;
   public normalizedPhysicalSize: Vector3;
-  public loaded: boolean;
+  private loaded: boolean;
   /* eslint-disable @typescript-eslint/naming-convention */
   public num_channels: number;
   public channel_names: string[];

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -135,12 +135,12 @@ export default class Volume {
   private currentScale: Vector3;
   private physicalSize: Vector3;
   public normalizedPhysicalSize: Vector3;
-  private loaded: boolean;
+  public loaded: boolean;
   /* eslint-disable @typescript-eslint/naming-convention */
   public num_channels: number;
   public channel_names: string[];
   public channel_colors_default: [number, number, number][];
-  private pixel_size: [number, number, number];
+  public pixel_size: [number, number, number];
   /* eslint-enable @typescript-eslint/naming-convention */
 
   constructor(imageInfo: ImageInfo = getDefaultImageInfo()) {

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -84,7 +84,7 @@ export default class VolumeDrawable {
 
     this.channelColors = this.volume.channel_colors_default.slice();
 
-    this.channelOptions = new Array(this.volume.num_channels).fill({});
+    this.channelOptions = new Array<VolumeChannelDisplayOptions>(this.volume.num_channels).fill({});
 
     this.fusion = this.channelColors.map((col, index) => {
       let rgbColor;
@@ -159,9 +159,9 @@ export default class VolumeDrawable {
         bmax: new Vector3(options.clipBounds[1], options.clipBounds[3], options.clipBounds[5]),
       };
       // note: dropping isOrthoAxis argument
-      this.setAxisClip(0, options.clipBounds[0], options.clipBounds[1]);
-      this.setAxisClip(1, options.clipBounds[2], options.clipBounds[3]);
-      this.setAxisClip(2, options.clipBounds[4], options.clipBounds[5]);
+      this.setAxisClip("x", options.clipBounds[0], options.clipBounds[1]);
+      this.setAxisClip("y", options.clipBounds[2], options.clipBounds[3]);
+      this.setAxisClip("z", options.clipBounds[4], options.clipBounds[5]);
     }
     if (options.scale !== undefined) {
       this.setScale(new Vector3().fromArray(options.scale));
@@ -199,13 +199,13 @@ export default class VolumeDrawable {
     // merge to current channel options
     this.channelOptions[channelIndex] = Object.assign(this.channelOptions[channelIndex], options);
 
-    if (Object.hasOwnProperty.call(options, "enabled")) {
+    if (options.enabled !== undefined) {
       this.setVolumeChannelEnabled(channelIndex, options.enabled);
     }
-    if (Object.hasOwnProperty.call(options, "color")) {
+    if (options.color !== undefined) {
       this.updateChannelColor(channelIndex, options.color);
     }
-    if (Object.hasOwnProperty.call(options, "isosurfaceEnabled")) {
+    if (options.isosurfaceEnabled !== undefined) {
       const hasIso = this.hasIsosurface(channelIndex);
       if (hasIso !== options.isosurfaceEnabled) {
         if (hasIso && !options.isosurfaceEnabled) {
@@ -213,29 +213,29 @@ export default class VolumeDrawable {
         } else if (!hasIso && options.isosurfaceEnabled) {
           // 127 is half of the intensity range 0..255
           let isovalue = 127;
-          if (Object.hasOwnProperty.call(options, "isovalue")) {
+          if (options.isovalue !== undefined) {
             isovalue = options.isovalue;
           }
           // 1.0 is fully opaque
           let isosurfaceOpacity = 1.0;
-          if (Object.hasOwnProperty.call(options, "isosurfaceOpacity")) {
+          if (options.isosurfaceOpacity !== undefined) {
             isosurfaceOpacity = options.isosurfaceOpacity;
           }
           this.createIsosurface(channelIndex, isovalue, isosurfaceOpacity, isosurfaceOpacity < 1.0);
         }
       } else if (options.isosurfaceEnabled) {
-        if (Object.hasOwnProperty.call(options, "isovalue")) {
+        if (options.isovalue !== undefined) {
           this.updateIsovalue(channelIndex, options.isovalue);
         }
-        if (Object.hasOwnProperty.call(options, "isosurfaceOpacity")) {
+        if (options.isosurfaceOpacity !== undefined) {
           this.updateOpacity(channelIndex, options.isosurfaceOpacity);
         }
       }
     } else {
-      if (Object.hasOwnProperty.call(options, "isovalue")) {
+      if (options.isovalue !== undefined) {
         this.updateIsovalue(channelIndex, options.isovalue);
       }
-      if (Object.hasOwnProperty.call(options, "isosurfaceOpacity")) {
+      if (options.isosurfaceOpacity !== undefined) {
         this.updateOpacity(channelIndex, options.isosurfaceOpacity);
       }
     }
@@ -277,7 +277,7 @@ export default class VolumeDrawable {
   // @param {number} minval -0.5..0.5, should be less than maxval
   // @param {number} maxval -0.5..0.5, should be greater than minval
   // @param {boolean} isOrthoAxis is this an orthographic projection or just a clipping of the range for perspective view
-  setAxisClip(axis: number, minval: number, maxval: number, isOrthoAxis?: boolean): void {
+  setAxisClip(axis: "x" | "y" | "z", minval: number, maxval: number, isOrthoAxis?: boolean): void {
     this.bounds.bmax[axis] = maxval;
     this.bounds.bmin[axis] = minval;
 
@@ -647,9 +647,9 @@ export default class VolumeDrawable {
     this.setFlipAxes(this.flipX, this.flipY, this.flipZ);
 
     // reset clip bounds
-    this.setAxisClip(0, this.bounds.bmin.x, this.bounds.bmax.x);
-    this.setAxisClip(1, this.bounds.bmin.y, this.bounds.bmax.y);
-    this.setAxisClip(2, this.bounds.bmin.z, this.bounds.bmax.z);
+    this.setAxisClip("x", this.bounds.bmin.x, this.bounds.bmax.x);
+    this.setAxisClip("y", this.bounds.bmin.y, this.bounds.bmax.y);
+    this.setAxisClip("z", this.bounds.bmin.z, this.bounds.bmax.z);
     this.updateClipRegion(
       this.bounds.bmin.x + 0.5,
       this.bounds.bmax.x + 0.5,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,14 +27,14 @@ export interface FuseChannel {
    };
  */
 export interface VolumeChannelDisplayOptions {
-  enabled: boolean;
-  color: [number, number, number];
-  specularColor: [number, number, number];
-  emissiveColor: [number, number, number];
-  glossiness: number;
-  isosurfaceEnabled: boolean;
-  isovalue: number;
-  isosurfaceOpacity: number;
+  enabled?: boolean;
+  color?: [number, number, number];
+  specularColor?: [number, number, number];
+  emissiveColor?: [number, number, number];
+  glossiness?: number;
+  isosurfaceEnabled?: boolean;
+  isovalue?: number;
+  isosurfaceOpacity?: number;
 }
 
 /**


### PR DESCRIPTION
Fixing some type errors that appear in website-3d-cell-viewer when types are exported properly from here (#69) which I thought indicated problems with volume-viewer types rather than cell-viewer ones. Including:
- Change axis types from numeric indices to letters (`xyz`) to match three's `Vector3` type
- Make all properties of `VolumeChannelDisplayOptions` optional (matches `VolumeDisplayOptions`)
- Publicize any private fields that 3d-cell-viewer was accessing anyways. NOTE: I did this uncritically to just flag that the cell viewer was doing this. Changing `private` to `public` may not be the best final answer for a couple of these.