### PR TITLE
Feature/3d scale indicator

### DIFF
--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -72,7 +72,7 @@ export default class PathTracedVolume {
   private screenOutputDenoiseMaterial: ShaderMaterial;
   private screenOutputMesh: Mesh;
   private gradientDelta: number;
-  private renderUpdateListener?: (number) => void;
+  private renderUpdateListener?: (iteration: number) => void;
 
   constructor(volume: Volume) {
     // need?

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -73,7 +73,7 @@ export default class RayMarchedAtlasVolume {
     this.cubeTransformNode = new Group();
     this.cubeTransformNode.name = "VolumeContainerNode";
 
-    this.cubeTransformNode.add(this.boxHelper, this.cubeMesh, this.tickMarksMesh);
+    this.cubeTransformNode.add(this.boxHelper, this.tickMarksMesh, this.cubeMesh);
 
     this.uniforms = rayMarchingShaderUniforms;
 

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -29,9 +29,6 @@ import { ThreeJsPanel } from "./ThreeJsPanel";
 
 import { Bounds, FuseChannel } from "./types";
 
-// TODO calculate tick mark sizes better
-const NUM_TICK_MARKS = 4;
-
 const BOUNDING_BOX_DEFAULT_COLOR = new Color(0xffff00);
 
 export default class RayMarchedAtlasVolume {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -34,7 +34,6 @@ const BOUNDING_BOX_DEFAULT_COLOR = new Color(0xffff00);
 export default class RayMarchedAtlasVolume {
   public volume: Volume;
   public bounds: Bounds;
-  public tickMarksPhysicalLength!: number;
   private cube: BoxGeometry;
   private cubeMesh: Mesh<BufferGeometry, Material>;
   private boxHelper: Box3Helper;
@@ -103,10 +102,10 @@ export default class RayMarchedAtlasVolume {
   }
 
   private createTickMarks(): LineSegments {
+    // Length of tick mark lines in world units
     const TICK_LENGTH = 0.05;
-    const { physicalScale, normalizedPhysicalSize } = this.volume;
-    this.tickMarksPhysicalLength = 10 ** Math.floor(Math.log10(physicalScale / 2));
-    const numTickMarks = physicalScale / this.tickMarksPhysicalLength;
+    const { tickMarkPhysicalLength, physicalScale, normalizedPhysicalSize } = this.volume;
+    const numTickMarks = physicalScale / tickMarkPhysicalLength;
 
     const vertices: number[] = [];
 

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -103,7 +103,7 @@ export default class RayMarchedAtlasVolume {
 
   private createTickMarks(): LineSegments {
     // Length of tick mark lines in world units
-    const TICK_LENGTH = 0.05;
+    const TICK_LENGTH = 0.025;
     const { tickMarkPhysicalLength, physicalScale, normalizedPhysicalSize } = this.volume;
     const numTickMarks = physicalScale / tickMarkPhysicalLength;
 

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -34,7 +34,7 @@ const BOUNDING_BOX_DEFAULT_COLOR = new Color(0xffff00);
 export default class RayMarchedAtlasVolume {
   public volume: Volume;
   public bounds: Bounds;
-  public tickMarksPhysicalLength: number;
+  public tickMarksPhysicalLength!: number;
   private cube: BoxGeometry;
   private cubeMesh: Mesh<BufferGeometry, Material>;
   private boxHelper: Box3Helper;
@@ -67,11 +67,9 @@ export default class RayMarchedAtlasVolume {
     this.boxHelper.updateMatrixWorld();
     this.boxHelper.visible = false;
 
-    this.tickMarksMesh = new LineSegments();
+    this.tickMarksMesh = this.createTickMarks();
     this.tickMarksMesh.updateMatrixWorld();
     this.tickMarksMesh.visible = false;
-    this.tickMarksPhysicalLength = 1;
-    this.createTickMarks();
 
     this.cubeTransformNode = new Group();
     this.cubeTransformNode.name = "VolumeContainerNode";
@@ -104,7 +102,7 @@ export default class RayMarchedAtlasVolume {
     this.channelData = new FusedChannelData(volume.imageInfo.atlas_width, volume.imageInfo.atlas_height);
   }
 
-  private createTickMarks(): void {
+  private createTickMarks(): LineSegments {
     const TICK_LENGTH = 0.05;
     const { physicalScale, normalizedPhysicalSize } = this.volume;
     this.tickMarksPhysicalLength = 10 ** Math.floor(Math.log10(physicalScale / 2));
@@ -170,9 +168,7 @@ export default class RayMarchedAtlasVolume {
 
     const geometry = new BufferGeometry();
     geometry.setAttribute("position", new BufferAttribute(new Float32Array(vertices), 3));
-    this.tickMarksMesh = new LineSegments(geometry, new LineBasicMaterial({ color: BOUNDING_BOX_DEFAULT_COLOR }));
-
-    // this.updateTickMarkScaleText();
+    return new LineSegments(geometry, new LineBasicMaterial({ color: BOUNDING_BOX_DEFAULT_COLOR }));
   }
 
   public cleanup(): void {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -2,11 +2,13 @@ import {
   Box3,
   Box3Helper,
   BoxGeometry,
+  BufferAttribute,
   BufferGeometry,
   Color,
   Euler,
   Group,
   LineBasicMaterial,
+  LineSegments,
   Material,
   Matrix4,
   Mesh,
@@ -27,12 +29,18 @@ import { ThreeJsPanel } from "./ThreeJsPanel";
 
 import { Bounds, FuseChannel } from "./types";
 
+// TODO calculate tick mark sizes better
+const NUM_TICK_MARKS = 4;
+
+const BOUNDING_BOX_DEFAULT_COLOR = new Color(0xffff00);
+
 export default class RayMarchedAtlasVolume {
   public volume: Volume;
   public bounds: Bounds;
   private cube: BoxGeometry;
   private cubeMesh: Mesh<BufferGeometry, Material>;
   private boxHelper: Box3Helper;
+  private tickMarksMesh: LineSegments;
   private cubeTransformNode: Group;
   private uniforms: typeof rayMarchingShaderUniforms;
   private channelData: FusedChannelData;
@@ -56,16 +64,20 @@ export default class RayMarchedAtlasVolume {
 
     this.boxHelper = new Box3Helper(
       new Box3(new Vector3(-0.5, -0.5, -0.5), new Vector3(0.5, 0.5, 0.5)),
-      new Color(0xffff00)
+      BOUNDING_BOX_DEFAULT_COLOR
     );
     this.boxHelper.updateMatrixWorld();
     this.boxHelper.visible = false;
 
+    this.tickMarksMesh = new LineSegments();
+    this.tickMarksMesh.updateMatrixWorld();
+    this.tickMarksMesh.visible = false;
+    this.createTickMarks();
+
     this.cubeTransformNode = new Group();
     this.cubeTransformNode.name = "VolumeContainerNode";
 
-    this.cubeTransformNode.add(this.boxHelper);
-    this.cubeTransformNode.add(this.cubeMesh);
+    this.cubeTransformNode.add(this.boxHelper, this.tickMarksMesh, this.cubeMesh);
 
     this.uniforms = rayMarchingShaderUniforms;
 
@@ -93,6 +105,69 @@ export default class RayMarchedAtlasVolume {
     this.channelData = new FusedChannelData(volume.imageInfo.atlas_width, volume.imageInfo.atlas_height);
   }
 
+  private createTickMarks(): void {
+    const { physicalScale, normalizedPhysicalSize } = this.volume;
+    const tickMarkLength = 10 ** Math.floor(Math.log10(physicalScale / 2));
+    const numTickMarks = physicalScale / tickMarkLength;
+
+    const vertices: number[] = [];
+
+    const tickLengthX = 1 / (normalizedPhysicalSize.x * numTickMarks);
+    for (let x = -0.5; x <= 0.5; x += tickLengthX) {
+      vertices.push(
+        // x, -0.5,  -0.5,
+        // x, -0.55, -0.5,
+
+        // x,  0.5,  -0.5,
+        // x,  0.55, -0.5,
+
+        // x, -0.5,   0.5,
+        // x, -0.55,  0.5,
+
+        x,  0.5,   0.5,
+        x,  0.55,  0.5,
+      );
+    }
+
+    const tickLengthY = 1 / (normalizedPhysicalSize.y * numTickMarks);
+    for (let y = 0.5; y >= -0.5; y -= tickLengthY) {
+      vertices.push(
+        // -0.5,  y, -0.5,
+        // -0.55, y, -0.5,
+
+        //  0.5,  y, -0.5,
+        //  0.55, y, -0.5,
+
+        -0.5,  y,  0.5,
+        -0.55, y,  0.5,
+
+        //  0.5,  y,  0.5,
+        //  0.55, y,  0.5,
+      );
+    }
+
+    const tickLengthZ = 1 / (normalizedPhysicalSize.z * numTickMarks);
+    for (let z = 0.5; z >= 0.5; z -= tickLengthZ) {
+      vertices.push(
+        // -0.5,  -0.5, z,
+        // -0.55, -0.5, z,
+
+        //  0.5,  -0.5, z,
+        //  0.55, -0.5, z,
+
+        -0.5,   0.5, z,
+        -0.55,  0.5, z,
+
+        //  0.5,   0.5, z,
+        //  0.55,  0.5, z,
+      );
+    }
+
+    const geometry = new BufferGeometry();
+    geometry.setAttribute("position", new BufferAttribute(new Float32Array(vertices), 3));
+    this.tickMarksMesh = new LineSegments(geometry, new LineBasicMaterial({color: BOUNDING_BOX_DEFAULT_COLOR}));
+  }
+
   public cleanup(): void {
     this.cube.dispose();
     this.cubeMesh.material.dispose();
@@ -107,14 +182,17 @@ export default class RayMarchedAtlasVolume {
 
   public setShowBoundingBox(showBoundingBox: boolean): void {
     this.boxHelper.visible = showBoundingBox;
+    this.tickMarksMesh.visible = showBoundingBox;
   }
 
   public setBoundingBoxColor(color: [number, number, number]): void {
+    const newBoxColor = new Color(color[0], color[1], color[2]);
     // note this material update is supposed to be a hidden implementation detail
     // but I didn't want to re-create a whole boxHelper again.
     // I could also create a new LineBasicMaterial but that would also rely on knowledge
     // that Box3Helper expects that type.
-    (this.boxHelper.material as LineBasicMaterial).color = new Color(color[0], color[1], color[2]);
+    (this.boxHelper.material as LineBasicMaterial).color = newBoxColor;
+    (this.tickMarksMesh.material as LineBasicMaterial).color = newBoxColor;
   }
 
   public doRender(canvas: ThreeJsPanel): void {
@@ -146,12 +224,13 @@ export default class RayMarchedAtlasVolume {
   public setScale(scale: Vector3): void {
     this.scale = scale;
 
-    this.cubeMesh.scale.copy(new Vector3(scale.x, scale.y, scale.z));
+    this.cubeMesh.scale.copy(scale);
     this.setUniform("volumeScale", scale);
     this.boxHelper.box.set(
       new Vector3(-0.5 * scale.x, -0.5 * scale.y, -0.5 * scale.z),
       new Vector3(0.5 * scale.x, 0.5 * scale.y, 0.5 * scale.z)
     );
+    this.tickMarksMesh.scale.copy(scale);
   }
 
   public setRayStepSizes(_primary: number, _secondary: number): void {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -105,63 +105,66 @@ export default class RayMarchedAtlasVolume {
   }
 
   private createTickMarks(): void {
+    const TICK_LENGTH = 0.05;
     const { physicalScale, normalizedPhysicalSize } = this.volume;
     this.tickMarksPhysicalLength = 10 ** Math.floor(Math.log10(physicalScale / 2));
     const numTickMarks = physicalScale / this.tickMarksPhysicalLength;
 
     const vertices: number[] = [];
 
-    const tickLengthX = 1 / (normalizedPhysicalSize.x * numTickMarks);
-    for (let x = -0.5; x <= 0.5; x += tickLengthX) {
+    const tickEndY = TICK_LENGTH / normalizedPhysicalSize.y + 0.5;
+    const tickSpacingX = 1 / (normalizedPhysicalSize.x * numTickMarks);
+    for (let x = -0.5; x <= 0.5; x += tickSpacingX) {
       // prettier-ignore
       vertices.push(
-      x, 0.5,  0.5,
-      x, 0.55, 0.5,
+        x, 0.5,       0.5,
+        x, tickEndY,  0.5,
 
-      x, -0.5,  -0.5,
-      x, -0.55, -0.5,
+        x, -0.5,      -0.5,
+        x, -tickEndY, -0.5,
 
-      x, 0.5,  -0.5,
-      x, 0.55, -0.5,
+        x, 0.5,       -0.5,
+        x, tickEndY,  -0.5,
 
-      x, -0.5,  0.5,
-      x, -0.55, 0.5,
+        x, -0.5,      0.5,
+        x, -tickEndY, 0.5,
       );
     }
 
-    const tickLengthY = 1 / (normalizedPhysicalSize.y * numTickMarks);
-    for (let y = 0.5; y >= -0.5; y -= tickLengthY) {
+    const tickEndX = TICK_LENGTH / normalizedPhysicalSize.x + 0.5;
+    const tickSpacingY = 1 / (normalizedPhysicalSize.y * numTickMarks);
+    for (let y = 0.5; y >= -0.5; y -= tickSpacingY) {
       // prettier-ignore
       vertices.push(
-        -0.5,  y, 0.5,
-        -0.55, y, 0.5,
+        -0.5,      y, 0.5,
+        -tickEndX, y, 0.5,
 
-        -0.5,  y, -0.5,
-        -0.55, y, -0.5,
+        -0.5,      y, -0.5,
+        -tickEndX, y, -0.5,
 
-        0.5,   y, -0.5,
-        0.55,  y, -0.5,
+        0.5,       y, -0.5,
+        tickEndX,  y, -0.5,
 
-        0.5,   y, 0.5,
-        0.55,  y, 0.5,
+        0.5,       y, 0.5,
+        tickEndX,  y, 0.5,
       );
     }
 
-    const tickLengthZ = 1 / (normalizedPhysicalSize.z * numTickMarks);
-    for (let z = 0.5; z >= -0.5; z -= tickLengthZ) {
+    const tickSpacingZ = 1 / (normalizedPhysicalSize.z * numTickMarks);
+    for (let z = 0.5; z >= -0.5; z -= tickSpacingZ) {
       // prettier-ignore
       vertices.push(
-        -0.5,  0.5,  z,
-        -0.55, 0.5,  z,
+        -0.5,      0.5,  z,
+        -tickEndX, 0.5,  z,
 
-        -0.5,  -0.5, z,
-        -0.55, -0.5, z,
+        -0.5,      -0.5, z,
+        -tickEndX, -0.5, z,
 
-        0.5,   -0.5, z,
-        0.55,  -0.5, z,
+        0.5,       -0.5, z,
+        tickEndX,  -0.5, z,
 
-        0.5,   0.5,  z,
-        0.55,  0.5,  z,
+        0.5,       0.5,  z,
+        tickEndX,  0.5,  z,
       );
     }
 

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -405,6 +405,7 @@ export class ThreeJsPanel {
   }
 
   setPerspectiveScaleBarColor(color: [number, number, number]): void {
+    // set the font color of the SVG container. only paths with `stroke="currentColor"` will react to this.
     const svgdiv = this.perspectiveScaleBarElement.lastChild as HTMLDivElement;
     svgdiv.style.color = `rgb(${color[0] * 255}, ${color[1] * 255}, ${color[2] * 255})`;
   }

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -84,8 +84,12 @@ export class View3d {
     }
   }
 
-  private updateOrthoScaleBar(volume: Volume) {
+  private updateOrthoScaleBar(volume: Volume): void {
     this.canvas3d.updateOrthoScaleBar(volume.physicalScale, volume.imageInfo.pixel_size_unit);
+  }
+
+  private updatePerspectiveScaleBar(volume: Volume): void {
+    this.canvas3d.updatePerspectiveScaleBar(volume.tickMarkPhysicalLength, volume.imageInfo.pixel_size_unit);
   }
 
   /**
@@ -223,6 +227,9 @@ export class View3d {
 
       if (unit) {
         this.image.volume.setUnitSymbol(unit);
+      } else if (!isOrthographicCamera(this.canvas3d.camera)) {
+        // `else if` because `setUnitSymbol` would have done this already
+        this.updatePerspectiveScaleBar(this.image.volume);
       }
     }
     this.redraw();
@@ -366,6 +373,8 @@ export class View3d {
 
     this.canvas3d.animateFuncs.push(this.preRender.bind(this));
     this.canvas3d.animateFuncs.push(img.onAnimate.bind(img));
+
+    this.updatePerspectiveScaleBar(img.volume);
 
     // redraw if not already in draw loop
     this.redraw();
@@ -538,6 +547,7 @@ export class View3d {
   setScaleUnit(unit: string): void {
     if (this.image) {
       this.image.volume.setUnitSymbol(unit);
+      this.updatePerspectiveScaleBar(this.image.volume);
       if (isOrthographicCamera(this.canvas3d.camera)) {
         this.updateOrthoScaleBar(this.image.volume);
       }

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -227,10 +227,9 @@ export class View3d {
 
       if (unit) {
         this.image.volume.setUnitSymbol(unit);
-      } else if (!isOrthographicCamera(this.canvas3d.camera)) {
-        // `else if` because `setUnitSymbol` would have done this already
-        this.updatePerspectiveScaleBar(this.image.volume);
       }
+
+      this.updatePerspectiveScaleBar(this.image.volume);
     }
     this.redraw();
   }

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -239,6 +239,9 @@ export class View3d {
     if (this.image) {
       this.image.setShowBoundingBox(showBoundingBox);
     }
+    this.canvas3d.setShowPerspectiveScaleBar(
+      showBoundingBox && this.canvas3d.showOrthoScaleBar && this.volumeRenderMode !== RENDERMODE_PATHTRACE
+    );
     this.redraw();
   }
 
@@ -246,6 +249,7 @@ export class View3d {
     if (this.image) {
       this.image.setBoundingBoxColor(color);
     }
+    this.canvas3d.setPerspectiveScaleBarColor(color);
     this.redraw();
   }
 
@@ -479,6 +483,9 @@ export class View3d {
    */
   setShowScaleBar(showScaleBar: boolean): void {
     this.canvas3d.setShowOrthoScaleBar(showScaleBar);
+    this.canvas3d.setShowPerspectiveScaleBar(
+      showScaleBar && !!this.image?.showBoundingBox && this.volumeRenderMode !== RENDERMODE_PATHTRACE
+    );
   }
 
   /**
@@ -507,7 +514,7 @@ export class View3d {
    *  `"bottom_left"`, `"bottom_right"`.
    */
   setScaleBarPosition(marginX: number, marginY: number, corner: ViewportCorner = ViewportCorner.BOTTOM_RIGHT): void {
-    this.canvas3d.setOrthoScaleBarPosition(marginX, marginY, corner);
+    this.canvas3d.setScaleBarPosition(marginX, marginY, corner);
   }
 
   /**
@@ -841,6 +848,11 @@ export class View3d {
 
       this.image.setRenderUpdateListener(this.renderUpdateListener);
     }
+
+    // TODO remove when pathtrace supports a bounding box
+    this.canvas3d.setShowPerspectiveScaleBar(
+      this.canvas3d.showOrthoScaleBar && !!this.image?.showBoundingBox && mode !== RENDERMODE_PATHTRACE
+    );
   }
 
   /**

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -138,6 +138,7 @@ export default class Volume {
   public physicalScale: number;
   public physicalUnitSymbol: string;
   public normalizedPhysicalSize: Vector3;
+  public tickMarkPhysicalLength: number;
   private loaded: boolean;
   /* eslint-disable @typescript-eslint/naming-convention */
   public num_channels: number;
@@ -192,6 +193,7 @@ export default class Volume {
     }
 
     this.physicalUnitSymbol = this.imageInfo.pixel_size_unit;
+    this.tickMarkPhysicalLength = 1;
     this.setVoxelSize(this.pixel_size);
 
     // make sure a transform is specified
@@ -247,6 +249,9 @@ export default class Volume {
     this.physicalScale = Math.max(this.physicalSize.x, this.physicalSize.y, this.physicalSize.z);
     // Compute the volume's max extent - scaled to max dimension.
     this.normalizedPhysicalSize = this.physicalSize.clone().divideScalar(this.physicalScale);
+    // While we're here, pick a power of 10 that divides into our max dimension a reasonable number of times
+    // and save it to be the length of tick marks in 3d.
+    this.tickMarkPhysicalLength = 10 ** Math.floor(Math.log10(this.physicalScale / 2));
 
     // sx, sy, sz should be same as normalizedPhysicalSize
     this.scale = new Vector3(sx, sy, sz);

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -36,7 +36,7 @@ export default class VolumeDrawable {
   private meshVolume: MeshVolume;
   private primaryRayStepSize: number;
   private secondaryRayStepSize: number;
-  private showBoundingBox: boolean;
+  public showBoundingBox: boolean;
   private boundingBoxColor: [number, number, number];
 
   // these two should never coexist simultaneously. always one or the other is present

--- a/src/constants/scaleBarSVG.ts
+++ b/src/constants/scaleBarSVG.ts
@@ -1,0 +1,22 @@
+const scaleBarSVG = `
+<svg enable-background="new 0 0 150 75.3" viewBox="0 0 150 75.3" xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <linearGradient id="a" gradientTransform="matrix(1 0 0 -1 0 76)" gradientUnits="userSpaceOnUse" x1=".3035"
+    x2="149.6965" y1="19.59" y2="19.59">
+    <stop offset="0" stop-color="currentColor" stop-opacity="0" />
+    <stop offset=".16" stop-color="currentColor" />
+    <stop offset=".84" stop-color="currentColor" />
+    <stop offset="1" stop-color="currentColor" stop-opacity="0" />
+  </linearGradient>
+  <g fill="none">
+    <path d="m.5 39.1 149 34.6" stroke="url(#a)" stroke-miterlimit="10" stroke-width="4" />
+    <path d="m101.5 73.6 11-8.5" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" />
+    <path d="m25.1 55.7 11-8.5" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" />
+    <path
+      d="m36.2 40c0-12 5.3-12.4 10.5-14.2 5-1.7 17.3 1.9 22.6 1.7s8-5 8.4-11.8c-.4 6.9 3.4 13.8 10 16.3 8 3 17.9 2.7 23.2 7.3 7 6 3.3 12.2 1.6 19.1"
+      stroke="white" stroke-dasharray="2 4" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" />
+  </g>
+</svg>
+`;
+
+export default scaleBarSVG;


### PR DESCRIPTION
Add tick marks to the bounding box as in Simularium, along with Simularium's 2d indicator of spacing between tick marks.

The spacing between tick marks is always some power of 10 physical units that produces at least 2 tick marks along the volume's longest axis. The scale indicator matches the color of the bounding box, and is only visible when all these conditions are met: the viewer is in 3d mode and not path tracing, the bounding box is enabled, and scale bars have not been disabled with `View3d.setShowScaleBar`.

Combined with #82, this resolves #66.

### Screenshots
![image](https://user-images.githubusercontent.com/53030214/214477679-9dad2e65-9762-4bc3-b916-f8234ee1bcfa.png)
(From Cell Feature Explorer)
![image](https://user-images.githubusercontent.com/53030214/214468217-231a6658-e019-41e4-88ed-14325ddfcc54.png)
