### PR TITLE
Feature/indicator position setters

### DIFF
--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -311,10 +311,10 @@ export class ThreeJsPanel {
     // at offsets lower than BASE_MARGIN, axes may extend off screen
     const BASE_MARGIN = 50;
     this.axisOffset = [marginX + BASE_MARGIN, marginY + BASE_MARGIN];
-    if (corner.startsWith("top")) {
+    if (corner % 4 < 2) { // top
       this.axisOffset[1] = this.getHeight() - this.axisOffset[1];
     }
-    if (corner.endsWith("right")) {
+    if (corner % 2) { // right
       this.axisOffset[0] = this.getWidth() - this.axisOffset[0];
     }
     this.axisCamera.position.set(-this.axisOffset[0], -this.axisOffset[1], this.axisScale * 2.0);
@@ -387,14 +387,8 @@ export class ThreeJsPanel {
     style.removeProperty("left");
     style.removeProperty("right");
 
-    let [yProp, xProp] = corner.split("_");
-    // Sanity check: must be valid css property names
-    if (xProp !== "left" && xProp !== "right") {
-      xProp = "right";
-    }
-    if (yProp !== "top" && yProp !== "bottom") {
-      yProp = "bottom";
-    }
+    const xProp = corner % 2 ? "right" : "left";
+    const yProp = corner % 4 < 2 ? "top" : "bottom";
 
     Object.assign(style, {
       [xProp]: marginX + "px",

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -17,7 +17,7 @@ import {
 
 import TrackballControls from "./TrackballControls.js";
 import Timing from "./Timing";
-import { isOrthographicCamera, ViewportCorner } from "./types";
+import { isOrthographicCamera, ViewportCorner, isTop, isRight } from "./types";
 
 const DEFAULT_PERSPECTIVE_CAMERA_DISTANCE = 5.0;
 const DEFAULT_PERSPECTIVE_CAMERA_NEAR = 0.001;
@@ -182,7 +182,7 @@ export class ThreeJsPanel {
 
     this.camera = this.perspectiveCamera;
     this.controls = this.perspectiveControls;
-    
+
     this.axisCamera = new OrthographicCamera();
     this.axisHelperScene = new Scene();
     this.axisHelperObject = new Object3D();
@@ -311,10 +311,10 @@ export class ThreeJsPanel {
     // at offsets lower than BASE_MARGIN, axes may extend off screen
     const BASE_MARGIN = 50;
     this.axisOffset = [marginX + BASE_MARGIN, marginY + BASE_MARGIN];
-    if (corner % 4 < 2) { // top
+    if (isTop(corner)) {
       this.axisOffset[1] = this.getHeight() - this.axisOffset[1];
     }
-    if (corner % 2) { // right
+    if (isRight(corner)) {
       this.axisOffset[0] = this.getWidth() - this.axisOffset[0];
     }
     this.axisCamera.position.set(-this.axisOffset[0], -this.axisOffset[1], this.axisScale * 2.0);
@@ -322,7 +322,7 @@ export class ThreeJsPanel {
 
   orthoScreenPixelsToPhysicalUnits(pixels: number, physicalUnitsPerWorldUnit: number): number {
     // At orthoScale = 0.5, the viewport is 1 world unit tall
-    const worldUnitsPerPixel = this.orthoScale * 2 / this.getHeight();
+    const worldUnitsPerPixel = (this.orthoScale * 2) / this.getHeight();
     // Multiply by devicePixelRatio to convert from scaled CSS pixels to physical pixels
     // (to account for high dpi monitors, e.g.). We didn't do this to height above because
     // that value comes from three, which works in physical pixels.
@@ -362,7 +362,7 @@ export class ThreeJsPanel {
     const scaleValue = Math.floor(physicalMaxWidth / div10) * div10;
     let scaleStr = scaleValue.toString();
     if (digits < 1) {
-      // Handle irrational floating point values (e.g. 0.30000000000000004) 
+      // Handle irrational floating point values (e.g. 0.30000000000000004)
       scaleStr = scaleStr.slice(0, Math.abs(digits) + 2);
     }
     this.orthoScaleBarElement.innerHTML = `${scaleStr}${unit || ""}`;
@@ -387,8 +387,8 @@ export class ThreeJsPanel {
     style.removeProperty("left");
     style.removeProperty("right");
 
-    const xProp = corner % 2 ? "right" : "left";
-    const yProp = corner % 4 < 2 ? "top" : "bottom";
+    const xProp = isRight(corner) ? "right" : "left";
+    const yProp = isTop(corner) ? "top" : "bottom";
 
     Object.assign(style, {
       [xProp]: marginX + "px",

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -314,6 +314,14 @@ export class ThreeJsPanel {
     this.axisCamera.position.set(-this.axisOffset[0], -this.axisOffset[1], this.axisScale * 2.0);
   }
 
+  setAxisPosition(marginX: number, marginY: number) {
+    // Offset is relative to center of object, not corner of possible extent
+    // at offsets lower than BASE_MARGIN, axes may extend off screen
+    const BASE_MARGIN = 50;
+    this.axisOffset = [marginX + BASE_MARGIN, marginY + BASE_MARGIN];
+    this.axisCamera.position.set(-this.axisOffset[0], -this.axisOffset[1], this.axisScale * 2.0);
+  }
+
   orthoScreenPixelsToPhysicalUnits(pixels: number, physicalUnitsPerWorldUnit: number): number {
     // At orthoScale = 0.5, the viewport is 1 world unit tall
     const worldUnitsPerPixel = this.orthoScale * 2 / this.getHeight();
@@ -370,6 +378,13 @@ export class ThreeJsPanel {
   setShowOrthoScaleBar(visible: boolean): void {
     this.showOrthoScaleBar = visible;
     this.updateOrthoScaleBarVisibility();
+  }
+
+  setOrthoScaleBarPosition(marginX: number, marginY: number) {
+    Object.assign(this.orthoScaleBarElement.style, {
+      right: marginX + "px",
+      bottom: marginY + "px",
+    });
   }
 
   setAutoRotate(rotate: boolean): void {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -17,7 +17,7 @@ import {
 
 import TrackballControls from "./TrackballControls.js";
 import Timing from "./Timing";
-import { isOrthographicCamera } from "./types";
+import { isOrthographicCamera, ViewportCorner } from "./types";
 
 const DEFAULT_PERSPECTIVE_CAMERA_DISTANCE = 5.0;
 const DEFAULT_PERSPECTIVE_CAMERA_NEAR = 0.001;
@@ -55,7 +55,7 @@ export class ThreeJsPanel {
   private axisOffset: [number, number];
   private axisHelperScene: Scene;
   private axisHelperObject: Object3D;
-  private axisCamera: PerspectiveCamera | OrthographicCamera;
+  private axisCamera: OrthographicCamera;
 
   private orthoScaleBarElement: HTMLDivElement;
   public showOrthoScaleBar: boolean;
@@ -76,12 +76,6 @@ export class ThreeJsPanel {
     parentElement.appendChild(this.containerdiv);
 
     this.scene = new Scene();
-    this.axisHelperScene = new Scene();
-    this.axisHelperObject = new Object3D();
-
-    this.showAxis = false;
-    this.axisScale = 50.0;
-    this.axisOffset = [66, 66];
 
     this.orthoScaleBarElement = document.createElement("div");
     this.showOrthoScaleBar = true;
@@ -187,8 +181,18 @@ export class ThreeJsPanel {
     this.orthoControlsZ.panSpeed = this.canvas.clientWidth * 0.5;
 
     this.camera = this.perspectiveCamera;
-    this.axisCamera = new PerspectiveCamera();
     this.controls = this.perspectiveControls;
+    
+    this.axisCamera = new OrthographicCamera();
+    this.axisHelperScene = new Scene();
+    this.axisHelperObject = new Object3D();
+    this.axisHelperObject.name = "axisHelperParentObject";
+
+    this.showAxis = false;
+    // size of axes in px.
+    this.axisScale = 50.0;
+    // offset from bottom left corner in px.
+    this.axisOffset = [66.0, 66.0];
 
     this.setupAxisHelper();
     this.setupOrthoScaleBar();
@@ -280,18 +284,6 @@ export class ThreeJsPanel {
   setupAxisHelper(): void {
     // set up axis widget.
 
-    this.showAxis = false;
-
-    // size of axes in px.
-    this.axisScale = 50.0;
-    // offset from bottom left corner in px.
-    this.axisOffset = [66.0, 66.0];
-
-    this.axisHelperScene = new Scene();
-
-    this.axisHelperObject = new Object3D();
-    this.axisHelperObject.name = "axisHelperParentObject";
-
     const axisCubeMaterial = new MeshBasicMaterial({
       color: 0xaeacad,
     });
@@ -314,11 +306,17 @@ export class ThreeJsPanel {
     this.axisCamera.position.set(-this.axisOffset[0], -this.axisOffset[1], this.axisScale * 2.0);
   }
 
-  setAxisPosition(marginX: number, marginY: number) {
+  setAxisPosition(marginX: number, marginY: number, corner: ViewportCorner) {
     // Offset is relative to center of object, not corner of possible extent
     // at offsets lower than BASE_MARGIN, axes may extend off screen
     const BASE_MARGIN = 50;
     this.axisOffset = [marginX + BASE_MARGIN, marginY + BASE_MARGIN];
+    if (corner.startsWith("top")) {
+      this.axisOffset[1] = this.getHeight() - this.axisOffset[1];
+    }
+    if (corner.endsWith("right")) {
+      this.axisOffset[0] = this.getWidth() - this.axisOffset[0];
+    }
     this.axisCamera.position.set(-this.axisOffset[0], -this.axisOffset[1], this.axisScale * 2.0);
   }
 
@@ -345,6 +343,7 @@ export class ThreeJsPanel {
       textAlign: "right",
       lineHeight: "0px",
       fontFamily: "-apple-system, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+      fontSize: "14px",
       boxSizing: "border-box",
       paddingRight: "10px",
     };
@@ -380,10 +379,26 @@ export class ThreeJsPanel {
     this.updateOrthoScaleBarVisibility();
   }
 
-  setOrthoScaleBarPosition(marginX: number, marginY: number) {
-    Object.assign(this.orthoScaleBarElement.style, {
-      right: marginX + "px",
-      bottom: marginY + "px",
+  setOrthoScaleBarPosition(marginX: number, marginY: number, corner: ViewportCorner) {
+    const { style } = this.orthoScaleBarElement;
+
+    style.removeProperty("top");
+    style.removeProperty("bottom");
+    style.removeProperty("left");
+    style.removeProperty("right");
+
+    let [yProp, xProp] = corner.split("_");
+    // Sanity check: must be valid css property names
+    if (xProp !== "left" && xProp !== "right") {
+      xProp = "right";
+    }
+    if (yProp !== "top" && yProp !== "bottom") {
+      yProp = "bottom";
+    }
+
+    Object.assign(style, {
+      [xProp]: marginX + "px",
+      [yProp]: marginY + "px",
     });
   }
 
@@ -482,15 +497,11 @@ export class ThreeJsPanel {
       this.camera.updateProjectionMatrix();
     }
 
-    if (isOrthographicCamera(this.axisCamera)) {
-      this.axisCamera.left = 0;
-      this.axisCamera.right = w;
-      this.axisCamera.top = h;
-      this.axisCamera.bottom = 0;
-      this.axisCamera.updateProjectionMatrix();
-    } else {
-      this.axisCamera.updateProjectionMatrix();
-    }
+    this.axisCamera.left = 0;
+    this.axisCamera.right = w;
+    this.axisCamera.top = h;
+    this.axisCamera.bottom = 0;
+    this.axisCamera.updateProjectionMatrix();
 
     if (this.renderer.getPixelRatio() !== window.devicePixelRatio) {
       this.renderer.setPixelRatio(window.devicePixelRatio);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -482,9 +482,12 @@ export class View3d {
   }
 
   /**
-   * Set the offset of the axis indicator from the bottom-left corner
+   * Set the position of the axis indicator, as a corner of the viewport and horizontal and vertical margins from the
+   * edge of the viewport.
    * @param {number} marginX
    * @param {number} marginY
+   * @param {ViewportCorner} [corner] The corner of the viewport in which the axis appears.
+   *  Possible values: `top_left`, `top_right`, `bottom_left`, `bottom_right`; default: `bottom_left`
    */
   setAxisPosition(marginX: number, marginY: number, corner: ViewportCorner = "bottom_left"): void {
     this.canvas3d.setAxisPosition(marginX, marginY, corner);
@@ -494,9 +497,12 @@ export class View3d {
   }
 
   /**
-   * Set the offset of the scale bar from the bottom-right corner
+   * Set the position of the scale bar, as a corner of the viewport and horizontal and vertical margins from the edge
+   * of the viewport.
    * @param {number} marginX
    * @param {number} marginY
+   * @param {ViewportCorner} [corner] The corner of the viewport in which the scale bar appears.
+   *  Possible values: `top_left`, `top_right`, `bottom_left`, `bottom_right`; default: `bottom_right`
    */
   setScaleBarPosition(marginX: number, marginY: number, corner: ViewportCorner = "bottom_right"): void {
     this.canvas3d.setOrthoScaleBarPosition(marginX, marginY, corner);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -487,8 +487,8 @@ export class View3d {
    * @param {number} marginX
    * @param {number} marginY
    * @param {ViewportCorner} [corner] The corner of the viewport in which the axis appears. Default: bottom-left.
-   *  TypeScript users should use the `ViewportCorner` enum. Otherwise, this parameter is a number where
-   *  `0`: top-left, `1`: top-right, `2`: bottom-left, `3`: bottom-right
+   *  TypeScript users should use the `ViewportCorner` enum. Otherwise, corner is one of: `top_left`, `top_right`,
+   *  `bottom_left`, `bottom_right`.
    */
   setAxisPosition(marginX: number, marginY: number, corner: ViewportCorner = ViewportCorner.BOTTOM_LEFT): void {
     this.canvas3d.setAxisPosition(marginX, marginY, corner);
@@ -502,9 +502,9 @@ export class View3d {
    * of the viewport.
    * @param {number} marginX
    * @param {number} marginY
-   * @param {number} [corner] The corner of the viewport in which the scale bar appears. Default: bottom-right.
-   *  TypeScript users should use the `ViewportCorner` enum. Otherwise, this parameter is a number where:
-   *  `0`: top-left, `1`: top-right, `2`: bottom-left, `3`: bottom-right
+   * @param {ViewportCorner} [corner] The corner of the viewport in which the scale bar appears. Default: bottom-right.
+   *  TypeScript users should use the `ViewportCorner` enum. Otherwise, corner is one of: `top_left`, `top_right`,
+   *  `bottom_left`, `bottom_right`.
    */
   setScaleBarPosition(marginX: number, marginY: number, corner: ViewportCorner = ViewportCorner.BOTTOM_RIGHT): void {
     this.canvas3d.setOrthoScaleBarPosition(marginX, marginY, corner);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -486,9 +486,9 @@ export class View3d {
    * edge of the viewport.
    * @param {number} marginX
    * @param {number} marginY
-   * @param {ViewportCorner} [corner] The corner of the viewport in which the axis appears. Default: bottom-left.
-   *  TypeScript users should use the `ViewportCorner` enum. Otherwise, corner is one of: `top_left`, `top_right`,
-   *  `bottom_left`, `bottom_right`.
+   * @param {string} [corner] The corner of the viewport in which the axis appears. Default: `"bottom_left"`.
+   *  TypeScript users should use the `ViewportCorner` enum. Otherwise, corner is one of: `"top_left"`, `"top_right"`,
+   *  `"bottom_left"`, `"bottom_right"`.
    */
   setAxisPosition(marginX: number, marginY: number, corner: ViewportCorner = ViewportCorner.BOTTOM_LEFT): void {
     this.canvas3d.setAxisPosition(marginX, marginY, corner);
@@ -502,9 +502,9 @@ export class View3d {
    * of the viewport.
    * @param {number} marginX
    * @param {number} marginY
-   * @param {ViewportCorner} [corner] The corner of the viewport in which the scale bar appears. Default: bottom-right.
-   *  TypeScript users should use the `ViewportCorner` enum. Otherwise, corner is one of: `top_left`, `top_right`,
-   *  `bottom_left`, `bottom_right`.
+   * @param {string} [corner] The corner of the viewport in which the scale bar appears. Default: `"bottom_right"`.
+   *  TypeScript users should use the `ViewportCorner` enum. Otherwise, corner is one of: `"top_left"`, `"top_right"`,
+   *  `"bottom_left"`, `"bottom_right"`.
    */
   setScaleBarPosition(marginX: number, marginY: number, corner: ViewportCorner = ViewportCorner.BOTTOM_RIGHT): void {
     this.canvas3d.setOrthoScaleBarPosition(marginX, marginY, corner);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -29,8 +29,6 @@ export class View3d {
   private parentEl: HTMLElement;
   private image?: VolumeDrawable;
 
-  private oldScale: Vector3;
-  private currentScale: Vector3;
   private lights: Light[];
   private lightContainer: Object3D;
   private ambientLight: AmbientLight;
@@ -61,8 +59,6 @@ export class View3d {
     this.parentEl = parentElement;
     window.addEventListener("resize", () => this.resize(null, this.parentEl.offsetWidth, this.parentEl.offsetHeight));
 
-    this.oldScale = new Vector3();
-    this.currentScale = new Vector3();
     this.lightContainer = new Object3D();
     this.ambientLight = new AmbientLight();
     this.spotLight = new SpotLight();
@@ -405,9 +401,6 @@ export class View3d {
   buildScene(): void {
     this.scene = this.canvas3d.scene;
 
-    this.oldScale = new Vector3(0.5, 0.5, 0.5);
-    this.currentScale = new Vector3(0.5, 0.5, 0.5);
-
     // background color
     this.canvas3d.setClearColor(this.backgroundColor, 1.0);
 
@@ -486,6 +479,27 @@ export class View3d {
    */
   setShowScaleBar(showScaleBar: boolean): void {
     this.canvas3d.setShowOrthoScaleBar(showScaleBar);
+  }
+
+  /**
+   * Set the offset of the axis indicator from the bottom-left corner
+   * @param {number} marginX
+   * @param {number} marginY
+   */
+  setAxisPosition(marginX: number, marginY: number): void {
+    this.canvas3d.setAxisPosition(marginX, marginY);
+    if (this.canvas3d.showAxis) {
+      this.canvas3d.redraw();
+    }
+  }
+
+  /**
+   * Set the offset of the scale bar from the bottom-right corner
+   * @param {number} marginX
+   * @param {number} marginY
+   */
+  setScaleBarPosition(marginX: number, marginY: number): void {
+    this.canvas3d.setOrthoScaleBarPosition(marginX, marginY);
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -5,7 +5,7 @@ import lightSettings from "./constants/lights";
 import VolumeDrawable from "./VolumeDrawable";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light";
 import Volume from "./Volume";
-import { VolumeChannelDisplayOptions, VolumeDisplayOptions, isOrthographicCamera } from "./types";
+import { VolumeChannelDisplayOptions, VolumeDisplayOptions, isOrthographicCamera, ViewportCorner } from "./types";
 
 export const RENDERMODE_RAYMARCH = 0;
 export const RENDERMODE_PATHTRACE = 1;
@@ -486,8 +486,8 @@ export class View3d {
    * @param {number} marginX
    * @param {number} marginY
    */
-  setAxisPosition(marginX: number, marginY: number): void {
-    this.canvas3d.setAxisPosition(marginX, marginY);
+  setAxisPosition(marginX: number, marginY: number, corner: ViewportCorner = "bottom_left"): void {
+    this.canvas3d.setAxisPosition(marginX, marginY, corner);
     if (this.canvas3d.showAxis) {
       this.canvas3d.redraw();
     }
@@ -498,8 +498,8 @@ export class View3d {
    * @param {number} marginX
    * @param {number} marginY
    */
-  setScaleBarPosition(marginX: number, marginY: number): void {
-    this.canvas3d.setOrthoScaleBarPosition(marginX, marginY);
+  setScaleBarPosition(marginX: number, marginY: number, corner: ViewportCorner = "bottom_right"): void {
+    this.canvas3d.setOrthoScaleBarPosition(marginX, marginY, corner);
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -486,10 +486,11 @@ export class View3d {
    * edge of the viewport.
    * @param {number} marginX
    * @param {number} marginY
-   * @param {ViewportCorner} [corner] The corner of the viewport in which the axis appears.
-   *  Possible values: `top_left`, `top_right`, `bottom_left`, `bottom_right`; default: `bottom_left`
+   * @param {ViewportCorner} [corner] The corner of the viewport in which the axis appears. Default: bottom-left.
+   *  TypeScript users should use the `ViewportCorner` enum. Otherwise, this parameter is a number where
+   *  `0`: top-left, `1`: top-right, `2`: bottom-left, `3`: bottom-right
    */
-  setAxisPosition(marginX: number, marginY: number, corner: ViewportCorner = "bottom_left"): void {
+  setAxisPosition(marginX: number, marginY: number, corner: ViewportCorner = ViewportCorner.BOTTOM_LEFT): void {
     this.canvas3d.setAxisPosition(marginX, marginY, corner);
     if (this.canvas3d.showAxis) {
       this.canvas3d.redraw();
@@ -501,10 +502,11 @@ export class View3d {
    * of the viewport.
    * @param {number} marginX
    * @param {number} marginY
-   * @param {ViewportCorner} [corner] The corner of the viewport in which the scale bar appears.
-   *  Possible values: `top_left`, `top_right`, `bottom_left`, `bottom_right`; default: `bottom_right`
+   * @param {number} [corner] The corner of the viewport in which the scale bar appears. Default: bottom-right.
+   *  TypeScript users should use the `ViewportCorner` enum. Otherwise, this parameter is a number where:
+   *  `0`: top-left, `1`: top-right, `2`: bottom-left, `3`: bottom-right
    */
-  setScaleBarPosition(marginX: number, marginY: number, corner: ViewportCorner = "bottom_right"): void {
+  setScaleBarPosition(marginX: number, marginY: number, corner: ViewportCorner = ViewportCorner.BOTTOM_RIGHT): void {
     this.canvas3d.setOrthoScaleBarPosition(marginX, marginY, corner);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import Channel from "./Channel";
 import VolumeMaker from "./VolumeMaker";
 import VolumeLoader from "./VolumeLoader";
 import Histogram from "./Histogram";
+import { ViewportCorner } from "./types";
 
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light";
 
@@ -17,6 +18,7 @@ export {
   VolumeLoader,
   Channel,
   Light,
+  ViewportCorner,
   AREA_LIGHT,
   RENDERMODE_PATHTRACE,
   RENDERMODE_RAYMARCH,

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,4 +81,9 @@ export interface VolumeDisplayOptions {
 export const isOrthographicCamera = (def: Camera): def is OrthographicCamera =>
   def && (def as OrthographicCamera).isOrthographicCamera;
 
-export type ViewportCorner = "top_left" | "top_right" | "bottom_left" | "bottom_right";
+export const enum ViewportCorner {
+  TOP_LEFT = 0,
+  TOP_RIGHT,
+  BOTTOM_LEFT,
+  BOTTOM_RIGHT,
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,3 +80,5 @@ export interface VolumeDisplayOptions {
 
 export const isOrthographicCamera = (def: Camera): def is OrthographicCamera =>
   def && (def as OrthographicCamera).isOrthographicCamera;
+
+export type ViewportCorner = "top_left" | "top_right" | "bottom_left" | "bottom_right";

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,8 +82,12 @@ export const isOrthographicCamera = (def: Camera): def is OrthographicCamera =>
   def && (def as OrthographicCamera).isOrthographicCamera;
 
 export const enum ViewportCorner {
-  TOP_LEFT = 0,
-  TOP_RIGHT,
-  BOTTOM_LEFT,
-  BOTTOM_RIGHT,
+  TOP_LEFT = "top_left",
+  TOP_RIGHT = "top_right",
+  BOTTOM_LEFT = "bottom_left",
+  BOTTOM_RIGHT = "bottom_right",
 }
+export const isTop = (corner: ViewportCorner): boolean =>
+  corner === ViewportCorner.TOP_LEFT || corner === ViewportCorner.TOP_RIGHT;
+export const isRight = (corner: ViewportCorner): boolean =>
+  corner === ViewportCorner.TOP_RIGHT || corner === ViewportCorner.BOTTOM_RIGHT;


### PR DESCRIPTION
Adds methods `setAxisPosition` and `setScaleBarPosition` to `View3d`, allowing the axis and scale indicators to be moved within the viewport. This gives a potential path forward for #66, #79, and allen-cell-animated/website-3d-cell-viewer#73, which all have to do with how these indicators interact with web-3d-viewer's clipping panel.

Both methods have the signature `(marginX: number, marginY: number, corner?: "top_left" | "top_right" | "bottom_left" | "bottom_right") => void`, where `marginX` and `marginY` are pixel offsets into the viewport from `corner`, and `corner` defaults to the current positions of these elements (`"bottom_left"` for the axes, `"bottom_right"` for the scale bar).

Also, removes unused parameters `oldScale` and `currentScale` from `View3d`, and cleans up some initialization code for the axis indicator.

Screenshot from web-3d-viewer, with both elements moved out of the way of the clipping drawer:
![image](https://user-images.githubusercontent.com/53030214/211432450-76eadf0a-38e4-49ef-be05-f17ae1834fd2.png)
