### PR TITLE
Feature/read time unit

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -1098,6 +1098,8 @@ function createTestVolume() {
     pixel_size_unit: "",
     transform: { translation: [0, 0, 0], rotation: [0, 0, 0] },
     times: 1,
+    time_scale: 1,
+    time_unit: "",
   };
   /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -30,6 +30,8 @@ export interface ImageInfo {
     rotation: [number, number, number];
   };
   times: number;
+  time_scale: number;
+  time_unit: string;
   userData?: Record<string, unknown>;
 }
 
@@ -58,6 +60,8 @@ export const getDefaultImageInfo = (): ImageInfo => {
       rotation: [0, 0, 0],
     },
     times: 1,
+    time_scale: 1,
+    time_unit: "",
   };
 };
 

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -246,8 +246,11 @@ class OMEZarrLoader implements IVolumeLoader {
     const spatialAxes = findSpatialAxesZYX(axisTCZYX);
 
     // Assume all axes have the same units - we have no means of storing per-axis unit symbols
-    const unitName = axes[spatialAxes[2]].unit;
-    const unitSymbol = unitNameToSymbol(unitName) || unitName || "";
+    const spaceUnitName = axes[spatialAxes[2]].unit;
+    const spaceUnitSymbol = unitNameToSymbol(spaceUnitName) || spaceUnitName || "";
+
+    const timeUnitName = this.hasT ? axes[axisTCZYX[0]].unit : undefined;
+    const timeUnitSymbol = unitNameToSymbol(timeUnitName) || timeUnitName || "";
 
     const levelToLoad = await pickLevelToLoad(multiscale, store, loadSpec);
     const dataset = datasets[levelToLoad];
@@ -265,6 +268,7 @@ class OMEZarrLoader implements IVolumeLoader {
     const sizeT = this.hasT ? multiscaleShape[axisTCZYX[0]] : 1;
 
     const scale5d = getScale(dataset);
+    const timeScale = this.hasT ? scale5d[axisTCZYX[0]] : 1;
     const tw = multiscaleShape[spatialAxes[2]];
     const th = multiscaleShape[spatialAxes[1]];
     const tz = multiscaleShape[spatialAxes[0]];
@@ -299,7 +303,7 @@ class OMEZarrLoader implements IVolumeLoader {
       pixel_size_x: scale5d[spatialAxes[2]],
       pixel_size_y: scale5d[spatialAxes[1]],
       pixel_size_z: scale5d[spatialAxes[0]] * DOWNSAMPLE_Z,
-      pixel_size_unit: unitSymbol,
+      pixel_size_unit: spaceUnitSymbol,
       name: displayMetadata.name,
       version: displayMetadata.version,
       transform: {
@@ -307,6 +311,8 @@ class OMEZarrLoader implements IVolumeLoader {
         rotation: [0, 0, 0],
       },
       times: sizeT,
+      time_scale: timeScale,
+      time_unit: timeUnitSymbol,
     };
     /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -3,7 +3,7 @@ import {
   buildDefaultMetadata,
   computePackedAtlasDims,
   estimateLevelForAtlas,
-  spatialUnitNameToSymbol,
+  unitNameToSymbol,
 } from "./VolumeLoaderUtils";
 import { ImageInfo } from "../Volume";
 import Volume from "../Volume";
@@ -198,7 +198,7 @@ class OMEZarrLoader implements IVolumeLoader {
 
     // Assume all axes have the same units - we have no means of storing per-axis unit symbols
     const unitName = axes[spatialAxes[2]].unit;
-    const unitSymbol = spatialUnitNameToSymbol(unitName) || unitName || "";
+    const unitSymbol = unitNameToSymbol(unitName) || unitName || "";
 
     const dimsPromises = multiscales.map(async (multiscale): Promise<VolumeDims> => {
       const shape = await fetchShapeOfLevel(store, imagegroup, multiscale);
@@ -247,7 +247,7 @@ class OMEZarrLoader implements IVolumeLoader {
 
     // Assume all axes have the same units - we have no means of storing per-axis unit symbols
     const unitName = axes[spatialAxes[2]].unit;
-    const unitSymbol = spatialUnitNameToSymbol(unitName) || unitName || "";
+    const unitSymbol = unitNameToSymbol(unitName) || unitName || "";
 
     const levelToLoad = await pickLevelToLoad(multiscale, store, loadSpec);
     const dataset = datasets[levelToLoad];

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -47,6 +47,8 @@ class OpenCellLoader implements IVolumeLoader {
         rotation: [0, 0, 0],
       },
       times: 1,
+      time_scale: 1,
+      time_unit: "",
     };
     /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -143,6 +143,8 @@ class TiffLoader implements IVolumeLoader {
         rotation: [0, 0, 0],
       },
       times: dims.sizet,
+      time_scale: 1,
+      time_unit: "",
     };
     /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -12,41 +12,54 @@ export type TypedArray =
   | Float32Array
   | Float64Array;
 
-// Preferred units in OME-Zarr are specified as full names. We want just the symbol.
-// See https://ngff.openmicroscopy.org/latest/#axes-md
+// Map from units to their symbols
+const UNIT_SYMBOLS = {
+  angstrom: "Å",
+  day: "d",
+  foot: "ft",
+  hour: "h",
+  inch: "in",
+  meter: "m",
+  mile: "mi",
+  minute: "min",
+  parsec: "pc",
+  second: "s",
+  yard: "yd",
+};
+
+// Units which may take SI prefixes (e.g. micro-, tera-)
+const SI_UNITS: (keyof typeof UNIT_SYMBOLS)[] = ["meter", "second"];
+
+// SI prefixes which abbreviate in nonstandard ways
+const SI_PREFIX_ABBVS = {
+  micro: "μ",
+  deca: "da",
+};
+
+/** Converts a full spatial or temporal unit name supported by OME-Zarr to its unit symbol */
+// (see https://ngff.openmicroscopy.org/latest/#axes-md)
 export function unitNameToSymbol(unitName?: string): string | null {
   if (unitName === undefined) {
     return null;
   }
 
-  const unitSymbols = {
-    angstrom: "Å",
-    day: "d",
-    decameter: "dam",
-    decasecond: "das",
-    foot: "ft",
-    hour: "h",
-    inch: "in",
-    meter: "m",
-    micrometer: "μm",
-    microsecond: "μs",
-    mile: "mi",
-    minute: "min",
-    parsec: "pc",
-    second: "s",
-    yard: "yd",
-  };
-  if (unitSymbols[unitName]) {
-    return unitSymbols[unitName];
+  if (UNIT_SYMBOLS[unitName]) {
+    return UNIT_SYMBOLS[unitName];
   }
 
-  const siUnits: (keyof typeof unitSymbols)[] = ["meter", "second"];
-  const prefixedSIUnit = siUnits.find((siUnit) => unitName.endsWith(siUnit));
+  const prefixedSIUnit = SI_UNITS.find((siUnit) => unitName.endsWith(siUnit));
   if (prefixedSIUnit) {
-    // SI prefixes not in unitSymbols are abbreviated by first letter, capitalized if prefix ends with "a"
-    const capitalize = unitName[unitName.length - 1 - prefixedSIUnit.length] === "a";
-    const prefix = capitalize ? unitName[0].toUpperCase() : unitName[0];
-    return prefix + unitSymbols[prefixedSIUnit];
+    const prefix = unitName.substring(0, unitName.length - prefixedSIUnit.length);
+
+    if (SI_PREFIX_ABBVS[prefix]) {
+      // "special" SI prefix
+      return SI_PREFIX_ABBVS[prefix] + UNIT_SYMBOLS[prefixedSIUnit];
+    }
+
+    // almost all SI prefixes are abbreviated by first letter, capitalized if prefix ends with "a"
+    const capitalize = prefix.endsWith("a");
+    const prefixAbbr = capitalize ? prefix[0].toUpperCase() : prefix[0];
+    return prefixAbbr + UNIT_SYMBOLS[prefixedSIUnit];
   }
 
   return null;

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -12,33 +12,41 @@ export type TypedArray =
   | Float32Array
   | Float64Array;
 
-// Preferred spatial units in OME-Zarr are specified as full names. We want just the symbol.
+// Preferred units in OME-Zarr are specified as full names. We want just the symbol.
 // See https://ngff.openmicroscopy.org/latest/#axes-md
-export function spatialUnitNameToSymbol(unitName?: string): string | null {
+export function unitNameToSymbol(unitName?: string): string | null {
   if (unitName === undefined) {
     return null;
   }
 
   const unitSymbols = {
     angstrom: "Å",
+    day: "d",
     decameter: "dam",
+    decasecond: "das",
     foot: "ft",
+    hour: "h",
     inch: "in",
     meter: "m",
     micrometer: "μm",
+    microsecond: "μs",
     mile: "mi",
+    minute: "min",
     parsec: "pc",
+    second: "s",
     yard: "yd",
   };
   if (unitSymbols[unitName]) {
     return unitSymbols[unitName];
   }
 
-  // SI prefixes not in unitSymbols are abbreviated by first letter, capitalized if prefix ends with "a"
-  if (unitName.endsWith("meter")) {
-    const capitalize = unitName[unitName.length - 6] === "a";
+  const siUnits: (keyof typeof unitSymbols)[] = ["meter", "second"];
+  const prefixedSIUnit = siUnits.find((siUnit) => unitName.endsWith(siUnit));
+  if (prefixedSIUnit) {
+    // SI prefixes not in unitSymbols are abbreviated by first letter, capitalized if prefix ends with "a"
+    const capitalize = unitName[unitName.length - 1 - prefixedSIUnit.length] === "a";
     const prefix = capitalize ? unitName[0].toUpperCase() : unitName[0];
-    return prefix + "m";
+    return prefix + unitSymbols[prefixedSIUnit];
   }
 
   return null;


### PR DESCRIPTION
### Problem

website-3d-cell-viewer time series designs show a time step indicator next to the scale bar. To display this we need to know the scale and units of the volume's time dimension.

### Solution

- Add fields to `ImageInfo`: `time_scale`, `time_unit`.
- Get `OMEZarrLoader` to populate them where available.
- Generalize `spatialUnitNameToSymbol` to handle converting time units to symbols too (as `unitNameToSymbol`).