### PR TITLE
Fix/tickmarks only appear in 3d mode

### DIFF
--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -42,6 +42,7 @@ export default class RayMarchedAtlasVolume {
   private uniforms: typeof rayMarchingShaderUniforms;
   private channelData: FusedChannelData;
   private scale: Vector3;
+  private isOrtho: boolean;
 
   constructor(volume: Volume) {
     // need?
@@ -54,6 +55,7 @@ export default class RayMarchedAtlasVolume {
       bmax: new Vector3(0.5, 0.5, 0.5),
     };
     this.scale = new Vector3(1.0, 1.0, 1.0);
+    this.isOrtho = false;
 
     this.cube = new BoxGeometry(1.0, 1.0, 1.0);
     this.cubeMesh = new Mesh(this.cube);
@@ -184,7 +186,7 @@ export default class RayMarchedAtlasVolume {
 
   public setShowBoundingBox(showBoundingBox: boolean): void {
     this.boxHelper.visible = showBoundingBox;
-    this.tickMarksMesh.visible = showBoundingBox;
+    this.tickMarksMesh.visible = showBoundingBox && !this.isOrtho;
   }
 
   public setBoundingBoxColor(color: [number, number, number]): void {
@@ -269,6 +271,8 @@ export default class RayMarchedAtlasVolume {
   }
 
   public setIsOrtho(isOrthoAxis: boolean): void {
+    this.isOrtho = isOrthoAxis;
+    this.tickMarksMesh.visible = this.boxHelper.visible && !isOrthoAxis;
     this.setUniform("isOrtho", isOrthoAxis ? 1.0 : 0.0);
     if (!isOrthoAxis) {
       this.setOrthoThickness(1.0);

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -87,7 +87,7 @@ export default class VolumeDrawable {
     this.channelOptions = new Array<VolumeChannelDisplayOptions>(this.volume.num_channels).fill({});
 
     this.fusion = this.channelColors.map((col, index) => {
-      let rgbColor;
+      let rgbColor: number | [number, number, number];
       // take copy of original channel color
       if (col[0] === 0 && col[1] === 0 && col[2] === 0) {
         rgbColor = 0;


### PR DESCRIPTION
Feedback from @TravisKroeker re: #79: tickmarks only appear on the bounding box in 3D view mode.