### PR TITLE
Feature/time indicator

### DIFF
--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -64,6 +64,9 @@ export class ThreeJsPanel {
   public showOrthoScaleBar: boolean;
   private perspectiveScaleBarElement: HTMLDivElement;
   public showPerspectiveScaleBar: boolean;
+  private timestepIndicatorElement: HTMLDivElement;
+  // TODO come back to see if this remains marked unused. if so, delete; if not, mark public
+  private showTimestepIndicator: boolean;
 
   private dataurlcallback?: (url: string) => void;
 
@@ -88,6 +91,8 @@ export class ThreeJsPanel {
     this.showOrthoScaleBar = true;
     this.perspectiveScaleBarElement = document.createElement("div");
     this.showPerspectiveScaleBar = false;
+    this.timestepIndicatorElement = document.createElement("div");
+    this.showTimestepIndicator = false;
 
     this.zooming = false;
     this.animateFuncs = [];
@@ -206,7 +211,7 @@ export class ThreeJsPanel {
     this.axisOffset = [66.0, 66.0];
 
     this.setupAxisHelper();
-    this.setupScaleBarElements();
+    this.setupIndicatorElements();
   }
 
   updateCameraFocus(fov: number, _focalDistance: number, _apertureSize: number): void {
@@ -344,7 +349,7 @@ export class ThreeJsPanel {
     return pixels * window.devicePixelRatio * worldUnitsPerPixel * physicalUnitsPerWorldUnit;
   }
 
-  setupScaleBarElements(): void {
+  setupIndicatorElements(): void {
     const scaleBarContainerStyle: Partial<CSSStyleDeclaration> = {
       fontFamily: "-apple-system, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif",
       position: "absolute",
@@ -362,9 +367,9 @@ export class ThreeJsPanel {
       display: "none",
       color: "white",
       mixBlendMode: "difference",
+      fontSize: "14px",
       textAlign: "right",
       lineHeight: "0px",
-      fontSize: "14px",
       boxSizing: "border-box",
       paddingRight: "10px",
     };
@@ -387,6 +392,19 @@ export class ThreeJsPanel {
     svgdiv.innerHTML = scaleBarSVG;
     this.perspectiveScaleBarElement.appendChild(labeldiv);
     this.perspectiveScaleBarElement.appendChild(svgdiv);
+
+    // Time step indicator
+    const timestepIndicatorStyle: Partial<CSSStyleDeclaration> = {
+      fontFamily: "-apple-system, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+      position: "absolute",
+      right: "200px",
+      bottom: "20px",
+      color: "white",
+      mixBlendMode: "difference",
+      display: "none",
+    };
+    Object.assign(this.timestepIndicatorElement.style, timestepIndicatorStyle);
+    this.containerdiv.appendChild(this.timestepIndicatorElement);
   }
 
   updateOrthoScaleBar(scale: number, unit?: string): void {
@@ -410,6 +428,10 @@ export class ThreeJsPanel {
   updatePerspectiveScaleBar(length: number, unit?: string): void {
     const labeldiv = this.perspectiveScaleBarElement.firstChild as HTMLDivElement;
     labeldiv.innerHTML = `${length}${unit || ""}`;
+  }
+
+  updateTimestepIndicator(progress: number, total: number, unit: string): void {
+    this.timestepIndicatorElement.innerHTML = `${progress} / ${total} ${unit}`;
   }
 
   setPerspectiveScaleBarColor(color: [number, number, number]): void {
@@ -436,8 +458,13 @@ export class ThreeJsPanel {
     this.updateScaleBarVisibility();
   }
 
-  setScaleBarPosition(marginX: number, marginY: number, corner: ViewportCorner) {
-    const { style } = this.scaleBarContainerElement;
+  setShowTimestepIndicator(visible: boolean): void {
+    this.showTimestepIndicator = visible;
+    this.timestepIndicatorElement.style.display = visible ? "" : "none";
+  }
+
+  setIndicatorPosition(timestep: boolean, marginX: number, marginY: number, corner: ViewportCorner) {
+    const { style } = timestep ? this.timestepIndicatorElement : this.scaleBarContainerElement;
 
     style.removeProperty("top");
     style.removeProperty("bottom");

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -369,7 +369,7 @@ export class ThreeJsPanel {
       mixBlendMode: "difference",
       fontSize: "14px",
       textAlign: "right",
-      lineHeight: "0px",
+      lineHeight: "0",
       boxSizing: "border-box",
       paddingRight: "10px",
     };
@@ -397,11 +397,12 @@ export class ThreeJsPanel {
     const timestepIndicatorStyle: Partial<CSSStyleDeclaration> = {
       fontFamily: "-apple-system, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif",
       position: "absolute",
-      right: "200px",
+      right: "20px",
       bottom: "20px",
       color: "white",
       mixBlendMode: "difference",
       display: "none",
+      lineHeight: "0.75",
     };
     Object.assign(this.timestepIndicatorElement.style, timestepIndicatorStyle);
     this.containerdiv.appendChild(this.timestepIndicatorElement);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -358,8 +358,6 @@ export class View3d {
 
     this.updatePerspectiveScaleBar(img.volume);
     this.updateTimestepIndicator(img.volume);
-    // TODO remove
-    this.setShowTimestepIndicator(img.volume.imageInfo.times > 1);
 
     // redraw if not already in draw loop
     this.redraw();

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -91,9 +91,10 @@ export class View3d {
   }
 
   private updateTimestepIndicator(volume: Volume): void {
-    const { times, time_scale, time_unit } = volume.imageInfo;
+    // convert names to camel case keep eslint happy
+    const { times, time_scale: timeScale, time_unit: timeUnit } = volume.imageInfo;
     const currentTime = volume.loadSpec.time;
-    this.canvas3d.updateTimestepIndicator(currentTime * time_scale, times * time_scale, time_unit);
+    this.canvas3d.updateTimestepIndicator(currentTime * timeScale, times * timeScale, timeUnit);
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -91,7 +91,7 @@ export class View3d {
   }
 
   private updateTimestepIndicator(volume: Volume): void {
-    // convert names to camel case keep eslint happy
+    // convert names to camel case to keep eslint happy
     const { times, time_scale: timeScale, time_unit: timeUnit } = volume.imageInfo;
     const currentTime = volume.loadSpec.time;
     this.canvas3d.updateTimestepIndicator(currentTime * timeScale, times * timeScale, timeUnit);

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,5 @@ export const enum ViewportCorner {
   BOTTOM_LEFT = "bottom_left",
   BOTTOM_RIGHT = "bottom_right",
 }
-export const isTop = (corner: ViewportCorner): boolean =>
-  corner === ViewportCorner.TOP_LEFT || corner === ViewportCorner.TOP_RIGHT;
-export const isRight = (corner: ViewportCorner): boolean =>
-  corner === ViewportCorner.TOP_RIGHT || corner === ViewportCorner.BOTTOM_RIGHT;
+export const isTop = (corner: ViewportCorner): boolean => corner.toLowerCase().startsWith("top");
+export const isRight = (corner: ViewportCorner): boolean => corner.toLowerCase().endsWith("right");

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,5 +87,7 @@ export const enum ViewportCorner {
   BOTTOM_LEFT = "bottom_left",
   BOTTOM_RIGHT = "bottom_right",
 }
-export const isTop = (corner: ViewportCorner): boolean => corner.toLowerCase().startsWith("top");
-export const isRight = (corner: ViewportCorner): boolean => corner.toLowerCase().endsWith("right");
+export const isTop = (corner: ViewportCorner): boolean =>
+  corner === ViewportCorner.TOP_LEFT || corner === ViewportCorner.TOP_RIGHT;
+export const isRight = (corner: ViewportCorner): boolean =>
+  corner === ViewportCorner.TOP_RIGHT || corner === ViewportCorner.BOTTOM_RIGHT;


### PR DESCRIPTION
Adds a time step indicator as appears in [time series designs](https://www.figma.com/file/TGor606RxgS2L8uVcHAEEb/Time-series?type=design&node-id=102-2315&t=iXjtlTWUgM8ao9GY-0). The indicator works like other existing indicators (2d and 3d scale bars, axes) and has a similar API: `setShowTimestepIndicator`, `setTimestepIndicatorPosition`.

### Screenshot
(from website-3d-cell-viewer)
![image](https://github.com/allen-cell-animated/volume-viewer/assets/53030214/d94b7417-3533-44a9-922e-09ff4a75b646)
