### PR TITLE
imageMetadata

### DIFF
--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -124,6 +124,7 @@ interface VolumeDataObserver {
  */
 export default class Volume {
   public imageInfo: ImageInfo;
+  public imageMetadata: Record<string, unknown>;
   public name: string;
   public x: number;
   public y: number;
@@ -148,6 +149,8 @@ export default class Volume {
   /* eslint-enable @typescript-eslint/naming-convention */
 
   constructor(imageInfo: ImageInfo = getDefaultImageInfo()) {
+    // imageMetadata to be filled in by Volume Loaders
+    this.imageMetadata = {};
     this.scale = new Vector3(1, 1, 1);
     this.physicalSize = new Vector3(1, 1, 1);
     this.physicalScale = 1;

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -1,4 +1,5 @@
 import { IVolumeLoader, LoadSpec, PerChannelCallback, VolumeDims } from "./IVolumeLoader";
+import { buildDefaultMetadata } from "./VolumeLoaderUtils";
 import { ImageInfo } from "../Volume";
 import Volume from "../Volume";
 
@@ -42,7 +43,7 @@ class JsonImageInfoLoader implements IVolumeLoader {
     const imageInfo = await this.getImageInfo(loadSpec);
 
     const vol = new Volume(imageInfo);
-
+    vol.imageMetadata = buildDefaultMetadata(imageInfo);
     // if you need to adjust image paths prior to download,
     // now is the time to do it.
     // Try to figure out the urlPrefix from the LoadSpec.

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -1,5 +1,10 @@
 import { IVolumeLoader, LoadSpec, PerChannelCallback, VolumeDims } from "./IVolumeLoader";
-import { computePackedAtlasDims, estimateLevelForAtlas, spatialUnitNameToSymbol } from "./VolumeLoaderUtils";
+import {
+  buildDefaultMetadata,
+  computePackedAtlasDims,
+  estimateLevelForAtlas,
+  spatialUnitNameToSymbol,
+} from "./VolumeLoaderUtils";
 import { ImageInfo } from "../Volume";
 import Volume from "../Volume";
 
@@ -233,6 +238,7 @@ class OMEZarrLoader implements IVolumeLoader {
 
     // got some data, now let's construct the volume.
     const vol = new Volume(imgdata);
+    vol.imageMetadata = buildDefaultMetadata(imgdata);
 
     const storepath = imagegroup + "/" + dataset.path;
     // do each channel on a worker

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -1,4 +1,5 @@
 import { IVolumeLoader, LoadSpec, PerChannelCallback, VolumeDims } from "./IVolumeLoader";
+import { buildDefaultMetadata } from "./VolumeLoaderUtils";
 import { ImageInfo } from "../Volume";
 import Volume from "../Volume";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader";
@@ -63,6 +64,8 @@ class OpenCellLoader implements IVolumeLoader {
 
     // got some data, now let's construct the volume.
     const vol = new Volume(imgdata);
+    vol.imageMetadata = buildDefaultMetadata(imgdata);
+
     JsonImageInfoLoader.loadVolumeAtlasData(vol, urls, onChannelLoaded);
     return vol;
   }

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -1,5 +1,5 @@
 import { IVolumeLoader, LoadSpec, PerChannelCallback, VolumeDims } from "./IVolumeLoader";
-import { computePackedAtlasDims } from "./VolumeLoaderUtils";
+import { buildDefaultMetadata, computePackedAtlasDims } from "./VolumeLoaderUtils";
 import { ImageInfo } from "../Volume";
 import Volume from "../Volume";
 
@@ -139,6 +139,8 @@ class TiffLoader implements IVolumeLoader {
     /* eslint-enable @typescript-eslint/naming-convention */
 
     const vol = new Volume(imgdata);
+    vol.imageMetadata = buildDefaultMetadata(imgdata);
+
     // do each channel on a worker?
     for (let channel = 0; channel < dims.sizec; ++channel) {
       const params = {

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -1,5 +1,7 @@
 import "regenerator-runtime/runtime";
 
+import { ImageInfo } from "../Volume";
+
 export type TypedArray =
   | Uint8Array
   | Int8Array
@@ -75,4 +77,26 @@ export function estimateLevelForAtlas(spatialDimsZYX: number[][], maxAtlasEdge =
     }
   }
   return levelToLoad;
+}
+
+// currently everything needed can come from the imageInfo
+// but in the future each IVolumeLoader could have a completely separate implementation.
+export function buildDefaultMetadata(imageInfo: ImageInfo): Record<string, unknown> {
+  const metadata = {};
+  metadata["Dimensions"] = { x: imageInfo.tile_width, y: imageInfo.tile_height, z: imageInfo.tiles };
+  metadata["Original dimensions"] = { x: imageInfo.width, y: imageInfo.height, z: imageInfo.tiles };
+  metadata["Physical size"] = {
+    x: imageInfo.width * imageInfo.pixel_size_x + imageInfo.pixel_size_unit,
+    y: imageInfo.height * imageInfo.pixel_size_y + imageInfo.pixel_size_unit,
+    z: imageInfo.tiles * imageInfo.pixel_size_z + imageInfo.pixel_size_unit,
+  };
+  metadata["Physical size per pixel"] = {
+    x: imageInfo.pixel_size_x + imageInfo.pixel_size_unit,
+    y: imageInfo.pixel_size_y + imageInfo.pixel_size_unit,
+    z: imageInfo.pixel_size_z + imageInfo.pixel_size_unit,
+  };
+  metadata["Channels"] = imageInfo.channels;
+  metadata["Time series frames"] = imageInfo.times || 1;
+  metadata["User data"] = imageInfo.userData;
+  return metadata;
 }

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -79,6 +79,15 @@ export function estimateLevelForAtlas(spatialDimsZYX: number[][], maxAtlasEdge =
   return levelToLoad;
 }
 
+function isEmpty(obj) {
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // currently everything needed can come from the imageInfo
 // but in the future each IVolumeLoader could have a completely separate implementation.
 export function buildDefaultMetadata(imageInfo: ImageInfo): Record<string, unknown> {
@@ -97,6 +106,9 @@ export function buildDefaultMetadata(imageInfo: ImageInfo): Record<string, unkno
   };
   metadata["Channels"] = imageInfo.channels;
   metadata["Time series frames"] = imageInfo.times || 1;
-  metadata["User data"] = imageInfo.userData;
+  // don't add User data if it's empty
+  if (imageInfo.userData && !isEmpty(imageInfo.userData)) {
+    metadata["User data"] = imageInfo.userData;
+  }
   return metadata;
 }


### PR DESCRIPTION
Each Volume now gets a imageMetadata object.
The object is empty by default, and is intended to be populated by the IVolumeLoaders.
There is a simple utility function for now, which does the same thing for every volume.  But in the future now there is room for the VolumeLoaders to inject metadata that is available only in the file format they are loading (e.g. OME Metadata).

The intent here is that the website-3d-cell-viewer can now just pick up this `volume.imageMetadata` for its metadata display, and not need to consider what its contents are.

2 open questions: 
1. should I type this any differently than a generic Record<string, unknown> ?
2. do we need a code path to create an imageMetadata for volumes that do not get created by IVolumeLoaders?

