### PR TITLE
select optimal zarr multiresolution based on a 2kX2k tiled texture size

### DIFF
--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -16,7 +16,9 @@ export class LoadSpec {
 
 export class VolumeDims {
   subpath = "";
+  // shape: [t, c, z, y, x]
   shape: number[] = [0, 0, 0, 0, 0];
+  // spacing: [t, c, z, y, x]; generally expect 1 for non-spatial dimensions
   spacing: number[] = [1, 1, 1, 1, 1];
   spatialUnit = "micron";
   dataType = "uint8";

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -89,7 +89,6 @@ class OMEZarrLoader implements IVolumeLoader {
     // get all shapes
     for (const i in multiscales) {
       const shape = await fetchShapeOfLevel(store, imagegroup, multiscales[i]);
-      // just stick it in multiscales for now.
       if (shape.length != axes.length) {
         console.log("ERROR: shape length " + shape.length + " does not match axes length " + axes.length);
       }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -57,9 +57,7 @@ function findSpatialAxesZYX(axisTCZYX): number[] {
 }
 
 async function fetchShapeOfLevel(store, imagegroup, multiscale): Promise<number[]> {
-  // get all shapes
   const level = await openArray({ store: store, path: imagegroup + "/" + multiscale.path, mode: "r" });
-
   const shape = level.meta.shape;
   return shape;
 }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -39,18 +39,19 @@ function remapAxesToTCZYX(axes): number[] {
   return axisTCZYX;
 }
 
-function findSpatialAxesZYX(axisTCZYX): number[] {
-  const spatialAxes: number[] = [];
+function findSpatialAxesZYX(axisTCZYX): [number, number, number] {
+  // return in ZYX order
+  const spatialAxes: [number, number, number] = [-1, -1, -1];
   if (axisTCZYX[2] > -1) {
-    spatialAxes.push(axisTCZYX[2]);
+    spatialAxes[0] = axisTCZYX[2];
   }
   if (axisTCZYX[3] > -1) {
-    spatialAxes.push(axisTCZYX[3]);
+    spatialAxes[1] = axisTCZYX[3];
   }
   if (axisTCZYX[4] > -1) {
-    spatialAxes.push(axisTCZYX[4]);
+    spatialAxes[2] = axisTCZYX[4];
   }
-  if (spatialAxes.length != 3) {
+  if (spatialAxes.some((el) => el === -1)) {
     console.log("ERROR: zarr loader expects a z, y, and x axis.");
   }
   return spatialAxes;
@@ -79,7 +80,7 @@ class OMEZarrLoader implements IVolumeLoader {
 
     const axisTCZYX = remapAxesToTCZYX(axes);
     // ZYX
-    const spatialAxes: number[] = findSpatialAxesZYX(axisTCZYX);
+    const spatialAxes = findSpatialAxesZYX(axisTCZYX);
 
     // Assume all axes have the same units - we have no means of storing per-axis unit symbols
     const unitName = axes[spatialAxes[2]].unit;
@@ -133,7 +134,7 @@ class OMEZarrLoader implements IVolumeLoader {
     const hasT = axisTCZYX[0] > -1;
     const hasC = axisTCZYX[1] > -1;
     // ZYX
-    const spatialAxes: number[] = findSpatialAxesZYX(axisTCZYX);
+    const spatialAxes = findSpatialAxesZYX(axisTCZYX);
 
     const numlevels = multiscales.length;
     // Assume all axes have the same units - we have no means of storing per-axis unit symbols

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -1,7 +1,5 @@
 import "regenerator-runtime/runtime";
 
-import { VolumeDims } from "./IVolumeLoader";
-
 export type TypedArray =
   | Uint8Array
   | Int8Array
@@ -58,14 +56,19 @@ export function computePackedAtlasDims(z, tw, th): { nrows: number; ncols: numbe
   return { nrows, ncols };
 }
 
-export function estimateLevelForAtlas(multiscales: VolumeDims[], maxAtlasEdge = 4096) {
+export function estimateLevelForAtlas(spatialDimsZYX: number[][], maxAtlasEdge = 4096) {
   // update levelToLoad after we get size info about multiscales.
   // decide to max out at a 4k x 4k texture.
-  let levelToLoad = multiscales.length - 1;
-  for (let i = 0; i < multiscales.length; ++i) {
+  let levelToLoad = spatialDimsZYX.length - 1;
+  for (let i = 0; i < spatialDimsZYX.length; ++i) {
     // estimate atlas size:
-    const s = multiscales[i].shape[2] * multiscales[i].shape[3] * multiscales[i].shape[4];
-    if (s / maxAtlasEdge <= maxAtlasEdge) {
+    const x = spatialDimsZYX[i][2];
+    const y = spatialDimsZYX[i][1];
+    const z = spatialDimsZYX[i][0];
+    const xtiles = Math.floor(maxAtlasEdge / x);
+    const ytiles = Math.floor(maxAtlasEdge / y);
+
+    if (xtiles * ytiles >= z) {
       console.log("Will load level " + i);
       levelToLoad = i;
       break;


### PR DESCRIPTION
The zarr dimension code tries to auto-select a multiresolution level to display.  The autoselection of multiresolution level was picking the worst resolution even if a better one would fit.  
This fix computes an estimate of the best multiresolution layer based on how we would ideally tile the z slices in our internal texture for rendering.
The code in the zarr loader is a bit ugly because I want to remap the dimension order back to TCZYX even if it is ordered differently inside the file. So there are some indirections through the index remappings.  Some of this remapping stuff was being repeated in two places so I did a DRY refactor into functions.

The result of this code is that the zarr loader won't always just select the worst resolution.
