### PR TITLE
Feature/disable interpolation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
             <option value="PT">Pathtrace</option>
             <option value="MP">Max project</option>
         </select>
+        <button id="interpolateBtn">Interpolate</button>
         <button id="screenshotBtn">Screenshot</button>
     </p>
     <p style="margin:2px;">

--- a/public/index.ts
+++ b/public/index.ts
@@ -18,7 +18,7 @@ import { State } from "./types";
 import { getDefaultImageInfo } from "../src/Volume";
 
 const loadTimeSeries = false;
-const loadTestData = true;
+const loadTestData = false;
 
 let view3D: View3d;
 
@@ -65,6 +65,7 @@ const myState: State = {
 
   isPT: false,
   isMP: false,
+  interpolationActive: true,
 
   isTurntable: false,
   isAxisShowing: false,
@@ -1252,6 +1253,13 @@ function main() {
       changeRenderMode(false, false);
     }
   });
+
+  const interpolateBtn = document.getElementById("interpolateBtn");
+  interpolateBtn?.addEventListener("click", () => {
+    myState.interpolationActive = !myState.interpolationActive;
+    view3D.setInterpolationActive(myState.volume, myState.interpolationActive);
+  });
+
   const screenshotBtn = document.getElementById("screenshotBtn");
   screenshotBtn?.addEventListener("click", () => {
     view3D.capture((dataUrl) => {

--- a/public/index.ts
+++ b/public/index.ts
@@ -1257,7 +1257,7 @@ function main() {
   const interpolateBtn = document.getElementById("interpolateBtn");
   interpolateBtn?.addEventListener("click", () => {
     myState.interpolationActive = !myState.interpolationActive;
-    view3D.setInterpolationActive(myState.volume, myState.interpolationActive);
+    view3D.setInterpolationEnabled(myState.volume, myState.interpolationActive);
   });
 
   const screenshotBtn = document.getElementById("screenshotBtn");

--- a/public/index.ts
+++ b/public/index.ts
@@ -18,7 +18,7 @@ import { State } from "./types";
 import { getDefaultImageInfo } from "../src/Volume";
 
 const loadTimeSeries = false;
-const loadTestData = false;
+const loadTestData = true;
 
 let view3D: View3d;
 

--- a/public/types.ts
+++ b/public/types.ts
@@ -44,6 +44,7 @@ export interface State {
 
   isPT: boolean;
   isMP: boolean;
+  interpolationActive: boolean;
 
   isTurntable: boolean;
   isAxisShowing: boolean;

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -610,8 +610,9 @@ export default class PathTracedVolume {
     this.resetProgress();
   }
 
-  setInterpolationEnabled(_active: boolean): void {
-    // no op... for now
+  setInterpolationEnabled(active: boolean): void {
+    this.volumeTexture.minFilter = this.volumeTexture.magFilter = active ? LinearFilter : NearestFilter;
+    this.volumeTexture.needsUpdate = true;
   }
 
   //////////////////////////////////////////

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -610,6 +610,10 @@ export default class PathTracedVolume {
     this.resetProgress();
   }
 
+  setInterpolationActive(_active: boolean): void {
+    // no op... for now
+  }
+
   //////////////////////////////////////////
   //////////////////////////////////////////
 
@@ -642,9 +646,7 @@ export default class PathTracedVolume {
       }
     }
 
-    const unchanged = ch.every((elem, index) => {
-      return elem === this.viewChannels[index];
-    }, this);
+    const unchanged = ch.every((elem, index) => elem === this.viewChannels[index], this);
     if (unchanged) {
       return;
     }

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -610,7 +610,7 @@ export default class PathTracedVolume {
     this.resetProgress();
   }
 
-  setInterpolationActive(_active: boolean): void {
+  setInterpolationEnabled(_active: boolean): void {
     // no op... for now
   }
 

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -194,8 +194,8 @@ export default class RayMarchedAtlasVolume {
     }
   }
 
-  public setInterpolationActive(active: boolean): void {
-    this.setUniform("doInterpolation", active);
+  public setInterpolationEnabled(active: boolean): void {
+    this.setUniform("interpolationEnabled", active);
   }
 
   public viewpointMoved(): void {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -194,6 +194,10 @@ export default class RayMarchedAtlasVolume {
     }
   }
 
+  public setInterpolationActive(active: boolean): void {
+    this.setUniform("doInterpolation", active);
+  }
+
   public viewpointMoved(): void {
     // no op
   }
@@ -258,7 +262,10 @@ export default class RayMarchedAtlasVolume {
   //////////////////////////////////////////
   //////////////////////////////////////////
 
-  private setUniform(name, value) {
+  private setUniform<U extends keyof typeof rayMarchingShaderUniforms>(
+    name: U,
+    value: typeof rayMarchingShaderUniforms[U]["value"]
+  ) {
     if (!this.uniforms[name]) {
       return;
     }

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -502,6 +502,7 @@ export class View3d {
     if (this.image) {
       this.image.setInterpolationActive(active);
     }
+    this.redraw();
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -498,9 +498,9 @@ export class View3d {
     }
   }
 
-  setInterpolationActive(volume: Volume, active: boolean): void {
+  setInterpolationEnabled(volume: Volume, active: boolean): void {
     if (this.image) {
-      this.image.setInterpolationActive(active);
+      this.image.setInterpolationEnabled(active);
     }
     this.redraw();
   }

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -498,6 +498,12 @@ export class View3d {
     }
   }
 
+  setInterpolationActive(volume: Volume, active: boolean): void {
+    if (this.image) {
+      this.image.setInterpolationActive(active);
+    }
+  }
+
   /**
    * Notify the view that it has been resized.  This will automatically be connected to the window when the View3d is created.
    * @param {HTMLElement=} comp Ignored.

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -269,11 +269,7 @@ export default class Volume {
 
   onChannelLoaded(batch: number[]): void {
     // check to see if all channels are now loaded, and fire an event(?)
-    if (
-      this.channels.every(function (element, _index, _array) {
-        return element.loaded;
-      })
-    ) {
+    if (this.channels.every((element) => element.loaded)) {
       this.loaded = true;
     }
     for (let i = 0; i < this.volumeDataObservers.length; ++i) {

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -291,8 +291,8 @@ export default class VolumeDrawable {
     this.volumeRendering.setIsOrtho(isOrtho);
   }
 
-  setInterpolationActive(active: boolean): void {
-    this.volumeRendering.setInterpolationActive(active);
+  setInterpolationEnabled(active: boolean): void {
+    this.volumeRendering.setInterpolationEnabled(active);
   }
 
   setOrthoThickness(value: number): void {

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -291,6 +291,10 @@ export default class VolumeDrawable {
     this.volumeRendering.setIsOrtho(isOrtho);
   }
 
+  setInterpolationActive(active: boolean): void {
+    this.volumeRendering.setInterpolationActive(active);
+  }
+
   setOrthoThickness(value: number): void {
     !this.PT && this.meshVolume.setOrthoThickness(value);
     this.volumeRendering.setOrthoThickness(value);

--- a/src/constants/volumeRayMarchShader.ts
+++ b/src/constants/volumeRayMarchShader.ts
@@ -96,8 +96,8 @@ vec4 sampleAs3DTexture(sampler2D tex, vec4 pos) {
     // loc ranges from 0 to 1/ATLAS_X, 1/ATLAS_Y
     // shrink loc0 to within one half edge texel - so as not to sample across edges of tiles.
     loc0 = vec2(0.5/textureRes.x, 0.5/textureRes.y) + loc0*vec2(1.0-(ATLAS_X)/textureRes.x, 1.0-(ATLAS_Y)/textureRes.y);
+    
     // interpolate between two slices
-
     float z = (pos.z)*(nSlices-1.0);
     float z0 = floor(z);
     float t = z-z0; //mod(z, 1.0);
@@ -132,6 +132,7 @@ vec4 sampleAs3DTexture(sampler2D tex, vec4 pos) {
     retval.rgb *= maskVal;
     return bounds*retval;
   } else {
+    // No interpolation - sample just one slice at a pixel center
     loc0 = floor(loc0 * textureRes) / textureRes;
     loc0 += vec2(0.5/textureRes.x, 0.5/textureRes.y);
 
@@ -145,6 +146,7 @@ vec4 sampleAs3DTexture(sampler2D tex, vec4 pos) {
     o = clamp(o, vec2(0.0, 0.0), vec2(1.0-1.0/ATLAS_X, 1.0-1.0/ATLAS_Y)) + loc0;
     vec4 voxelColor = texture2D(tex, o);
 
+    // Apply mask
     float voxelMask = texture2D(textureAtlasMask, o).x;
     voxelMask = mix(voxelMask, 1.0, maskAlpha);
     voxelColor.rgb *= voxelMask;

--- a/src/constants/volumeRayMarchShader.ts
+++ b/src/constants/volumeRayMarchShader.ts
@@ -41,7 +41,7 @@ uniform float isOrtho;
 uniform float orthoThickness;
 uniform float orthoScale;
 uniform int maxProject;
-uniform bool doInterpolation;
+uniform bool interpolationEnabled;
 uniform vec3 flipVolume;
 uniform vec3 volumeScale;
 
@@ -92,7 +92,7 @@ vec4 sampleAs3DTexture(sampler2D tex, vec4 pos) {
     (flipVolume.x*(pos.x - 0.5) + 0.5)/ATLAS_X,
     (flipVolume.y*(pos.y - 0.5) + 0.5)/ATLAS_Y);
 
-  if (doInterpolation) {
+  if (interpolationEnabled) {
     // loc ranges from 0 to 1/ATLAS_X, 1/ATLAS_Y
     // shrink loc0 to within one half edge texel - so as not to sample across edges of tiles.
     loc0 = vec2(0.5/textureRes.x, 0.5/textureRes.y) + loc0*vec2(1.0-(ATLAS_X)/textureRes.x, 1.0-(ATLAS_Y)/textureRes.y);
@@ -390,7 +390,7 @@ export const rayMarchingShaderUniforms = {
     type: "i",
     value: 0,
   },
-  doInterpolation: {
+  interpolationEnabled: {
     type: "b",
     value: true,
   },

--- a/src/constants/volumeRayMarchShader.ts
+++ b/src/constants/volumeRayMarchShader.ts
@@ -139,7 +139,9 @@ vec4 sampleAtlasNearest(sampler2D tex, vec4 pos) {
     (flipVolume.x*(pos.x - 0.5) + 0.5)/ATLAS_X,
     (flipVolume.y*(pos.y - 0.5) + 0.5)/ATLAS_Y);
 
-  // No interpolation - sample just one slice at a pixel center
+  // No interpolation - sample just one slice at a pixel center.
+  // Ideally this would be accomplished in part by switching this texture to linear
+  //   filtering, but three makes this difficult to do through a WebGLRenderTarget.
   loc0 = floor(loc0 * textureRes) / textureRes;
   loc0 += vec2(0.5/textureRes.x, 0.5/textureRes.y);
 

--- a/src/constants/volumeRayMarchShader.ts
+++ b/src/constants/volumeRayMarchShader.ts
@@ -76,10 +76,10 @@ vec2 offsetFrontBack(float t, float nx, float ny) {
   int a = int(t);
   int ax = int(ATLAS_X);
   vec2 os = vec2(float(a-(a/ax)*ax) / ATLAS_X, float(a/ax) / ATLAS_Y);
-  return os;
+  return clamp(os, vec2(0.0, 0.0), vec2(1.0-1.0/ATLAS_X, 1.0-1.0/ATLAS_Y));
 }
 
-vec4 sampleAs3DTexture(sampler2D tex, vec4 pos) {
+vec4 sampleAtlasLinear(sampler2D tex, vec4 pos) {
   float bounds = float(pos[0] >= 0.0 && pos[0] <= 1.0 &&
                        pos[1] >= 0.0 && pos[1] <= 1.0 &&
                        pos[2] >= 0.0 && pos[2] <= 1.0 );
@@ -92,67 +92,72 @@ vec4 sampleAs3DTexture(sampler2D tex, vec4 pos) {
     (flipVolume.x*(pos.x - 0.5) + 0.5)/ATLAS_X,
     (flipVolume.y*(pos.y - 0.5) + 0.5)/ATLAS_Y);
 
-  if (interpolationEnabled) {
-    // loc ranges from 0 to 1/ATLAS_X, 1/ATLAS_Y
-    // shrink loc0 to within one half edge texel - so as not to sample across edges of tiles.
-    loc0 = vec2(0.5/textureRes.x, 0.5/textureRes.y) + loc0*vec2(1.0-(ATLAS_X)/textureRes.x, 1.0-(ATLAS_Y)/textureRes.y);
-    
-    // interpolate between two slices
-    float z = (pos.z)*(nSlices-1.0);
-    float z0 = floor(z);
-    float t = z-z0; //mod(z, 1.0);
-    float z1 = min(z0+1.0, nSlices-1.0);
+  // loc ranges from 0 to 1/ATLAS_X, 1/ATLAS_Y
+  // shrink loc0 to within one half edge texel - so as not to sample across edges of tiles.
+  loc0 = vec2(0.5/textureRes.x, 0.5/textureRes.y) + loc0*vec2(1.0-(ATLAS_X)/textureRes.x, 1.0-(ATLAS_Y)/textureRes.y);
+  
+  // interpolate between two slices
+  float z = (pos.z)*(nSlices-1.0);
+  float z0 = floor(z);
+  float t = z-z0; //mod(z, 1.0);
+  float z1 = min(z0+1.0, nSlices-1.0);
 
-    // flipped:
-    if (flipVolume.z == -1.0) {
-      z0 = nSlices - z0 - 1.0;
-      z1 = nSlices - z1 - 1.0;
-      t = 1.0 - t;
-    }
-
-    // get slice offsets in texture atlas
-    vec2 o0 = offsetFrontBack(z0,ATLAS_X,ATLAS_Y);//*pix;
-    vec2 o1 = offsetFrontBack(z1,ATLAS_X,ATLAS_Y);//*pix;
-    o0 = clamp(o0, vec2(0.0,0.0), vec2(1.0-1.0/ATLAS_X, 1.0-1.0/ATLAS_Y)) + loc0;
-    o1 = clamp(o1, vec2(0.0,0.0), vec2(1.0-1.0/ATLAS_X, 1.0-1.0/ATLAS_Y)) + loc0;
-
-    vec4 slice0Color = texture2D(tex, o0);
-    vec4 slice1Color = texture2D(tex, o1);
-    // NOTE we could premultiply the mask in the fuse function,
-    // but that is slower to update the maskAlpha value than here in the shader.
-    // it is a memory vs perf tradeoff.  Do users really need to update the maskAlpha at realtime speed?
-    float slice0Mask = texture2D(textureAtlasMask, o0).x;
-    float slice1Mask = texture2D(textureAtlasMask, o1).x;
-    // or use max for conservative 0 or 1 masking?
-    float maskVal = mix(slice0Mask, slice1Mask, t);
-    // take mask from 0..1 to alpha..1
-    maskVal = mix(maskVal, 1.0, maskAlpha);
-    vec4 retval = mix(slice0Color, slice1Color, t);
-    // only mask the rgb, not the alpha(?)
-    retval.rgb *= maskVal;
-    return bounds*retval;
-  } else {
-    // No interpolation - sample just one slice at a pixel center
-    loc0 = floor(loc0 * textureRes) / textureRes;
-    loc0 += vec2(0.5/textureRes.x, 0.5/textureRes.y);
-
-    float z = min(floor(pos.z * nSlices), nSlices-1.0);
-    
-    if (flipVolume.z == -1.0) {
-      z = nSlices - z - 1.0;
-    }
-
-    vec2 o = offsetFrontBack(z, ATLAS_X, ATLAS_Y);
-    o = clamp(o, vec2(0.0, 0.0), vec2(1.0-1.0/ATLAS_X, 1.0-1.0/ATLAS_Y)) + loc0;
-    vec4 voxelColor = texture2D(tex, o);
-
-    // Apply mask
-    float voxelMask = texture2D(textureAtlasMask, o).x;
-    voxelMask = mix(voxelMask, 1.0, maskAlpha);
-    voxelColor.rgb *= voxelMask;
-
-    return bounds*voxelColor;
+  // flipped:
+  if (flipVolume.z == -1.0) {
+    z0 = nSlices - z0 - 1.0;
+    z1 = nSlices - z1 - 1.0;
+    t = 1.0 - t;
   }
+
+  // get slice offsets in texture atlas
+  vec2 o0 = offsetFrontBack(z0,ATLAS_X,ATLAS_Y) + loc0;
+  vec2 o1 = offsetFrontBack(z1,ATLAS_X,ATLAS_Y) + loc0;
+
+  vec4 slice0Color = texture2D(tex, o0);
+  vec4 slice1Color = texture2D(tex, o1);
+  // NOTE we could premultiply the mask in the fuse function,
+  // but that is slower to update the maskAlpha value than here in the shader.
+  // it is a memory vs perf tradeoff.  Do users really need to update the maskAlpha at realtime speed?
+  float slice0Mask = texture2D(textureAtlasMask, o0).x;
+  float slice1Mask = texture2D(textureAtlasMask, o1).x;
+  // or use max for conservative 0 or 1 masking?
+  float maskVal = mix(slice0Mask, slice1Mask, t);
+  // take mask from 0..1 to alpha..1
+  maskVal = mix(maskVal, 1.0, maskAlpha);
+  vec4 retval = mix(slice0Color, slice1Color, t);
+  // only mask the rgb, not the alpha(?)
+  retval.rgb *= maskVal;
+  return bounds*retval;
+}
+
+vec4 sampleAtlasNearest(sampler2D tex, vec4 pos) {
+  float bounds = float(pos[0] >= 0.0 && pos[0] <= 1.0 &&
+                       pos[1] >= 0.0 && pos[1] <= 1.0 &&
+                       pos[2] >= 0.0 && pos[2] <= 1.0 );
+  float nSlices = float(SLICES);
+  vec2 loc0 = vec2(
+    (flipVolume.x*(pos.x - 0.5) + 0.5)/ATLAS_X,
+    (flipVolume.y*(pos.y - 0.5) + 0.5)/ATLAS_Y);
+
+  // No interpolation - sample just one slice at a pixel center
+  loc0 = floor(loc0 * textureRes) / textureRes;
+  loc0 += vec2(0.5/textureRes.x, 0.5/textureRes.y);
+
+  float z = min(floor(pos.z * nSlices), nSlices-1.0);
+  
+  if (flipVolume.z == -1.0) {
+    z = nSlices - z - 1.0;
+  }
+
+  vec2 o = offsetFrontBack(z, ATLAS_X, ATLAS_Y) + loc0;
+  vec4 voxelColor = texture2D(tex, o);
+
+  // Apply mask
+  float voxelMask = texture2D(textureAtlasMask, o).x;
+  voxelMask = mix(voxelMask, 1.0, maskAlpha);
+  voxelColor.rgb *= voxelMask;
+
+  return bounds*voxelColor;
 }
 
 bool intersectBox(in vec3 r_o, in vec3 r_d, in vec3 boxMin, in vec3 boxMax,
@@ -227,7 +232,7 @@ vec4 integrateVolume(vec4 eye_o,vec4 eye_d,
     // AABB clip is independent of this and is only used to determine tnear and tfar.
     pos.xyz = (pos.xyz-(-0.5))/((0.5)-(-0.5)); //0.5 * (pos + 1.0); // map position from [boxMin, boxMax] to [0, 1] coordinates
 
-    vec4 col = sampleAs3DTexture(textureAtlas, pos);
+    vec4 col = interpolationEnabled ? sampleAtlasLinear(textureAtlas, pos) : sampleAtlasNearest(textureAtlas, pos);
 
     if (maxProject != 0) {
       col.xyz *= BRIGHTNESS;

--- a/src/constants/volumeRayMarchShader.ts
+++ b/src/constants/volumeRayMarchShader.ts
@@ -206,7 +206,7 @@ vec4 integrateVolume(vec4 eye_o,vec4 eye_d,
   float invstep = (tfar-tnear)/csteps;
   // special-casing the single slice to remove the random ray dither.
   // this removes a Moire pattern visible in single slice images, which we want to view as 2D images as best we can.
-  float r = (SLICES==1.0) ?  0.0 : 0.5 - 1.0*rand(eye_d.xy);
+  float r = (SLICES==1.0) ? 0.0 : rand(eye_d.xy);
   // if ortho and clipped, make step size smaller so we still get same number of steps
   float tstep = invstep*orthoThickness;
   float tfarsurf = r*tstep;

--- a/src/constants/volumeRayMarchShader.ts
+++ b/src/constants/volumeRayMarchShader.ts
@@ -390,7 +390,7 @@ export const rayMarchingShaderUniforms = {
   },
   doInterpolation: {
     type: "b",
-    value: false,
+    value: true,
   },
   flipVolume: {
     type: "v3",

--- a/src/constants/volumeRayMarchShader.ts
+++ b/src/constants/volumeRayMarchShader.ts
@@ -92,13 +92,10 @@ vec4 sampleAs3DTexture(sampler2D tex, vec4 pos) {
     (flipVolume.x*(pos.x - 0.5) + 0.5)/ATLAS_X,
     (flipVolume.y*(pos.y - 0.5) + 0.5)/ATLAS_Y);
 
-  if (!doInterpolation) {
-    loc0 = floor(loc0 * textureRes) / textureRes;
-  }
-  // loc ranges from 0 to 1/ATLAS_X, 1/ATLAS_Y
-  // shrink loc0 to within one half edge texel - so as not to sample across edges of tiles.
-  loc0 = vec2(0.5/textureRes.x, 0.5/textureRes.y) + loc0*vec2(1.0-(ATLAS_X)/textureRes.x, 1.0-(ATLAS_Y)/textureRes.y);
   if (doInterpolation) {
+    // loc ranges from 0 to 1/ATLAS_X, 1/ATLAS_Y
+    // shrink loc0 to within one half edge texel - so as not to sample across edges of tiles.
+    loc0 = vec2(0.5/textureRes.x, 0.5/textureRes.y) + loc0*vec2(1.0-(ATLAS_X)/textureRes.x, 1.0-(ATLAS_Y)/textureRes.y);
     // interpolate between two slices
 
     float z = (pos.z)*(nSlices-1.0);
@@ -135,6 +132,9 @@ vec4 sampleAs3DTexture(sampler2D tex, vec4 pos) {
     retval.rgb *= maskVal;
     return bounds*retval;
   } else {
+    loc0 = floor(loc0 * textureRes) / textureRes;
+    loc0 += vec2(0.5/textureRes.x, 0.5/textureRes.y);
+
     float z = min(floor(pos.z * nSlices), nSlices-1.0);
     
     if (flipVolume.z == -1.0) {


### PR DESCRIPTION
Resolve #62: add "the option to toggle voxel interpolation like in napari." (In ray march mode - would disabling interpolation in pathtrace mode mean anything or make sense?) Via:
- new shader math to do nearest-neighbor interpolation, with a new uniform to switch to that code
  - also, a tweak to ray dithering offsets
- new method `setInterpolationEnabled` to change interpolation behavior
- new button in the test viewer to enable/disable smooth interpolation

And a couple stray modifications:
- shrink a couple arrow functions
- give `rayMarchedAtlasVolume.setUniform` a solid type signature

## Screenshots
![image](https://user-images.githubusercontent.com/53030214/202324382-0218293a-478d-41ce-8c4a-2b5cc41379c3.png)

(from website-3d-cell-viewer)
![image](https://user-images.githubusercontent.com/53030214/202322473-d76d66bd-a2af-4bd7-ab8f-5e5de740325a.png)
![image](https://user-images.githubusercontent.com/53030214/202322557-a90a47b8-5702-42b2-8a62-c49c2287b135.png)

I also attempted to replicate the same image of a cell membrane in both website-3d-cell-viewer and Fiji, to verify that the shader math is correct and samples pure pixel values. Fiji is first, 3d viewer is second:

![695296_fiji](https://user-images.githubusercontent.com/53030214/202322843-475b7105-45da-4c00-90f5-a90fe49314a5.png)
![695296_3dv](https://user-images.githubusercontent.com/53030214/202322848-9b6eabd6-b7d3-4af8-b440-d0ee6fb9b832.png)
