### PR TITLE
Feature/orthographic scale bar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,7 @@
         <button id="3D">3D</button>
         <button id="rotBtn">Turntable</button>
         <button id="axisBtn">Axis</button>
+        <button id="showScaleBar">ScaleBar</button>
         <button id="xfBtn">Align</button>
         <button id="resetCamBtn">ResetCam</button>
         <select name="Render mode" id="renderMode">

--- a/public/index.ts
+++ b/public/index.ts
@@ -1064,7 +1064,7 @@ function createTestVolume() {
     pixel_size_z: 1,
     name: "AICS-10_5_5",
     version: "0.0.0",
-    unit_symbol: "",
+    pixel_size_unit: "",
     transform: { translation: [0, 0, 0], rotation: [0, 0, 0] },
     times: 1,
   };

--- a/public/index.ts
+++ b/public/index.ts
@@ -1062,6 +1062,7 @@ function createTestVolume() {
     pixel_size_z: 1,
     name: "AICS-10_5_5",
     version: "0.0.0",
+    unit: "",
     transform: { translation: [0, 0, 0], rotation: [0, 0, 0] },
     times: 1,
   };

--- a/public/index.ts
+++ b/public/index.ts
@@ -71,6 +71,8 @@ const myState: State = {
   isAxisShowing: false,
   isAligned: true,
 
+  showScaleBar: true,
+
   showBoundingBox: false,
   boundingBoxColor: [255, 255, 0],
   backgroundColor: [0, 0, 0],
@@ -1118,6 +1120,11 @@ function main() {
     myState.showBoundingBox = !myState.showBoundingBox;
     view3D.setShowBoundingBox(myState.volume, myState.showBoundingBox);
   });
