### PR TITLE
Fix/horizontal scale in orthographic modes breaks on resize

### DIFF
--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -31,7 +31,7 @@ import {
 import { LUT_ARRAY_LENGTH } from "./Histogram";
 import Volume from "./Volume";
 import { Bounds, isOrthographicCamera } from "./types";
-import { ThreeJsPanel } from "./ThreeJsPanel";
+import { DEFAULT_ORTHO_SCALE, ThreeJsPanel } from "./ThreeJsPanel";
 import VolumeDrawable from "./VolumeDrawable";
 import { Light } from "./Light";
 
@@ -422,7 +422,7 @@ export default class PathTracedVolume {
 
     // the choice of y = scale/aspect or x = scale*aspect is made here to match up with the other raymarch volume
     const fScale = isOrthographicCamera(cam)
-      ? canvas.orthoScale
+      ? DEFAULT_ORTHO_SCALE
       : Math.tan((0.5 * (cam as PerspectiveCamera).fov * Math.PI) / 180.0);
 
     const aspect = this.pathTracingUniforms.uResolution.value.x / this.pathTracingUniforms.uResolution.value.y;

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -31,7 +31,7 @@ import {
 import { LUT_ARRAY_LENGTH } from "./Histogram";
 import Volume from "./Volume";
 import { Bounds, isOrthographicCamera } from "./types";
-import { DEFAULT_ORTHO_SCALE, ThreeJsPanel } from "./ThreeJsPanel";
+import { ThreeJsPanel } from "./ThreeJsPanel";
 import VolumeDrawable from "./VolumeDrawable";
 import { Light } from "./Light";
 
@@ -422,7 +422,7 @@ export default class PathTracedVolume {
 
     // the choice of y = scale/aspect or x = scale*aspect is made here to match up with the other raymarch volume
     const fScale = isOrthographicCamera(cam)
-      ? DEFAULT_ORTHO_SCALE
+      ? canvas.getOrthoScale()
       : Math.tan((0.5 * (cam as PerspectiveCamera).fov * Math.PI) / 180.0);
 
     const aspect = this.pathTracingUniforms.uResolution.value.x / this.pathTracingUniforms.uResolution.value.y;

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -24,6 +24,8 @@ const DEFAULT_PERSPECTIVE_CAMERA_DISTANCE = 5.0;
 const DEFAULT_PERSPECTIVE_CAMERA_NEAR = 0.001;
 const DEFAULT_PERSPECTIVE_CAMERA_FAR = 20.0;
 
+export const DEFAULT_ORTHO_SCALE = 0.5;
+
 export class ThreeJsPanel {
   public containerdiv: HTMLDivElement;
   private canvas: HTMLCanvasElement;
@@ -35,7 +37,6 @@ export class ThreeJsPanel {
   public hasWebGL2: boolean;
   public renderer: WebGLRenderer;
   private timer: Timing;
-  public orthoScale: number;
   private fov: number;
   private perspectiveCamera: PerspectiveCamera;
   private perspectiveControls: TrackballControls;
@@ -138,8 +139,7 @@ export class ThreeJsPanel {
 
     this.timer = new Timing();
 
-    const scale = 0.5;
-    this.orthoScale = scale;
+    const scale = DEFAULT_ORTHO_SCALE;
     const aspect = this.getWidth() / this.getHeight();
 
     this.fov = 20;
@@ -333,7 +333,7 @@ export class ThreeJsPanel {
 
   orthoScreenPixelsToPhysicalUnits(pixels: number, physicalUnitsPerWorldUnit: number): number {
     // At orthoScale = 0.5, the viewport is 1 world unit tall
-    const worldUnitsPerPixel = (this.orthoScale * 2) / this.getHeight();
+    const worldUnitsPerPixel = (this.controls.scale * 2) / this.getHeight();
     // Multiply by devicePixelRatio to convert from scaled CSS pixels to physical pixels
     // (to account for high dpi monitors, e.g.). We didn't do this to height above because
     // that value comes from three, which works in physical pixels.
@@ -539,8 +539,8 @@ export class ThreeJsPanel {
     this.orthoControlsX.aspect = aspect;
     this.orthoControlsX.panSpeed = w * 0.5;
     if (isOrthographicCamera(this.camera)) {
-      this.camera.left = -this.orthoScale * aspect;
-      this.camera.right = this.orthoScale * aspect;
+      this.camera.left = -DEFAULT_ORTHO_SCALE * aspect;
+      this.camera.right = DEFAULT_ORTHO_SCALE * aspect;
       this.camera.updateProjectionMatrix();
     } else {
       this.camera.aspect = aspect;
@@ -581,8 +581,6 @@ export class ThreeJsPanel {
     // update the axis helper in case the view was rotated
     if (!isOrthographicCamera(this.camera)) {
       this.axisHelperObject.rotation.setFromRotationMatrix(this.camera.matrixWorldInverse);
-    } else {
-      this.orthoScale = this.controls.scale;
     }
 
     // do whatever we have to do before the main render of this.scene

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -24,7 +24,7 @@ const DEFAULT_PERSPECTIVE_CAMERA_DISTANCE = 5.0;
 const DEFAULT_PERSPECTIVE_CAMERA_NEAR = 0.001;
 const DEFAULT_PERSPECTIVE_CAMERA_FAR = 20.0;
 
-export const DEFAULT_ORTHO_SCALE = 0.5;
+const DEFAULT_ORTHO_SCALE = 0.5;
 
 export class ThreeJsPanel {
   public containerdiv: HTMLDivElement;
@@ -331,9 +331,13 @@ export class ThreeJsPanel {
     this.axisCamera.position.set(-this.axisOffset[0], -this.axisOffset[1], this.axisScale * 2.0);
   }
 
+  getOrthoScale(): number {
+    return this.controls.scale;
+  }
+
   orthoScreenPixelsToPhysicalUnits(pixels: number, physicalUnitsPerWorldUnit: number): number {
     // At orthoScale = 0.5, the viewport is 1 world unit tall
-    const worldUnitsPerPixel = (this.controls.scale * 2) / this.getHeight();
+    const worldUnitsPerPixel = (this.getOrthoScale() * 2) / this.getHeight();
     // Multiply by devicePixelRatio to convert from scaled CSS pixels to physical pixels
     // (to account for high dpi monitors, e.g.). We didn't do this to height above because
     // that value comes from three, which works in physical pixels.


### PR DESCRIPTION
Provides a fix for allen-cell-animated/website-3d-cell-viewer#122.

The problem had to do with resize handling code erroneously using the zoom level of the orthographic camera when updating aspect ratio. Switching to a 2d mode, zooming in or out, then triggering a resize (which in website-3d-cell-viewer also occurs on actions like toggling bounding box or interpolation) would thus set the camera to an incorrect aspect.

The zoom level appeared to have made it into that calculation due to confusion over whether the value (`ThreeJsPanel.orthoScale`) referred to the initial/"default" scale or the current scale. To clarify, I removed this property and replaced it with a constant (`ORTHO_SCALE`) where the former was expected and a getter (`getOrthoScale`) where the latter was expected.