### PR TITLE
Feature/zarr multiscales

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -1241,7 +1241,7 @@ function main() {
     myState.isMP = mp;
     view3D.setVolumeRenderMode(pt ? RENDERMODE_PATHTRACE : RENDERMODE_RAYMARCH);
     view3D.setMaxProjectMode(myState.volume, mp);
-  }
+  };
   renderModeSelect?.addEventListener("change", ({ currentTarget }) => {
     if ((currentTarget as HTMLOptionElement)!.value === "PT") {
       if (view3D.hasWebGL2()) {
@@ -1283,7 +1283,8 @@ function main() {
   } else if (loadTestData) {
     //fetchOpenCell();
     //fetchTiff("https://animatedcell-test-data.s3.us-west-2.amazonaws.com/AICS-12_881.ome.tif", 0);
-    fetchZarr("https://animatedcell-test-data.s3.us-west-2.amazonaws.com/Lamin_multi-06-Deskew-28.zarr", "Image_0", 0);
+    //fetchZarr("https://animatedcell-test-data.s3.us-west-2.amazonaws.com/Lamin_multi-06-Deskew-28.zarr", "Image_0", 0);
+    fetchZarr("https://animatedcell-test-data.s3.us-west-2.amazonaws.com/variance/1.zarr", "", 0);
     //fetchZarr("http://localhost:9020/example-data/AICS-12_143.zarr", "AICS-12_143", 0);
     //fetchImage("AICS-12_881_atlas.json", "");
   } else {

--- a/public/index.ts
+++ b/public/index.ts
@@ -1285,6 +1285,7 @@ function main() {
     //fetchTiff("https://animatedcell-test-data.s3.us-west-2.amazonaws.com/AICS-12_881.ome.tif", 0);
     //fetchZarr("https://animatedcell-test-data.s3.us-west-2.amazonaws.com/Lamin_multi-06-Deskew-28.zarr", "Image_0", 0);
     fetchZarr("https://animatedcell-test-data.s3.us-west-2.amazonaws.com/variance/1.zarr", "", 0);
+    //fetchZarr("https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr ", "", 0);
     //fetchZarr("http://localhost:9020/example-data/AICS-12_143.zarr", "AICS-12_143", 0);
     //fetchImage("AICS-12_881_atlas.json", "");
   } else {

--- a/src/VolumeLoader.ts
+++ b/src/VolumeLoader.ts
@@ -241,7 +241,6 @@ export default class VolumeLoader {
         );
       }
     }
-    console.log(multiscales);
 
     const downsampleZ = 2; // z/downsampleZ is number of z slices in reduced volume
 
@@ -258,7 +257,6 @@ export default class VolumeLoader {
         multiscales[i].shape[spatialAxes[2]];
       if (s / maxAtlasEdge <= maxAtlasEdge) {
         console.log("Will load level " + i);
-        console.log(multiscales[i]);
         levelToLoad = i;
         break;
       }

--- a/src/VolumeLoader.ts
+++ b/src/VolumeLoader.ts
@@ -257,7 +257,9 @@ export default class VolumeLoader {
         multiscales[i].shape[spatialAxes[1]] *
         multiscales[i].shape[spatialAxes[2]];
       if (s / maxAtlasEdge <= maxAtlasEdge) {
-        levelToLoad = numlevels - 1 - i;
+        console.log("Will load level " + i);
+        console.log(multiscales[i]);
+        levelToLoad = i;
         break;
       }
     }

--- a/src/VolumeLoader.ts
+++ b/src/VolumeLoader.ts
@@ -210,7 +210,7 @@ export default class VolumeLoader {
       } else if (axis.name === "x") {
         axisTCZYX[4] = i;
       } else {
-        console.log("ERROR: UNRECOGNIZED AXIS " + axis.name);
+        console.log("ERROR: UNRECOGNIZED AXIS in zarr: " + axis.name);
       }
     }
     // ZYX
@@ -225,7 +225,7 @@ export default class VolumeLoader {
       spatialAxes.push(axisTCZYX[4]);
     }
     if (spatialAxes.length != 3) {
-      console.log("ERROR: expect a z,y,and x axis.");
+      console.log("ERROR: zarr loader expects a z, y, and x axis.");
     }
 
     const numlevels = multiscales.length;

--- a/src/VolumeLoader.ts
+++ b/src/VolumeLoader.ts
@@ -264,17 +264,17 @@ export default class VolumeLoader {
       }
     }
 
-    const dataset2 = multiscales[levelToLoad];
-    const c = hasC ? dataset2.shape[axisTCZYX[1]] : 1;
-    const sizeT = hasT ? dataset2.shape[axisTCZYX[0]] : 1;
+    const dataset = multiscales[levelToLoad];
+    const c = hasC ? dataset.shape[axisTCZYX[1]] : 1;
+    const sizeT = hasT ? dataset.shape[axisTCZYX[0]] : 1;
 
     // technically there can be any number of coordinateTransformations
     // but there must be only one of type "scale".
     // Here I assume that is the only one.
-    const scale5d = dataset2.coordinateTransformations[0].scale;
-    const tw = dataset2.shape[spatialAxes[2]];
-    const th = dataset2.shape[spatialAxes[1]];
-    const tz = dataset2.shape[spatialAxes[0]];
+    const scale5d = dataset.coordinateTransformations[0].scale;
+    const tw = dataset.shape[spatialAxes[2]];
+    const th = dataset.shape[spatialAxes[1]];
+    const tz = dataset.shape[spatialAxes[0]];
 
     // compute rows and cols and atlas width and ht, given tw and th
     const loadedZ = Math.ceil(tz / downsampleZ);
@@ -319,7 +319,7 @@ export default class VolumeLoader {
     // got some data, now let's construct the volume.
     const vol = new Volume(imgdata);
 
-    const storepath = imagegroup + "/" + dataset2.path;
+    const storepath = imagegroup + "/" + dataset.path;
     // do each channel on a worker
     for (let i = 0; i < c; ++i) {
       const worker = new Worker(new URL("./workers/FetchZarrWorker", import.meta.url));

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -59,7 +59,16 @@ self.onmessage = function (e) {
   const store = new HTTPStore(e.data.urlStore);
   openArray({ store: store, path: e.data.path, mode: "r" })
     .then((level) => {
-      return level.get([time, channelIndex, null, null, null]);
+      // build slice spec
+      // assuming ZYX are the last three dimensions:
+      const sliceSpec = [null, null, null];
+      if (channelIndex > -1) {
+        sliceSpec.unshift(channelIndex);
+      }
+      if (time > -1) {
+        sliceSpec.unshift(time);
+      }
+      return level.get(sliceSpec);
     })
     .then((channel) => {
       channel = channel as NestedArray<TypedArray>;
@@ -68,7 +77,7 @@ self.onmessage = function (e) {
       const nx = channel.shape[2];
 
       const u8: Uint8Array = convertChannel(channel.data as TypedArray[][], nx, ny, nz, channel.dtype, downsampleZ);
-      const results = { data: u8, channel: channelIndex };
+      const results = { data: u8, channel: channelIndex === -1 ? 0 : channelIndex };
       postMessage(results, [results.data.buffer]);
     });
 };


### PR DESCRIPTION
Two improvements to zarr loading:
1. auto select the largest multiscale that will fit tiled into a 4096x4096 texture atlas
2. allow loading data that doesn't have a T or C dimension.

For zarr loading, the viewer still assumes TCZYX as standard dimension names, and expects data to at least have ZYX as the last 3 dims.
