### PR TITLE
Feature/add max project button to test viewer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
         <button id="xfBtn">Align</button>
         <button id="resetCamBtn">ResetCam</button>
         <button id="ptBtn" disabled>Pathtrace</button>
+        <button id="mpBtn">Max project</button>
         <button id="screenshotBtn">Screenshot</button>
     </p>
     <p style="margin:2px;">

--- a/public/index.html
+++ b/public/index.html
@@ -17,8 +17,11 @@
         <button id="axisBtn">Axis</button>
         <button id="xfBtn">Align</button>
         <button id="resetCamBtn">ResetCam</button>
-        <button id="ptBtn" disabled>Pathtrace</button>
-        <button id="mpBtn">Max project</button>
+        <select name="Render mode" id="renderMode">
+            <option value="RM" selected>Volumetric</option>
+            <option value="PT">Pathtrace</option>
+            <option value="MP">Max project</option>
+        </select>
         <button id="screenshotBtn">Screenshot</button>
     </p>
     <p style="margin:2px;">

--- a/public/index.ts
+++ b/public/index.ts
@@ -1234,27 +1234,23 @@ function main() {
     });
   }
 
-  if (view3D.hasWebGL2()) {
-    const ptBtn = document.getElementById("ptBtn") as HTMLButtonElement;
-    ptBtn.disabled = false;
-    ptBtn.addEventListener("click", () => {
-      myState.isPT = !myState.isPT;
-      if (myState.isMP) {
-        myState.isMP = false;
-        view3D.setMaxProjectMode(myState.volume, false);
-      }
-      view3D.setVolumeRenderMode(myState.isPT ? RENDERMODE_PATHTRACE : RENDERMODE_RAYMARCH);
-      view3D.updateLights(myState.lights);
-    });
+  const renderModeSelect = document.getElementById("renderMode");
+  const changeRenderMode = (pt: boolean, mp: boolean) => {
+    myState.isPT = pt;
+    myState.isMP = mp;
+    view3D.setVolumeRenderMode(pt ? RENDERMODE_PATHTRACE : RENDERMODE_RAYMARCH);
+    view3D.setMaxProjectMode(myState.volume, mp);
   }
-  const mpBtn = document.getElementById("mpBtn");
-  mpBtn?.addEventListener("click", () => {
-    if (myState.isPT) {
-      myState.isPT = false;
-      view3D.setVolumeRenderMode(RENDERMODE_RAYMARCH);
+  renderModeSelect?.addEventListener("change", ({ currentTarget }) => {
+    if ((currentTarget as HTMLOptionElement)!.value === "PT") {
+      if (view3D.hasWebGL2()) {
+        changeRenderMode(true, false);
+      }
+    } else if ((currentTarget as HTMLOptionElement)!.value === "MP") {
+      changeRenderMode(false, true);
+    } else {
+      changeRenderMode(false, false);
     }
-    myState.isMP = !myState.isMP;
-    view3D.setMaxProjectMode(myState.volume, myState.isMP);
   });
   const screenshotBtn = document.getElementById("screenshotBtn");
   screenshotBtn?.addEventListener("click", () => {

--- a/public/types.ts
+++ b/public/types.ts
@@ -43,6 +43,7 @@ export interface State {
   secondaryRay: number;
 
   isPT: boolean;
+  isMP: boolean;
 
   isTurntable: boolean;
   isAxisShowing: boolean;


### PR DESCRIPTION
## Problem

When testing approaches for maximum intensity projections, I had no way of switching the test viewer from ray march mode to max project mode.

## Solution

Add a button that does this.

#### Screenshot:
![image](https://user-images.githubusercontent.com/53030214/200036889-8fa91f24-8735-4674-a8de-6dcdb5892049.png)