+  const showScaleBarBtn = document.getElementById("showScaleBar");
+  showScaleBarBtn?.addEventListener("click", () => {
+    myState.showScaleBar = !myState.showScaleBar;
+    view3D.setShowScaleBar(myState.showScaleBar);
+  })
 
   // convert value to rgb array
   function hexToRgb(hex, last: [number, number, number]): [number, number, number] {

--- a/public/index.ts
+++ b/public/index.ts
@@ -1062,7 +1062,7 @@ function createTestVolume() {
     pixel_size_z: 1,
     name: "AICS-10_5_5",
     version: "0.0.0",
-    unit: "",
+    unit_symbol: "",
     transform: { translation: [0, 0, 0], rotation: [0, 0, 0] },
     times: 1,
   };

--- a/public/types.ts
+++ b/public/types.ts
@@ -50,6 +50,8 @@ export interface State {
   isAxisShowing: boolean;
   isAligned: boolean;
 
+  showScaleBar: boolean;
+
   showBoundingBox: boolean;
   boundingBoxColor: [number, number, number];
 

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -311,10 +311,13 @@ export class ThreeJsPanel {
     this.axisCamera.position.set(-this.axisOffset[0], -this.axisOffset[1], this.axisScale * 2.0);
   }
 
-  orthoScreenPixelsToPhysicalUnits(pixels: number, scale: number): number {
-    // at orthoScale = 0.5, the viewport is 1 world unit tall
+  orthoScreenPixelsToPhysicalUnits(pixels: number, physicalUnitsPerWorldUnit: number): number {
+    // At orthoScale = 0.5, the viewport is 1 world unit tall
     const worldUnitsPerPixel = this.orthoScale * 2 / this.getHeight();
-    return pixels * window.devicePixelRatio * worldUnitsPerPixel * scale;
+    // Multiply by devicePixelRatio to convert from scaled CSS pixels to physical pixels
+    // (to account for high dpi monitors, e.g.). We didn't do this to height above because
+    // that value comes from three, which works in physical pixels.
+    return pixels * window.devicePixelRatio * worldUnitsPerPixel * physicalUnitsPerWorldUnit;
   }
 
   setupOrthoScaleBar(): void {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -36,7 +36,6 @@ export class ThreeJsPanel {
   public renderer: WebGLRenderer;
   private timer: Timing;
   public orthoScale: number;
-  public orthoHorizontalAxis: number;
   private fov: number;
   private perspectiveCamera: PerspectiveCamera;
   private perspectiveControls: TrackballControls;
@@ -59,6 +58,8 @@ export class ThreeJsPanel {
   private axisHelperObject: Object3D;
   private axisCamera: PerspectiveCamera | OrthographicCamera;
 
+  // Index of the horizontal axis in orthographic view modes, used for picking pixel scales for the scale bar
+  public orthoHorizontalAxis: number;
   private orthoScaleBarElement: HTMLDivElement;
   private scaleBarUnit?: string;
 
@@ -472,6 +473,11 @@ export class ThreeJsPanel {
       this.axisCamera.updateProjectionMatrix();
     } else {
       this.axisCamera.updateProjectionMatrix();
+    }
+
+    // The window may have moved to a monitor of a different resolution
+    if (this.renderer.getPixelRatio() !== window.devicePixelRatio) {
+      this.renderer.setPixelRatio(window.devicePixelRatio);
     }
 
     this.renderer.setSize(w, h);

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -468,7 +468,6 @@ export class ThreeJsPanel {
       this.axisCamera.updateProjectionMatrix();
     }
 
-    // The window may have moved to a monitor of a different resolution
     if (this.renderer.getPixelRatio() !== window.devicePixelRatio) {
       this.renderer.setPixelRatio(window.devicePixelRatio);
     }

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -312,6 +312,12 @@ export class ThreeJsPanel {
     this.axisCamera.position.set(-this.axisOffset[0], -this.axisOffset[1], this.axisScale * 2.0);
   }
 
+  orthoScreenPixelsToPhysicalUnits(pixels: number, scale = 1): number {
+    // at orthoScale = 0.5, the viewport is 1 world unit tall
+    const worldUnitsPerPixel = this.orthoScale * 2 / this.getHeight();
+    return pixels * window.devicePixelRatio * worldUnitsPerPixel * scale;
+  }
+
   setupOrthoScaleBar(): void {
     const orthoScaleBarStyle: Partial<CSSStyleDeclaration> = {
       border: "1px solid white",
@@ -319,8 +325,8 @@ export class ThreeJsPanel {
       height: "10px",
       display: "none",
       position: "absolute",
-      right: "15px",
-      bottom: "50px",
+      right: "20px",
+      bottom: "20px",
       color: "white",
       mixBlendMode: "difference",
       textAlign: "right",
@@ -338,7 +344,7 @@ export class ThreeJsPanel {
     // We want to find the largest round number of physical units that keeps the scale bar within this width on screen
     const SCALE_BAR_MAX_WIDTH = 150;
     // Convert max width to volume physical units
-    const physicalMaxWidth = this.orthoScale * 2 * (SCALE_BAR_MAX_WIDTH * window.devicePixelRatio / this.getHeight()) * scale;
+    const physicalMaxWidth = this.orthoScreenPixelsToPhysicalUnits(SCALE_BAR_MAX_WIDTH, scale);
     // Round off all but the most significant digit of worldSpaceMaxWidth
     const digits = Math.floor(Math.log10(physicalMaxWidth));
     const div10 = 10 ** digits;
@@ -350,9 +356,6 @@ export class ThreeJsPanel {
     }
     this.orthoScaleBarElement.innerHTML = `${scaleStr}${this.scaleBarUnit || ""}`;
     this.orthoScaleBarElement.style.width = `${SCALE_BAR_MAX_WIDTH * (scaleValue / physicalMaxWidth)}px`;
-    // Uncomment to disable rounding and stick to a fixed width
-    // this.orthoScaleBarElement.innerHTML = `${worldSpaceMaxWidth}${this.scaleBarUnit || ""}`;
-    // this.orthoScaleBarElement.style.width = `${SCALE_BAR_MAX_WIDTH}px`;
   }
 
   setOrthoScaleBarVisible(visible: boolean): void {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -58,7 +58,6 @@ export class ThreeJsPanel {
   private axisCamera: PerspectiveCamera | OrthographicCamera;
 
   private orthoScaleBarElement: HTMLDivElement;
-  private scaleBarUnit?: string;
 
   private dataurlcallback?: (url: string) => void;
 
@@ -312,7 +311,7 @@ export class ThreeJsPanel {
     this.axisCamera.position.set(-this.axisOffset[0], -this.axisOffset[1], this.axisScale * 2.0);
   }
 
-  orthoScreenPixelsToPhysicalUnits(pixels: number, scale = 1): number {
+  orthoScreenPixelsToPhysicalUnits(pixels: number, scale: number): number {
     // at orthoScale = 0.5, the viewport is 1 world unit tall
     const worldUnitsPerPixel = this.orthoScale * 2 / this.getHeight();
     return pixels * window.devicePixelRatio * worldUnitsPerPixel * scale;
@@ -337,10 +336,9 @@ export class ThreeJsPanel {
     };
     Object.assign(this.orthoScaleBarElement.style, orthoScaleBarStyle);
     this.containerdiv.appendChild(this.orthoScaleBarElement);
-    this.updateOrthoScaleBar();
   }
 
-  updateOrthoScaleBar(scale = 1): void {
+  updateOrthoScaleBar(scale: number, unit?: string): void {
     // We want to find the largest round number of physical units that keeps the scale bar within this width on screen
     const SCALE_BAR_MAX_WIDTH = 150;
     // Convert max width to volume physical units
@@ -354,16 +352,12 @@ export class ThreeJsPanel {
       // Handle irrational floating point values (e.g. 0.30000000000000004) 
       scaleStr = scaleStr.slice(0, Math.abs(digits) + 2);
     }
-    this.orthoScaleBarElement.innerHTML = `${scaleStr}${this.scaleBarUnit || ""}`;
+    this.orthoScaleBarElement.innerHTML = `${scaleStr}${unit || ""}`;
     this.orthoScaleBarElement.style.width = `${SCALE_BAR_MAX_WIDTH * (scaleValue / physicalMaxWidth)}px`;
   }
 
   setOrthoScaleBarVisible(visible: boolean): void {
     this.orthoScaleBarElement.style.display = visible ? "" : "none";
-  }
-
-  setOrthoScaleBarUnit(unit: string): void {
-    this.scaleBarUnit = unit;
   }
 
   setAutoRotate(rotate: boolean): void {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -349,7 +349,7 @@ export class ThreeJsPanel {
     const SCALE_BAR_MAX_WIDTH = 150;
     // Convert max width to volume physical units
     const physicalMaxWidth = this.orthoScreenPixelsToPhysicalUnits(SCALE_BAR_MAX_WIDTH, scale);
-    // Round off all but the most significant digit of worldSpaceMaxWidth
+    // Round off all but the most significant digit of physicalMaxWidth
     const digits = Math.floor(Math.log10(physicalMaxWidth));
     const div10 = 10 ** digits;
     const scaleValue = Math.floor(physicalMaxWidth / div10) * div10;

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -1,6 +1,5 @@
 import {
   AxesHelper,
-  Camera,
   Color,
   Vector3,
   Object3D,
@@ -335,7 +334,7 @@ export class ThreeJsPanel {
     this.updateOrthoScaleBar();
   }
 
-  updateOrthoScaleBar(scale: number = 1): void {
+  updateOrthoScaleBar(scale = 1): void {
     // We want to find the largest round number of physical units that keeps the scale bar within this width on screen
     const SCALE_BAR_MAX_WIDTH = 150;
     // Convert max width to volume physical units

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -325,6 +325,7 @@ export class ThreeJsPanel {
       right: "15px",
       bottom: "50px",
       color: "white",
+      mixBlendMode: "difference",
       textAlign: "right",
       lineHeight: "0px",
       fontFamily: "-apple-system, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif",

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -58,6 +58,7 @@ export class ThreeJsPanel {
   private axisCamera: PerspectiveCamera | OrthographicCamera;
 
   private orthoScaleBarElement: HTMLDivElement;
+  public showOrthoScaleBar: boolean;
 
   private dataurlcallback?: (url: string) => void;
 
@@ -81,6 +82,9 @@ export class ThreeJsPanel {
     this.showAxis = false;
     this.axisScale = 50.0;
     this.axisOffset = [66, 66];
+
+    this.orthoScaleBarElement = document.createElement("div");
+    this.showOrthoScaleBar = true;
 
     this.zooming = false;
     this.animateFuncs = [];
@@ -187,7 +191,6 @@ export class ThreeJsPanel {
     this.controls = this.perspectiveControls;
 
     this.setupAxisHelper();
-    this.orthoScaleBarElement = document.createElement("div");
     this.setupOrthoScaleBar();
   }
 
@@ -359,8 +362,14 @@ export class ThreeJsPanel {
     this.orthoScaleBarElement.style.width = `${SCALE_BAR_MAX_WIDTH * (scaleValue / physicalMaxWidth)}px`;
   }
 
-  setOrthoScaleBarVisible(visible: boolean): void {
+  updateOrthoScaleBarVisibility(): void {
+    const visible = isOrthographicCamera(this.camera) && this.showOrthoScaleBar;
     this.orthoScaleBarElement.style.display = visible ? "" : "none";
+  }
+
+  setShowOrthoScaleBar(visible: boolean): void {
+    this.showOrthoScaleBar = visible;
+    this.updateOrthoScaleBarVisibility();
   }
 
   setAutoRotate(rotate: boolean): void {
@@ -410,29 +419,26 @@ export class ThreeJsPanel {
         this.replaceCamera(this.orthographicCameraX);
         this.replaceControls(this.orthoControlsX);
         this.axisHelperObject.rotation.set(0, Math.PI * 0.5, 0);
-        this.setOrthoScaleBarVisible(true);
         break;
       case "XZ":
       case "Y":
         this.replaceCamera(this.orthographicCameraY);
         this.replaceControls(this.orthoControlsY);
         this.axisHelperObject.rotation.set(Math.PI * 0.5, 0, 0);
-        this.setOrthoScaleBarVisible(true);
         break;
       case "XY":
       case "Z":
         this.replaceCamera(this.orthographicCameraZ);
         this.replaceControls(this.orthoControlsZ);
         this.axisHelperObject.rotation.set(0, 0, 0);
-        this.setOrthoScaleBarVisible(true);
         break;
       default:
         this.replaceCamera(this.perspectiveCamera);
         this.replaceControls(this.perspectiveControls);
         this.axisHelperObject.rotation.setFromRotationMatrix(this.camera.matrixWorldInverse);
-        this.setOrthoScaleBarVisible(false);
         break;
     }
+    this.updateOrthoScaleBarVisibility();
   }
 
   getCanvas(): HTMLCanvasElement {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -332,9 +332,7 @@ export class ThreeJsPanel {
       boxSizing: "border-box",
       paddingRight: "10px",
     };
-    Object.keys(orthoScaleBarStyle).forEach((property) => {
-      this.orthoScaleBarElement.style[property] = orthoScaleBarStyle[property];
-    });
+    Object.assign(this.orthoScaleBarElement.style, orthoScaleBarStyle);
     this.containerdiv.appendChild(this.orthoScaleBarElement);
     this.updateOrthoScaleBar();
   }

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -337,11 +337,17 @@ export class ThreeJsPanel {
     const SCALE_BAR_MAX_WIDTH = 150;
     const UNIT = "µm";
     const worldSpaceMaxWidth = this.orthoScale * SCALE_BAR_MAX_WIDTH * 0.10833333333333332;
-    // Round off all but the most significant digit of projectedWidth
-    const div10 = 10 ** Math.floor(Math.log10(worldSpaceMaxWidth));
+    // Round off all but the most significant digit of worldSpaceMaxWidth
+    const digits = Math.floor(Math.log10(worldSpaceMaxWidth));
+    const div10 = 10 ** digits;
     const scaleValue = Math.floor(worldSpaceMaxWidth / div10) * div10;
-    this.orthoScaleBarElement.innerHTML = `${scaleValue}${UNIT}`;
-    this.orthoScaleBarElement.style.width = SCALE_BAR_MAX_WIDTH * (scaleValue / worldSpaceMaxWidth) + "px";
+    let scaleStr = scaleValue.toString();
+    if (digits < 1) {
+      // Handle irrational floating point values (e.g. 0.30000000000000004) 
+      scaleStr = scaleStr.slice(0, Math.abs(digits) + 2);
+    }
+    this.orthoScaleBarElement.innerHTML = `${scaleStr}${UNIT}`;
+    this.orthoScaleBarElement.style.width = `${SCALE_BAR_MAX_WIDTH * (scaleValue / worldSpaceMaxWidth)}px`;
   }
 
   setOrthoScaleBarVisible(visible: boolean): void {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -59,6 +59,7 @@ export class ThreeJsPanel {
   private axisCamera: Camera;
 
   private orthoScaleBarElement: HTMLDivElement;
+  private scaleBarUnit?: string;
 
   private dataurlcallback?: (url: string) => void;
 
@@ -321,8 +322,10 @@ export class ThreeJsPanel {
       position: "absolute",
       right: "15px",
       bottom: "50px",
+      color: "white",
       textAlign: "right",
       lineHeight: "0px",
+      fontFamily: "-apple-system, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif",
       boxSizing: "border-box",
       paddingRight: "10px",
     };
@@ -346,12 +349,16 @@ export class ThreeJsPanel {
       // Handle irrational floating point values (e.g. 0.30000000000000004) 
       scaleStr = scaleStr.slice(0, Math.abs(digits) + 2);
     }
-    this.orthoScaleBarElement.innerHTML = `${scaleStr}${UNIT}`;
+    this.orthoScaleBarElement.innerHTML = `${scaleStr}${this.scaleBarUnit || ""}`;
     this.orthoScaleBarElement.style.width = `${SCALE_BAR_MAX_WIDTH * (scaleValue / worldSpaceMaxWidth)}px`;
   }
 
   setOrthoScaleBarVisible(visible: boolean): void {
     this.orthoScaleBarElement.style.display = visible ? "" : "none";
+  }
+
+  setOrthoScaleBarUnit(unit: string): void {
+    this.scaleBarUnit = unit;
   }
 
   setAutoRotate(rotate: boolean): void {

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -89,8 +89,7 @@ export class View3d {
   }
 
   private updateOrthoScaleBar() {
-    const scale = this.image!.volume.pixel_size[this.canvas3d.orthoHorizontalAxis];
-    this.canvas3d.updateOrthoScaleBar(scale);
+    this.canvas3d.updateOrthoScaleBar(this.image!.volume.physicalScale);
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -89,7 +89,8 @@ export class View3d {
   }
 
   private updateOrthoScaleBar() {
-    this.canvas3d.updateOrthoScaleBar(this.image!.volume.pixel_size[this.canvas3d.orthoHorizontalAxis]);
+    const scale = this.image!.volume.pixel_size[this.canvas3d.orthoHorizontalAxis];
+    this.canvas3d.updateOrthoScaleBar(scale);
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -84,12 +84,12 @@ export class View3d {
     // keep the ortho scale up to date.
     if (this.image && isOrthographicCamera(this.canvas3d.camera)) {
       this.image.setOrthoScale(this.canvas3d.controls.scale);
-      this.updateOrthoScaleBar(this.image);
+      this.updateOrthoScaleBar(this.image.volume);
     }
   }
 
-  private updateOrthoScaleBar(image: VolumeDrawable) {
-    this.canvas3d.updateOrthoScaleBar(image.volume.physicalScale);
+  private updateOrthoScaleBar(volume: Volume) {
+    this.canvas3d.updateOrthoScaleBar(volume.physicalScale, volume.imageInfo.unit_symbol);
   }
 
   /**
@@ -224,9 +224,10 @@ export class View3d {
   setVoxelSize(volume: Volume, values: number[], unit?: string): void {
     if (this.image) {
       this.image.setVoxelSize(values);
-    }
-    if (unit) {
-      this.setScaleUnit(unit);
+
+      if (unit) {
+        this.image.volume.setUnitSymbol(unit);
+      }
     }
     this.redraw();
   }
@@ -366,8 +367,6 @@ export class View3d {
     this.canvas3d.animateFuncs.push(this.preRender.bind(this));
     this.canvas3d.animateFuncs.push(img.onAnimate.bind(img));
 
-    this.canvas3d.setOrthoScaleBarUnit(img.volume.imageInfo.unit_symbol);
-    
     // redraw if not already in draw loop
     this.redraw();
 
@@ -500,9 +499,11 @@ export class View3d {
    * @param {string} unit
    */
   setScaleUnit(unit: string): void {
-    this.canvas3d.setOrthoScaleBarUnit(unit);
-    if (this.image && isOrthographicCamera(this.canvas3d.camera)) {
-      this.updateOrthoScaleBar(this.image);
+    if (this.image) {
+      this.image.volume.setUnitSymbol(unit);
+      if (isOrthographicCamera(this.canvas3d.camera)) {
+        this.updateOrthoScaleBar(this.image.volume);
+      }
     }
   }
 

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -84,12 +84,12 @@ export class View3d {
     // keep the ortho scale up to date.
     if (this.image && isOrthographicCamera(this.canvas3d.camera)) {
       this.image.setOrthoScale(this.canvas3d.controls.scale);
-      this.updateOrthoScaleBar();
+      this.updateOrthoScaleBar(this.image);
     }
   }
 
-  private updateOrthoScaleBar() {
-    this.canvas3d.updateOrthoScaleBar(this.image!.volume.physicalScale);
+  private updateOrthoScaleBar(image: VolumeDrawable) {
+    this.canvas3d.updateOrthoScaleBar(image.volume.physicalScale);
   }
 
   /**
@@ -366,6 +366,8 @@ export class View3d {
     this.canvas3d.animateFuncs.push(this.preRender.bind(this));
     this.canvas3d.animateFuncs.push(img.onAnimate.bind(img));
 
+    this.canvas3d.setOrthoScaleBarUnit(img.volume.imageInfo.unit_symbol);
+    
     // redraw if not already in draw loop
     this.redraw();
 
@@ -500,7 +502,7 @@ export class View3d {
   setScaleUnit(unit: string): void {
     this.canvas3d.setOrthoScaleBarUnit(unit);
     if (this.image && isOrthographicCamera(this.canvas3d.camera)) {
-      this.updateOrthoScaleBar();
+      this.updateOrthoScaleBar(this.image);
     }
   }
 

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -473,11 +473,19 @@ export class View3d {
 
   /**
    * Enable or disable 3d axis display at lower left.
-   * @param {boolean} autorotate
+   * @param {boolean} showAxis
    */
   setShowAxis(showAxis: boolean): void {
     this.canvas3d.showAxis = showAxis;
     this.canvas3d.redraw();
+  }
+
+  /**
+   * Enable or disable scale indicators.
+   * @param showScaleBar
+   */
+  setShowScaleBar(showScaleBar: boolean): void {
+    this.canvas3d.setShowOrthoScaleBar(showScaleBar);
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -219,10 +219,14 @@ export class View3d {
    * Set voxel dimensions - controls volume scaling. For example, the physical measurements of the voxels from a biological data set
    * @param {Object} volume
    * @param {number} values Array of x,y,z floating point values for the physical voxel size scaling
+   * @param {string} unit The unit of `values`, if different than previous
    */
-  setVoxelSize(volume: Volume, values: number[]): void {
+  setVoxelSize(volume: Volume, values: number[], unit?: string): void {
     if (this.image) {
       this.image.setVoxelSize(values);
+    }
+    if (unit) {
+      this.setScaleUnit(unit);
     }
     this.redraw();
   }

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -84,7 +84,12 @@ export class View3d {
     // keep the ortho scale up to date.
     if (this.image && isOrthographicCamera(this.canvas3d.camera)) {
       this.image.setOrthoScale(this.canvas3d.controls.scale);
+      this.updateOrthoScaleBar();
     }
+  }
+
+  private updateOrthoScaleBar() {
+    this.canvas3d.updateOrthoScaleBar(this.image!.volume.pixel_size[this.canvas3d.orthoHorizontalAxis]);
   }
 
   /**
@@ -490,6 +495,9 @@ export class View3d {
    */
   setScaleUnit(unit: string): void {
     this.canvas3d.setOrthoScaleBarUnit(unit);
+    if (this.image && isOrthographicCamera(this.canvas3d.camera)) {
+      this.updateOrthoScaleBar();
+    }
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -89,7 +89,7 @@ export class View3d {
   }
 
   private updateOrthoScaleBar(volume: Volume) {
-    this.canvas3d.updateOrthoScaleBar(volume.physicalScale, volume.imageInfo.unit_symbol);
+    this.canvas3d.updateOrthoScaleBar(volume.physicalScale, volume.imageInfo.pixel_size_unit);
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -485,6 +485,14 @@ export class View3d {
   }
 
   /**
+   * Set the unit symbol for the scale bar (e.g. µm)
+   * @param {string} unit
+   */
+  setScaleUnit(unit: string): void {
+    this.canvas3d.setOrthoScaleBarUnit(unit);
+  }
+
+  /**
    * Invert axes of volume. -1 to invert, +1 NOT to invert.
    * @param {Object} volume
    * @param {number} flipX x axis sense

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -15,7 +15,7 @@ export interface ImageInfo {
   pixel_size_x: number;
   pixel_size_y: number;
   pixel_size_z: number;
-  unit: string;
+  unit_symbol: string;
   channel_names: string[];
   channel_colors?: [number, number, number][];
   rows: number;
@@ -43,7 +43,7 @@ export const getDefaultImageInfo = (): ImageInfo => {
     pixel_size_x: 1,
     pixel_size_y: 1,
     pixel_size_z: 1,
-    unit: "µm",
+    unit_symbol: "µm",
     channel_names: [],
     channel_colors: [],
     rows: 1,

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -136,6 +136,7 @@ export default class Volume {
   public scale: Vector3;
   private physicalSize: Vector3;
   public physicalScale: number;
+  public physicalUnitSymbol: string;
   public normalizedPhysicalSize: Vector3;
   private loaded: boolean;
   /* eslint-disable @typescript-eslint/naming-convention */
@@ -190,6 +191,7 @@ export default class Volume {
       channel.dims = [this.x, this.y, this.z];
     }
 
+    this.physicalUnitSymbol = this.imageInfo.unit_symbol;
     this.setVoxelSize(this.pixel_size);
 
     // make sure a transform is specified
@@ -248,6 +250,10 @@ export default class Volume {
 
     // sx, sy, sz should be same as normalizedPhysicalSize
     this.scale = new Vector3(sx, sy, sz);
+  }
+
+  setUnitSymbol(symbol: string): void {
+    this.physicalUnitSymbol = symbol;
   }
 
   cleanup(): void {

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -15,7 +15,7 @@ export interface ImageInfo {
   pixel_size_x: number;
   pixel_size_y: number;
   pixel_size_z: number;
-  unit_symbol: string;
+  pixel_size_unit: string;
   channel_names: string[];
   channel_colors?: [number, number, number][];
   rows: number;
@@ -43,7 +43,7 @@ export const getDefaultImageInfo = (): ImageInfo => {
     pixel_size_x: 1,
     pixel_size_y: 1,
     pixel_size_z: 1,
-    unit_symbol: "",
+    pixel_size_unit: "",
     channel_names: [],
     channel_colors: [],
     rows: 1,
@@ -191,7 +191,7 @@ export default class Volume {
       channel.dims = [this.x, this.y, this.z];
     }
 
-    this.physicalUnitSymbol = this.imageInfo.unit_symbol;
+    this.physicalUnitSymbol = this.imageInfo.pixel_size_unit;
     this.setVoxelSize(this.pixel_size);
 
     // make sure a transform is specified

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -15,6 +15,7 @@ export interface ImageInfo {
   pixel_size_x: number;
   pixel_size_y: number;
   pixel_size_z: number;
+  unit: string;
   channel_names: string[];
   channel_colors?: [number, number, number][];
   rows: number;
@@ -42,6 +43,7 @@ export const getDefaultImageInfo = (): ImageInfo => {
     pixel_size_x: 1,
     pixel_size_y: 1,
     pixel_size_z: 1,
+    unit: "µm",
     channel_names: [],
     channel_colors: [],
     rows: 1,

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -43,7 +43,7 @@ export const getDefaultImageInfo = (): ImageInfo => {
     pixel_size_x: 1,
     pixel_size_y: 1,
     pixel_size_z: 1,
-    unit_symbol: "µm",
+    unit_symbol: "",
     channel_names: [],
     channel_colors: [],
     rows: 1,

--- a/src/VolumeLoader.ts
+++ b/src/VolumeLoader.ts
@@ -154,15 +154,15 @@ export default class VolumeLoader {
         return response.json();
       })
       .then(function (myJson) {
-        const vol = new Volume(myJson);
+    const vol = new Volume(myJson);
 
-        // if you need to adjust image paths prior to download,
-        // now is the time to do it:
-        myJson.images.forEach(function (element) {
-          element.name = urlPrefix + element.name;
-        });
-        VolumeLoader.loadVolumeAtlasData(vol, myJson.images, onChannelLoaded);
-        return vol;
+    // if you need to adjust image paths prior to download,
+    // now is the time to do it:
+    myJson.images.forEach(function (element) {
+      element.name = urlPrefix + element.name;
+    });
+    VolumeLoader.loadVolumeAtlasData(vol, myJson.images, onChannelLoaded);
+    return vol;
       });
   }
 
@@ -332,6 +332,7 @@ export default class VolumeLoader {
       pixel_size_z: 2,
       name: "TEST",
       version: "1.0",
+      unit: "µm",
       transform: {
         translation: [0, 0, 0],
         rotation: [0, 0, 0],
@@ -413,6 +414,7 @@ export default class VolumeLoader {
       pixel_size_z: pixelsizez,
       name: "TEST",
       version: "1.0",
+      unit: "µm",
       transform: {
         translation: [0, 0, 0],
         rotation: [0, 0, 0],

--- a/src/VolumeLoader.ts
+++ b/src/VolumeLoader.ts
@@ -261,7 +261,8 @@ export default class VolumeLoader {
 
     const numlevels = multiscales.length;
     // Assume all axes have the same units - we have no means of storing per-axis unit symbols
-    const unitSymbol = spatialUnitSymbols[axes[spatialAxes[2]].unit] || axes[spatialAxes[2]].unit || "";
+    const unitName = axes[spatialAxes[2]].unit;
+    const unitSymbol = spatialUnitSymbols[unitName] || unitName || "";
 
     // get all shapes
     for (const i in multiscales) {

--- a/src/VolumeLoader.ts
+++ b/src/VolumeLoader.ts
@@ -186,7 +186,7 @@ export default class VolumeLoader {
     myJson.images.forEach((element) => {
       element.name = urlPrefix + element.name;
     });
-    myJson.unit_symbol = myJson.unit_symbol || "μm";
+    myJson.pixel_size_unit = myJson.pixel_size_unit || "μm";
     VolumeLoader.loadVolumeAtlasData(vol, myJson.images, onChannelLoaded);
     return vol;
   }
@@ -332,7 +332,7 @@ export default class VolumeLoader {
       pixel_size_x: scale5d[spatialAxes[2]],
       pixel_size_y: scale5d[spatialAxes[1]],
       pixel_size_z: scale5d[spatialAxes[0]] * downsampleZ,
-      unit_symbol: unitSymbol,
+      pixel_size_unit: unitSymbol,
       name: displayMetadata.name,
       version: displayMetadata.version,
       transform: {
@@ -413,7 +413,7 @@ export default class VolumeLoader {
       pixel_size_z: 2,
       name: "TEST",
       version: "1.0",
-      unit_symbol: "µm",
+      pixel_size_unit: "µm",
       transform: {
         translation: [0, 0, 0],
         rotation: [0, 0, 0],
@@ -496,7 +496,7 @@ export default class VolumeLoader {
       pixel_size_z: pixelsizez,
       name: "TEST",
       version: "1.0",
-      unit_symbol: unit || "",
+      pixel_size_unit: unit || "",
       transform: {
         translation: [0, 0, 0],
         rotation: [0, 0, 0],

--- a/src/VolumeLoader.ts
+++ b/src/VolumeLoader.ts
@@ -180,11 +180,13 @@ export default class VolumeLoader {
     const response = await fetch(url);
     const myJson = await response.json();
     const vol = new Volume(myJson);
+
     // if you need to adjust image paths prior to download,
     // now is the time to do it:
-    myJson.images.forEach(function (element) {
+    myJson.images.forEach((element) => {
       element.name = urlPrefix + element.name;
     });
+    myJson.unit_symbol = myJson.unit_symbol || "μm";
     VolumeLoader.loadVolumeAtlasData(vol, myJson.images, onChannelLoaded);
     return vol;
   }

--- a/src/VolumeLoader.ts
+++ b/src/VolumeLoader.ts
@@ -28,6 +28,37 @@ interface PackedChannelsImage {
 }
 type PackedChannelsImageRequests = Record<string, HTMLImageElement>;
 
+// Preferred spatial units in OME-Zarr are specified as full names. We want just the symbol.
+// See https://ngff.openmicroscopy.org/latest/#axes-md
+const spatialUnitSymbols = {
+  "angstrom":      "Å",
+  "attometer":     "am",
+  "centimeter":    "cm",
+  "decimeter":     "dm",
+  "exameter":      "Em",
+  "femtometer":    "fm",
+  "foot":          "ft",
+  "gigameter":     "Gm",
+  "hectometer":    "hm",
+  "inch":          "in",
+  "kilometer":     "km",
+  "megameter":     "Mm",
+  "meter":         "m",
+  "micrometer":    "μm",
+  "mile":          "mi",
+  "millimeter":    "mm",
+  "nanometer":     "nm",
+  "parsec":        "pc",
+  "petameter":     "Pm",
+  "picometer":     "pm",
+  "terameter":     "Tm",
+  "yard":          "yd",
+  "yoctometer":    "ym",
+  "yottameter":    "Ym",
+  "zeptometer":    "zm",
+  "zettameter":    "Zm",
+};
+
 // We want to find the most "square" packing of z tw by th tiles.
 // Compute number of rows and columns.
 function computePackedAtlasDims(z, tw, th): { nrows: number; ncols: number } {
@@ -229,6 +260,8 @@ export default class VolumeLoader {
     }
 
     const numlevels = multiscales.length;
+    // Assume all axes have the same units - we have no means of storing per-axis unit symbols
+    const unitSymbol = spatialUnitSymbols[axes[spatialAxes[2]].unit] || axes[spatialAxes[2]].unit || "";
 
     // get all shapes
     for (const i in multiscales) {
@@ -304,6 +337,7 @@ export default class VolumeLoader {
       pixel_size_x: scale5d[spatialAxes[2]],
       pixel_size_y: scale5d[spatialAxes[1]],
       pixel_size_z: scale5d[spatialAxes[0]] * downsampleZ,
+      unit_symbol: unitSymbol,
       name: displayMetadata.name,
       version: displayMetadata.version,
       transform: {
@@ -384,7 +418,7 @@ export default class VolumeLoader {
       pixel_size_z: 2,
       name: "TEST",
       version: "1.0",
-      unit: "µm",
+      unit_symbol: "µm",
       transform: {
         translation: [0, 0, 0],
         rotation: [0, 0, 0],
@@ -466,7 +500,7 @@ export default class VolumeLoader {
       pixel_size_z: pixelsizez,
       name: "TEST",
       version: "1.0",
-      unit: "µm",
+      unit_symbol: "µm",
       transform: {
         translation: [0, 0, 0],
         rotation: [0, 0, 0],


### PR DESCRIPTION
Partially address #66: in orthographic (XY/YZ/XZ) modes, where scale is the same regardless of distance from the camera, show a 2d scale bar in the corner of the viewport. The scale bar shows the length of some round number of physical units on screen (depending on zoom level) along with a unit symbol, which is either read in from volume data or set manually via methods.

#### Also:
- Make type of cameras more specific, removing the need for several explicit casts
- Ensure device pixel ratio is updated on resize when necessary (e.g. when moving between monitors of different resolutions)
- Remove unused `Volume.currentScale` property (always a copy of `Volume.scale`)
- vscode wanted to turn `VolumeLoader.loadJson` into an async function, so I let it

#### Work remaining on #66:
- Specify and implement what a scale indicator looks like in 3D mode: likely tickmarks on the bounding box, with a label either in the corner (as in Simularium) or next to the bounding box.
- Provide a means for clients to specify a new position for the scale bar, e.g. viewport corner + horizontal and vertical offset, since the scale bar in its current position would overlap the clipping drawer button in website-3d-cell-viewer. If this work added a means of moving the axis indicator similarly, this could open an easy path to resolving allen-cell-animated/website-3d-cell-viewer#73.

### Screenshots:
![image](https://user-images.githubusercontent.com/53030214/211113390-89f070e8-e039-4b1e-8793-57b5c9ebae06.png)
![image](https://user-images.githubusercontent.com/53030214/211113513-579cf24b-fa40-4e41-b713-d07aeba8c93a.png)

