### PR TITLE
Feature/time series API first steps

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -1130,16 +1130,15 @@ function createLoader(type: string): IVolumeLoader {
   }
 }
 
-function loadVolume(loadSpec: LoadSpec, loader: IVolumeLoader, cacheTimeSeries) {
-  loader
-    .createVolume(loadSpec, (url, v, channelIndex) => {
-      onChannelDataArrived(url, v, channelIndex, cacheTimeSeries, loadSpec.time);
-    })
-    .then((volume: Volume) => {
-      onVolumeCreated(volume, cacheTimeSeries, loadSpec.time);
-      myState.currentImageStore = loadSpec.url;
-      myState.currentImageName = loadSpec.url;
-    });
+async function loadVolume(loadSpec: LoadSpec, loader: IVolumeLoader, cacheTimeSeries: boolean): Promise<void> {
+  const volume = await loader.createVolume(loadSpec);
+  onVolumeCreated(volume, cacheTimeSeries, loadSpec.time);
+  loader.loadVolumeData(volume, loadSpec, (url, v, channelIndex) => {
+    onChannelDataArrived(url, v, channelIndex, cacheTimeSeries, loadSpec.time);
+  });
+
+  myState.currentImageStore = loadSpec.url;
+  myState.currentImageName = loadSpec.url;
 }
 
 function loadTestData(testdata: TestDataSpec) {

--- a/public/index.ts
+++ b/public/index.ts
@@ -1133,7 +1133,7 @@ function createLoader(type: string): IVolumeLoader {
 async function loadVolume(loadSpec: LoadSpec, loader: IVolumeLoader, cacheTimeSeries: boolean): Promise<void> {
   const volume = await loader.createVolume(loadSpec);
   onVolumeCreated(volume, cacheTimeSeries, loadSpec.time);
-  loader.loadVolumeData(volume, loadSpec, (url, v, channelIndex) => {
+  loader.loadVolumeData(volume, (url, v, channelIndex) => {
     onChannelDataArrived(url, v, channelIndex, cacheTimeSeries, loadSpec.time);
   });
 

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -4,6 +4,7 @@ import { ThreeJsPanel } from "./ThreeJsPanel";
 import lightSettings from "./constants/lights";
 import VolumeDrawable from "./VolumeDrawable";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light";
+import { IVolumeLoader, PerChannelCallback } from "./loaders/IVolumeLoader";
 import Volume from "./Volume";
 import { VolumeChannelDisplayOptions, VolumeDisplayOptions, isOrthographicCamera, ViewportCorner } from "./types";
 
@@ -190,6 +191,11 @@ export class View3d {
   // do fixups for when the volume has had a new empty channel added.
   onVolumeChannelAdded(volume: Volume, newChannelIndex: number): void {
     this.image?.onChannelAdded(newChannelIndex);
+  }
+
+  setTime(volume: Volume, time: number, loader: IVolumeLoader, onChannelLoaded?: PerChannelCallback): void {
+    volume.loadSpec.time = Math.max(0, Math.min(volume.imageInfo.times, time));
+    loader.loadVolumeData(volume, onChannelLoaded);
   }
 
   /**

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -3,6 +3,7 @@ import { Vector3 } from "three";
 import Channel from "./Channel";
 import Histogram from "./Histogram";
 import { getColorByChannelIndex } from "./constants/colors";
+import { LoadSpec } from "./loaders/IVolumeLoader";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export interface ImageInfo {
@@ -124,6 +125,7 @@ interface VolumeDataObserver {
  */
 export default class Volume {
   public imageInfo: ImageInfo;
+  public loadSpec: LoadSpec;
   public imageMetadata: Record<string, unknown>;
   public name: string;
   public x: number;
@@ -148,7 +150,7 @@ export default class Volume {
   public pixel_size: [number, number, number];
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  constructor(imageInfo: ImageInfo = getDefaultImageInfo()) {
+  constructor(imageInfo: ImageInfo = getDefaultImageInfo(), loadSpec: LoadSpec = new LoadSpec()) {
     // imageMetadata to be filled in by Volume Loaders
     this.imageMetadata = {};
     this.scale = new Vector3(1, 1, 1);
@@ -159,6 +161,7 @@ export default class Volume {
     this.loaded = false;
     this.imageInfo = imageInfo;
     this.name = this.imageInfo.name;
+    this.loadSpec = loadSpec;
 
     // clean up some possibly bad data.
     this.imageInfo.pixel_size_x = imageInfo.pixel_size_x || 1.0;

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -42,7 +42,8 @@ export interface IVolumeLoader {
    */
   createVolume(loadSpec: LoadSpec): Promise<Volume>;
 
-  /** Begin loading a volume's data, as specified in its `LoadSpec`.
+  /**
+   * Begin loading a volume's data, as specified in its `LoadSpec`.
    * Pass a callback to respond whenever a new channel is loaded.
    */
   // TODO make this return a promise that resolves when loading is done?

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -39,5 +39,9 @@ export interface IVolumeLoader {
   // create a Volume from a LoadSpec; async data download will be initiated here
   // TODO this is not cancellable in the sense that any async requests initiated here are not stored
   // in a way that they can be interrupted.
-  createVolume(loadSpec: LoadSpec, onChannelLoaded: PerChannelCallback): Promise<Volume>;
+  createVolume(loadSpec: LoadSpec): Promise<Volume>;
+
+  // TODO document
+  // TODO make this return a promise that resolves when loading is done?
+  loadVolumeData(volume: Volume, loadSpec: LoadSpec, onChannelLoaded: PerChannelCallback): void;
 }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -33,15 +33,20 @@ export class VolumeDims {
 export type PerChannelCallback = (imageurl: string, volume: Volume, channelIndex: number) => void;
 
 export interface IVolumeLoader {
-  // use VolumeDims to further refine a LoadSpec for use in createVolume
+  /** Use VolumeDims to further refine a `LoadSpec` for use in `createVolume` */
   loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]>;
 
-  // create a Volume from a LoadSpec; async data download will be initiated here
-  // TODO this is not cancellable in the sense that any async requests initiated here are not stored
-  // in a way that they can be interrupted.
+  /**
+   * Create an empty `Volume` from a `LoadSpec`, which must be passed to `loadVolumeData` to begin loading.
+   * May cache some values for use on only the next call to `loadVolumeData`.
+   */
   createVolume(loadSpec: LoadSpec): Promise<Volume>;
 
-  // TODO document
+  /** Begin loading a volume's data, as specified in its `LoadSpec`.
+   * Pass a callback to respond whenever a new channel is loaded.
+   */
   // TODO make this return a promise that resolves when loading is done?
+  // TODO this is not cancellable in the sense that any async requests initiated here are not stored
+  // in a way that they can be interrupted.
   loadVolumeData(volume: Volume, onChannelLoaded?: PerChannelCallback): void;
 }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -43,5 +43,5 @@ export interface IVolumeLoader {
 
   // TODO document
   // TODO make this return a promise that resolves when loading is done?
-  loadVolumeData(volume: Volume, loadSpec: LoadSpec, onChannelLoaded: PerChannelCallback): void;
+  loadVolumeData(volume: Volume, onChannelLoaded: PerChannelCallback): void;
 }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -43,5 +43,5 @@ export interface IVolumeLoader {
 
   // TODO document
   // TODO make this return a promise that resolves when loading is done?
-  loadVolumeData(volume: Volume, onChannelLoaded: PerChannelCallback): void;
+  loadVolumeData(volume: Volume, onChannelLoaded?: PerChannelCallback): void;
 }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -32,13 +32,21 @@ export class VolumeDims {
  */
 export type PerChannelCallback = (imageurl: string, volume: Volume, channelIndex: number) => void;
 
+/**
+ * Loads volume data from a source specified by a `LoadSpec`.
+ *
+ * Loaders may keep state for reuse between volume creation and volume loading, and should be kept alive until volume
+ * loading is complete. (See `createVolume`)
+ */
 export interface IVolumeLoader {
   /** Use VolumeDims to further refine a `LoadSpec` for use in `createVolume` */
   loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]>;
 
   /**
    * Create an empty `Volume` from a `LoadSpec`, which must be passed to `loadVolumeData` to begin loading.
-   * May cache some values for use on only the next call to `loadVolumeData`.
+   *
+   * May cache some values for use on only the next call to `loadVolumeData`; callers should guarantee that the next
+   * call to this loader's `loadVolumeData` is made on the returned `Volume` before the volume's state is changed.
    */
   createVolume(loadSpec: LoadSpec): Promise<Volume>;
 

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -42,7 +42,7 @@ class JsonImageInfoLoader implements IVolumeLoader {
   async createVolume(loadSpec: LoadSpec): Promise<Volume> {
     const imageInfo = await this.getImageInfo(loadSpec);
 
-    const vol = new Volume(imageInfo);
+    const vol = new Volume(imageInfo, loadSpec);
     vol.imageMetadata = buildDefaultMetadata(imageInfo);
     return vol;
   }

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -47,13 +47,13 @@ class JsonImageInfoLoader implements IVolumeLoader {
     return vol;
   }
 
-  async loadVolumeData(vol: Volume, loadSpec: LoadSpec, onChannelLoaded: PerChannelCallback): Promise<void> {
+  async loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback): Promise<void> {
     // if you need to adjust image paths prior to download,
     // now is the time to do it.
     // Try to figure out the urlPrefix from the LoadSpec.
     // For this format we assume the image data is in the same directory as the json file.
     // This regex removes everything after the last slash, so the url had better be simple.
-    const urlPrefix = loadSpec.url.replace(/[^/]*$/, "");
+    const urlPrefix = vol.loadSpec.url.replace(/[^/]*$/, "");
     this.imageArray.forEach((element) => {
       element.name = urlPrefix + element.name;
     });

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -39,11 +39,15 @@ class JsonImageInfoLoader implements IVolumeLoader {
     return [d];
   }
 
-  async createVolume(loadSpec: LoadSpec, onChannelLoaded: PerChannelCallback): Promise<Volume> {
+  async createVolume(loadSpec: LoadSpec): Promise<Volume> {
     const imageInfo = await this.getImageInfo(loadSpec);
 
     const vol = new Volume(imageInfo);
     vol.imageMetadata = buildDefaultMetadata(imageInfo);
+    return vol;
+  }
+
+  async loadVolumeData(vol: Volume, loadSpec: LoadSpec, onChannelLoaded: PerChannelCallback): Promise<void> {
     // if you need to adjust image paths prior to download,
     // now is the time to do it.
     // Try to figure out the urlPrefix from the LoadSpec.
@@ -54,7 +58,6 @@ class JsonImageInfoLoader implements IVolumeLoader {
       element.name = urlPrefix + element.name;
     });
     JsonImageInfoLoader.loadVolumeAtlasData(vol, this.imageArray, onChannelLoaded);
-    return vol;
   }
 
   /**

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -311,7 +311,7 @@ class OMEZarrLoader implements IVolumeLoader {
     /* eslint-enable @typescript-eslint/naming-convention */
 
     // got some data, now let's construct the volume.
-    const vol = new Volume(imgdata);
+    const vol = new Volume(imgdata, loadSpec);
     vol.imageMetadata = buildDefaultMetadata(imgdata);
     return vol;
   }
@@ -334,7 +334,7 @@ class OMEZarrLoader implements IVolumeLoader {
       const spatialAxes = findSpatialAxesZYX(axisTCZYX);
 
       const levelToLoad = await pickLevelToLoad(multiscale, store, loadSpec, spatialAxes);
-      this.multiscalePath = multiscale.datasets[levelToLoad];
+      this.multiscalePath = multiscale.datasets[levelToLoad].path;
     }
 
     const storepath = loadSpec.subpath + "/" + this.multiscalePath;

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -316,7 +316,8 @@ class OMEZarrLoader implements IVolumeLoader {
     return vol;
   }
 
-  async loadVolumeData(vol: Volume, loadSpec: LoadSpec, onChannelLoaded: PerChannelCallback): Promise<void> {
+  async loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback): Promise<void> {
+    const { loadSpec } = vol;
     const { channels, times } = vol.imageInfo;
 
     if (this.multiscalePath === undefined || this.hasC === undefined || this.hasT === undefined) {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -198,7 +198,7 @@ class OMEZarrLoader implements IVolumeLoader {
 
     // Assume all axes have the same units - we have no means of storing per-axis unit symbols
     const unitName = axes[spatialAxes[2]].unit;
-    const unitSymbol = (unitName && spatialUnitNameToSymbol(unitName)) || unitName || "";
+    const unitSymbol = spatialUnitNameToSymbol(unitName) || unitName || "";
 
     const dimsPromises = multiscales.map(async (multiscale): Promise<VolumeDims> => {
       const shape = await fetchShapeOfLevel(store, imagegroup, multiscale);
@@ -247,7 +247,7 @@ class OMEZarrLoader implements IVolumeLoader {
 
     // Assume all axes have the same units - we have no means of storing per-axis unit symbols
     const unitName = axes[spatialAxes[2]].unit;
-    const unitSymbol = (unitName && spatialUnitNameToSymbol(unitName)) || unitName || "";
+    const unitSymbol = spatialUnitNameToSymbol(unitName) || unitName || "";
 
     const levelToLoad = await pickLevelToLoad(multiscale, store, loadSpec);
     const dataset = datasets[levelToLoad];

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -56,7 +56,7 @@ class OpenCellLoader implements IVolumeLoader {
     return vol;
   }
 
-  loadVolumeData(vol: Volume, _: LoadSpec, onChannelLoaded: PerChannelCallback): void {
+  loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback): void {
     // HQTILE or LQTILE
     // make a json metadata dict for the two channels:
     const urls = [

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -15,21 +15,9 @@ class OpenCellLoader implements IVolumeLoader {
     return [d];
   }
 
-  async createVolume(_: LoadSpec, onChannelLoaded: PerChannelCallback): Promise<Volume> {
+  async createVolume(_: LoadSpec): Promise<Volume> {
     const numChannels = 2;
 
-    // HQTILE or LQTILE
-    // make a json metadata dict for the two channels:
-    const urls = [
-      {
-        name: "https://opencell.czbiohub.org/data/opencell-microscopy/roi/czML0383-P0007/czML0383-P0007-A02-PML0308-S13_ROI-0424-0025-0600-0600-LQTILE-CH405.jpg",
-        channels: [0],
-      },
-      {
-        name: "https://opencell.czbiohub.org/data/opencell-microscopy/roi/czML0383-P0007/czML0383-P0007-A02-PML0308-S13_ROI-0424-0025-0600-0600-LQTILE-CH488.jpg",
-        channels: [1],
-      },
-    ];
     // we know these are standardized to 600x600, two channels, one channel per jpg.
     const chnames: string[] = ["DNA", "Structure"];
 
@@ -65,9 +53,24 @@ class OpenCellLoader implements IVolumeLoader {
     // got some data, now let's construct the volume.
     const vol = new Volume(imgdata);
     vol.imageMetadata = buildDefaultMetadata(imgdata);
+    return vol;
+  }
+
+  loadVolumeData(vol: Volume, _: LoadSpec, onChannelLoaded: PerChannelCallback): void {
+    // HQTILE or LQTILE
+    // make a json metadata dict for the two channels:
+    const urls = [
+      {
+        name: "https://opencell.czbiohub.org/data/opencell-microscopy/roi/czML0383-P0007/czML0383-P0007-A02-PML0308-S13_ROI-0424-0025-0600-0600-LQTILE-CH405.jpg",
+        channels: [0],
+      },
+      {
+        name: "https://opencell.czbiohub.org/data/opencell-microscopy/roi/czML0383-P0007/czML0383-P0007-A02-PML0308-S13_ROI-0424-0025-0600-0600-LQTILE-CH488.jpg",
+        channels: [1],
+      },
+    ];
 
     JsonImageInfoLoader.loadVolumeAtlasData(vol, urls, onChannelLoaded);
-    return vol;
   }
 }
 

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -155,10 +155,10 @@ class TiffLoader implements IVolumeLoader {
     return vol;
   }
 
-  async loadVolumeData(vol: Volume, loadSpec: LoadSpec, onChannelLoaded: PerChannelCallback): Promise<void> {
+  async loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback): Promise<void> {
     //
     if (this.bytesPerSample === undefined || this.dimensionOrder === undefined) {
-      const dims = await getDimsFromUrl(loadSpec.url);
+      const dims = await getDimsFromUrl(vol.loadSpec.url);
 
       this.dimensionOrder = dims.dimensionorder;
       this.bytesPerSample = getBytesPerSample(dims.pixeltype);
@@ -178,7 +178,7 @@ class TiffLoader implements IVolumeLoader {
         sizez: imageInfo.tiles,
         dimensionOrder: this.dimensionOrder,
         bytesPerSample: this.bytesPerSample,
-        url: loadSpec.url,
+        url: vol.loadSpec.url,
       };
       const worker = new Worker(new URL("../workers/FetchTiffWorker", import.meta.url));
       worker.onmessage = function (e) {
@@ -187,7 +187,7 @@ class TiffLoader implements IVolumeLoader {
         vol.setChannelDataFromVolume(channel, u8);
         if (onChannelLoaded) {
           // make up a unique name? or have caller pass this in?
-          onChannelLoaded(loadSpec.url, vol, channel);
+          onChannelLoaded(vol.loadSpec.url, vol, channel);
         }
         worker.terminate();
       };

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -59,7 +59,26 @@ function getOMEDims(imageEl: Element): OMEDims {
   return dims;
 }
 
+async function getDimsFromUrl(url: string): Promise<OMEDims> {
+  const tiff = await fromUrl(url);
+  // DO NOT DO THIS, ITS SLOW
+  // const imagecount = await tiff.getImageCount();
+  // read the FIRST image
+  const image = await tiff.getImage();
+
+  const tiffimgdesc = prepareXML(image.getFileDirectory().ImageDescription);
+  const omeEl = getOME(tiffimgdesc);
+
+  const image0El = omeEl.getElementsByTagName("Image")[0];
+  return getOMEDims(image0El);
+}
+
+const getBytesPerSample = (type: string): number => (type === "uint8" ? 1 : type === "uint16" ? 2 : 4);
+
 class TiffLoader implements IVolumeLoader {
+  dimensionOrder?: string;
+  bytesPerSample?: number;
+
   async loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]> {
     const tiff = await fromUrl(loadSpec.url);
     // DO NOT DO THIS, ITS SLOW
@@ -82,19 +101,8 @@ class TiffLoader implements IVolumeLoader {
     return [d];
   }
 
-  async createVolume(loadSpec: LoadSpec, onChannelLoaded: PerChannelCallback): Promise<Volume> {
-    const tiff = await fromUrl(loadSpec.url);
-    // DO NOT DO THIS, ITS SLOW
-    // const imagecount = await tiff.getImageCount();
-    // read the FIRST image
-    const image = await tiff.getImage();
-
-    const tiffimgdesc = prepareXML(image.getFileDirectory().ImageDescription);
-    const omeEl = getOME(tiffimgdesc);
-
-    const image0El = omeEl.getElementsByTagName("Image")[0];
-    const dims = getOMEDims(image0El);
-
+  async createVolume(loadSpec: LoadSpec): Promise<Volume> {
+    const dims = await getDimsFromUrl(loadSpec.url);
     // compare with sizex, sizey
     //const width = image.getWidth();
     //const height = image.getHeight();
@@ -141,18 +149,35 @@ class TiffLoader implements IVolumeLoader {
     const vol = new Volume(imgdata);
     vol.imageMetadata = buildDefaultMetadata(imgdata);
 
+    this.dimensionOrder = dims.dimensionorder;
+    this.bytesPerSample = getBytesPerSample(dims.pixeltype);
+
+    return vol;
+  }
+
+  async loadVolumeData(vol: Volume, loadSpec: LoadSpec, onChannelLoaded: PerChannelCallback): Promise<void> {
+    //
+    if (this.bytesPerSample === undefined || this.dimensionOrder === undefined) {
+      const dims = await getDimsFromUrl(loadSpec.url);
+
+      this.dimensionOrder = dims.dimensionorder;
+      this.bytesPerSample = getBytesPerSample(dims.pixeltype);
+    }
+
+    const imageInfo = vol.imageInfo;
+
     // do each channel on a worker?
-    for (let channel = 0; channel < dims.sizec; ++channel) {
+    for (let channel = 0; channel < imageInfo.channels; ++channel) {
       const params = {
         channel: channel,
         // these are target xy sizes for the in-memory volume data
         // they may or may not be the same size as original xy sizes
-        tilesizex: tilesizex,
-        tilesizey: tilesizey,
-        sizec: dims.sizec,
-        sizez: dims.sizez,
-        dimensionOrder: dims.dimensionorder,
-        bytesPerSample: dims.pixeltype === "uint8" ? 1 : dims.pixeltype === "uint16" ? 2 : 4,
+        tilesizex: imageInfo.tile_width,
+        tilesizey: imageInfo.tile_height,
+        sizec: imageInfo.channels,
+        sizez: imageInfo.tiles,
+        dimensionOrder: this.dimensionOrder,
+        bytesPerSample: this.bytesPerSample,
         url: loadSpec.url,
       };
       const worker = new Worker(new URL("../workers/FetchTiffWorker", import.meta.url));
@@ -171,7 +196,9 @@ class TiffLoader implements IVolumeLoader {
       };
       worker.postMessage(params);
     }
-    return vol;
+
+    this.dimensionOrder = undefined;
+    this.bytesPerSample = undefined;
   }
 }
 

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -146,7 +146,7 @@ class TiffLoader implements IVolumeLoader {
     };
     /* eslint-enable @typescript-eslint/naming-convention */
 
-    const vol = new Volume(imgdata);
+    const vol = new Volume(imgdata, loadSpec);
     vol.imageMetadata = buildDefaultMetadata(imgdata);
 
     this.dimensionOrder = dims.dimensionorder;

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -14,7 +14,11 @@ export type TypedArray =
 
 // Preferred spatial units in OME-Zarr are specified as full names. We want just the symbol.
 // See https://ngff.openmicroscopy.org/latest/#axes-md
-export function spatialUnitNameToSymbol(unitName: string): string | null {
+export function spatialUnitNameToSymbol(unitName?: string): string | null {
+  if (unitName === undefined) {
+    return null;
+  }
+
   const unitSymbols = {
     angstrom: "Å",
     decameter: "dam",
@@ -42,7 +46,7 @@ export function spatialUnitNameToSymbol(unitName: string): string | null {
 
 // We want to find the most "square" packing of z tw by th tiles.
 // Compute number of rows and columns.
-export function computePackedAtlasDims(z, tw, th): { nrows: number; ncols: number } {
+export function computePackedAtlasDims(z: number, tw: number, th: number): { nrows: number; ncols: number } {
   let nextrows = 1;
   let nextcols = z;
   let ratio = (nextcols * tw) / (nextrows * th);


### PR DESCRIPTION
Implements the minimal first API changes described in the thread for #93:

- splits `IVolumeLoader.createVolume` into two methods: `createVolume` to initialize a `Volume` object, and `loadVolumeData` to load data into it
- `Volume` objects now own a `LoadSpec`, which `createVolume` sets and `loadVolumeData` uses
- Added `View3d.setTime`, which takes a `Volume`, an `IVolumeLoader`, and a `PerChannelCallback`. Note that, like `loadVolumeData`, `setTime` relies on the caller to trigger the propagation of channel data into the viewer in the per-channel callback.

`OMEZarrLoader` was the thorniest challenge when disentangling `Volume` creation with volume data loading, so the most intensive changes are in there. I also found it helpful to encode the OME-Zarr metadata spec in types to understand what was going on, so that file is now rigorously typed. Finally, while I was there I found a couple instances of an `await` statement within a for-loop which could be lifted out of the loop to allow promises to resolve concurrently, so I did that (and confirmed with `console.time` that it was worth doing).

Note also that I allowed `OMEZarrLoader` and `TiffLoader` to cache certain trivial and expensive but necessary values in `createVolume` to be used and deleted in the next call to `loadVolumeData`. This may introduce too much of a risk of unexpected behavior to keep around, or perhaps `createVolume` ought to just call `loadVolumeData` itself.