### PR TITLE
Feature/load single slice

### DIFF
--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -61,5 +61,5 @@ export interface IVolumeLoader {
   // TODO make this return a promise that resolves when loading is done?
   // TODO this is not cancellable in the sense that any async requests initiated here are not stored
   // in a way that they can be interrupted.
-  loadVolumeData(volume: Volume, onChannelLoaded?: PerChannelCallback): void;
+  loadVolumeData(volume: Volume, onChannelLoaded?: PerChannelCallback, loadSpec?: LoadSpec): void;
 }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -6,12 +6,12 @@ export class LoadSpec {
   scene = 0;
   time = 0;
   // sub-region; if not specified, the entire volume is loaded
-  minx: number | null = null;
-  miny: number | null = null;
-  minz: number | null = null;
-  maxx: number | null = null;
-  maxy: number | null = null;
-  maxz: number | null = null;
+  minx?: number;
+  miny?: number;
+  minz?: number;
+  maxx?: number;
+  maxy?: number;
+  maxz?: number;
 
   toString(): string {
     return `${this.url}:${this.subpath}${this.scene}:${this.time}:x(${this.minx},${this.maxx}):y(${this.miny},${this.maxy}):z(${this.minz},${this.maxz})`;

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -6,12 +6,12 @@ export class LoadSpec {
   scene = 0;
   time = 0;
   // sub-region; if not specified, the entire volume is loaded
-  minx = 0;
-  miny = 0;
-  minz = 0;
-  maxx = 0;
-  maxy = 0;
-  maxz = 0;
+  minx: number | null = null;
+  miny: number | null = null;
+  minz: number | null = null;
+  maxx: number | null = null;
+  maxy: number | null = null;
+  maxz: number | null = null;
 
   toString(): string {
     return `${this.url}:${this.subpath}${this.scene}:${this.time}:x(${this.minx},${this.maxx}):y(${this.miny},${this.maxy}):z(${this.minz},${this.maxz})`;

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -47,13 +47,14 @@ class JsonImageInfoLoader implements IVolumeLoader {
     return vol;
   }
 
-  async loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback): Promise<void> {
+  async loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback, explicitLoadSpec?: LoadSpec): Promise<void> {
+    const loadSpec = explicitLoadSpec || vol.loadSpec;
     // if you need to adjust image paths prior to download,
     // now is the time to do it.
     // Try to figure out the urlPrefix from the LoadSpec.
     // For this format we assume the image data is in the same directory as the json file.
     // This regex removes everything after the last slash, so the url had better be simple.
-    const urlPrefix = vol.loadSpec.url.replace(/[^/]*$/, "");
+    const urlPrefix = loadSpec.url.replace(/[^/]*$/, "");
     this.imageArray.forEach((element) => {
       element.name = urlPrefix + element.name;
     });

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -49,8 +49,6 @@ type OMEMultiscale = {
   metadata?: Record<string, unknown>;
 };
 
-const DOWNSAMPLE_Z = 1; // z/downsampleZ is number of z slices in reduced volume
-
 function getScale({ coordinateTransformations }: OMEDataset | OMEMultiscale): number[] {
   if (coordinateTransformations === undefined) {
     console.log("ERROR: no coordinate transformations for scale level");
@@ -276,8 +274,7 @@ class OMEZarrLoader implements IVolumeLoader {
     const tz = multiscaleShape[spatialAxes[0]];
 
     // compute rows and cols and atlas width and ht, given tw and th
-    const loadedZ = Math.ceil(tz / DOWNSAMPLE_Z);
-    const { nrows, ncols } = computePackedAtlasDims(loadedZ, tw, th);
+    const { nrows, ncols } = computePackedAtlasDims(tz, tw, th);
     const atlaswidth = ncols * tw;
     const atlasheight = nrows * th;
     console.log("atlas width and height: " + atlaswidth + " " + atlasheight);
@@ -299,7 +296,7 @@ class OMEZarrLoader implements IVolumeLoader {
       channel_names: chnames,
       rows: nrows,
       cols: ncols,
-      tiles: loadedZ, // TODO original z????
+      tiles: tz,
       tile_width: tw,
       tile_height: th,
       // for webgl reasons, it is best for atlas_width and atlas_height to be <= 2048
@@ -308,7 +305,7 @@ class OMEZarrLoader implements IVolumeLoader {
       atlas_height: atlasheight,
       pixel_size_x: scale5d[spatialAxes[2]],
       pixel_size_y: scale5d[spatialAxes[1]],
-      pixel_size_z: scale5d[spatialAxes[0]] * DOWNSAMPLE_Z,
+      pixel_size_z: scale5d[spatialAxes[0]],
       pixel_size_unit: spaceUnitSymbol,
       name: displayMetadata.name,
       version: displayMetadata.version,
@@ -372,7 +369,6 @@ class OMEZarrLoader implements IVolumeLoader {
           time: this.hasT ? Math.min(loadSpec.time, times) : -1,
         },
         channel: this.hasC ? i : -1,
-        downsampleZ: DOWNSAMPLE_Z,
         path: storepath,
       });
     }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -328,8 +328,8 @@ class OMEZarrLoader implements IVolumeLoader {
     return vol;
   }
 
-  async loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback): Promise<void> {
-    const { loadSpec } = vol;
+  async loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback, explicitLoadSpec?: LoadSpec): Promise<void> {
+    const loadSpec = explicitLoadSpec || vol.loadSpec;
     const { channels, times } = vol.imageInfo;
 
     if (this.multiscalePath === undefined || this.hasC === undefined || this.hasT === undefined) {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -353,7 +353,7 @@ class OMEZarrLoader implements IVolumeLoader {
     // do each channel on a worker
     for (let i = 0; i < channels; ++i) {
       const worker = new Worker(new URL("../workers/FetchZarrWorker", import.meta.url));
-      worker.onmessage = function (e) {
+      worker.onmessage = (e) => {
         const u8 = e.data.data;
         const channel = e.data.channel;
         vol.setChannelDataFromVolume(channel, u8);
@@ -363,12 +363,14 @@ class OMEZarrLoader implements IVolumeLoader {
         }
         worker.terminate();
       };
-      worker.onerror = function (e) {
+      worker.onerror = (e) => {
         alert("Error: Line " + e.lineno + " in " + e.filename + ": " + e.message);
       };
       worker.postMessage({
-        urlStore: loadSpec.url,
-        time: this.hasT ? Math.min(loadSpec.time, times) : -1,
+        spec: {
+          ...loadSpec,
+          time: this.hasT ? Math.min(loadSpec.time, times) : -1,
+        },
         channel: this.hasC ? i : -1,
         downsampleZ: DOWNSAMPLE_Z,
         path: storepath,

--- a/src/test/RequestQueue.test.ts
+++ b/src/test/RequestQueue.test.ts
@@ -48,8 +48,8 @@ describe("test RequestQueue", () => {
       const rq = new RequestQueue();
       const startTime = Date.now();
       const delayMs = 15;
-      const immediatePromise = rq.addRequest("a", async () => {});
-      const delayedPromise = rq.addRequest("b", async () => {}, delayMs);
+      const immediatePromise = rq.addRequest("a", () => Promise.resolve());
+      const delayedPromise = rq.addRequest("b", () => Promise.resolve(), delayMs);
 
       const promises: Promise<unknown>[] = [];
       promises.push(

--- a/src/test/RequestQueue.test.ts
+++ b/src/test/RequestQueue.test.ts
@@ -48,18 +48,22 @@ describe("test RequestQueue", () => {
       const rq = new RequestQueue();
       const startTime = Date.now();
       const delayMs = 15;
-      const immediatePromise = rq.addRequest("a", async () => {return;});
-      const delayedPromise = rq.addRequest("b", async () => {return;}, delayMs);
+      const immediatePromise = rq.addRequest("a", async () => {});
+      const delayedPromise = rq.addRequest("b", async () => {}, delayMs);
 
       const promises: Promise<unknown>[] = [];
-      promises.push(immediatePromise.then(() => {
-        expect(Date.now() - startTime).to.be.lessThan(delayMs);
-      }));
-      promises.push(delayedPromise.then(() => {
-        expect(Date.now() - startTime).to.be.greaterThanOrEqual(delayMs);
-      }));
+      promises.push(
+        immediatePromise.then(() => {
+          expect(Date.now() - startTime).to.be.lessThan(delayMs);
+        })
+      );
+      promises.push(
+        delayedPromise.then(() => {
+          expect(Date.now() - startTime).to.be.greaterThanOrEqual(delayMs);
+        })
+      );
       await Promise.all(promises);
-    })
+    });
 
     // Test that same promise is returned
 
@@ -329,7 +333,7 @@ describe("test RequestQueue", () => {
       expect(count).to.equal(0);
     });
 
-    async function mockLoader(loadSpec: LoadSpec, maxDelayMs = 10.0): Promise<TypedArray> {
+    async function mockLoader(loadSpec: Required<LoadSpec>, maxDelayMs = 10.0): Promise<TypedArray> {
       const x = loadSpec.maxx - loadSpec.minx;
       const y = loadSpec.maxy - loadSpec.miny;
       const z = loadSpec.maxz - loadSpec.minz;
@@ -349,7 +353,7 @@ describe("test RequestQueue", () => {
       frames: number,
       xDim: number,
       yDim: number,
-      action: (LoadSpec) => Promise<T>
+      action: (loadSpec: Required<LoadSpec>) => Promise<T>
     ): Request<T>[] {
       const requests: Request<T>[] = [];
       for (let i = startingFrame; i < startingFrame + frames; i++) {
@@ -364,7 +368,7 @@ describe("test RequestQueue", () => {
         requests.push({
           key: loadSpec.toString(),
           requestAction: () => {
-            return action(loadSpec);
+            return action(loadSpec as Required<LoadSpec>);
           },
         });
       }
@@ -379,10 +383,10 @@ describe("test RequestQueue", () => {
       const maxDelayMs = 10;
       let workCount = 0;
 
-      const action = async (loadSpec: LoadSpec) => {
+      const action = async (loadSpec: Required<LoadSpec>) => {
         // Check if the work we were going to do has been cancelled.
         if (rq.hasRequest(loadSpec.toString())) {
-          const ret = await mockLoader(loadSpec, maxDelayMs)
+          const ret = await mockLoader(loadSpec, maxDelayMs);
           workCount++;
           return ret;
         }
@@ -394,7 +398,7 @@ describe("test RequestQueue", () => {
       // Allow some but not all requests to complete
       await sleep(maxDelayMs * 0.5);
       rq.cancelAllRequests();
-      await sleep(maxDelayMs);  // Wait for all async actions to finish
+      await sleep(maxDelayMs); // Wait for all async actions to finish
       expect(workCount).to.be.greaterThan(0);
       expect(workCount).to.be.lessThan(numFrames - 1);
 

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -1,62 +1,34 @@
-import { HTTPStore, openArray, NestedArray, slice, TypedArray } from "zarr";
-import { LoadSpec } from "../loaders/IVolumeLoader";
+import { HTTPStore, openArray, slice, TypedArray } from "zarr";
+import { RawArray } from "zarr/types/rawArray";
 import { Slice } from "zarr/types/core/types";
+import { LoadSpec } from "../loaders/IVolumeLoader";
 
 export type FetchZarrMessage = {
   spec: LoadSpec;
   channel: number;
-  downsampleZ: number;
   path: string;
 };
 
-function convertChannel(
-  channelData: TypedArray[][],
-  nx: number,
-  ny: number,
-  nz: number,
-  dtype: string,
-  downsampleZ: number
-): Uint8Array {
-  const nresultpixels = nx * ny * Math.ceil(nz / downsampleZ);
-  const u8 = new Uint8Array(nresultpixels);
-  const xy = nx * ny;
-
+function convertChannelRaw(channelData: TypedArray, dtype: string): Uint8Array {
   if (dtype === "|u1") {
-    // flatten the 3d array and convert to uint8
-    // todo test perf with a loop over x,y,z instead
-    for (let z = 0, slice = 0; z < nz; z += downsampleZ, ++slice) {
-      for (let j = 0; j < xy; ++j) {
-        const yrow = Math.floor(j / nx);
-        const xcol = j % nx;
-        u8[j + slice * xy] = channelData[z][yrow][xcol];
-      }
-    }
-  } else {
-    let chmin = channelData[0][0][0];
-    let chmax = channelData[0][0][0];
-    // find min and max (only of data we are sampling?)
-    for (let z = 0; z < nz; z += downsampleZ) {
-      for (let j = 0; j < xy; ++j) {
-        const yrow = Math.floor(j / nx);
-        const xcol = j % nx;
-        const val = channelData[z][yrow][xcol];
-        if (val < chmin) {
-          chmin = val;
-        }
-        if (val > chmax) {
-          chmax = val;
-        }
-      }
-    }
-    // flatten the 3d array and convert to uint8
-    for (let z = 0, slice = 0; z < nz; z += downsampleZ, ++slice) {
-      for (let j = 0; j < xy; ++j) {
-        const yrow = Math.floor(j / nx);
-        const xcol = j % nx;
-        u8[j + slice * xy] = ((channelData[z][yrow][xcol] - chmin) / (chmax - chmin)) * 255;
-      }
-    }
+    return channelData as Uint8Array;
   }
+
+  const u8 = new Uint8Array(channelData.length);
+
+  // get min and max
+  let min = channelData[0];
+  let max = channelData[0];
+  channelData.forEach((val: number) => {
+    min = Math.min(min, val);
+    max = Math.max(max, val);
+  });
+
+  // normalize and convert to u8
+  const range = max - min;
+  channelData.forEach((val: number, idx: number) => {
+    u8[idx] = ((val - min) / range) * 255;
+  });
 
   return u8;
 }
@@ -64,7 +36,6 @@ function convertChannel(
 self.onmessage = async (e: MessageEvent<FetchZarrMessage>) => {
   const time = e.data.spec.time;
   const channelIndex = e.data.channel;
-  const downsampleZ = e.data.downsampleZ;
   const store = new HTTPStore(e.data.spec.url);
   const level = await openArray({ store: store, path: e.data.path, mode: "r" });
 
@@ -82,12 +53,9 @@ self.onmessage = async (e: MessageEvent<FetchZarrMessage>) => {
   if (time > -1) {
     sliceSpec.unshift(time);
   }
-  const channel = (await level.get(sliceSpec)) as NestedArray<TypedArray>;
-  // const channelRaw = await level.getRaw(sliceSpec);
+  const channel = (await level.getRaw(sliceSpec)) as RawArray;
 
-  const [nz, ny, nx] = channel.shape;
-
-  const u8: Uint8Array = convertChannel(channel.data as TypedArray[][], nx, ny, nz, channel.dtype, downsampleZ);
+  const u8: Uint8Array = convertChannelRaw(channel.data, channel.dtype);
   const results = { data: u8, channel: channelIndex === -1 ? 0 : channelIndex };
   postMessage(results, [results.data.buffer]);
 };

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -71,7 +71,11 @@ self.onmessage = async (e: MessageEvent<FetchZarrMessage>) => {
   // build slice spec
   // assuming ZYX are the last three dimensions:
   const { minx, maxx, miny, maxy, minz, maxz } = e.data.spec;
-  const sliceSpec: (Slice | number | null)[] = [slice(minz, maxz), slice(miny, maxy), slice(minx, maxx)];
+  const sliceSpec: (Slice | number)[] = [
+    slice(minz || null, maxz),
+    slice(miny || null, maxy),
+    slice(minx || null, maxx),
+  ];
   if (channelIndex > -1) {
     sliceSpec.unshift(channelIndex);
   }

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -9,7 +9,7 @@ export type FetchZarrMessage = {
   path: string;
 };
 
-function convertChannelRaw(channelData: TypedArray, dtype: string): Uint8Array {
+function convertChannel(channelData: TypedArray, dtype: string): Uint8Array {
   if (dtype === "|u1") {
     return channelData as Uint8Array;
   }
@@ -55,7 +55,7 @@ self.onmessage = async (e: MessageEvent<FetchZarrMessage>) => {
   }
   const channel = (await level.getRaw(sliceSpec)) as RawArray;
 
-  const u8: Uint8Array = convertChannelRaw(channel.data, channel.dtype);
+  const u8: Uint8Array = convertChannel(channel.data, channel.dtype);
   const results = { data: u8, channel: channelIndex === -1 ? 0 : channelIndex };
   postMessage(results, [results.data.buffer]);
 };

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -43,9 +43,9 @@ self.onmessage = async (e: MessageEvent<FetchZarrMessage>) => {
   // assuming ZYX are the last three dimensions:
   const { minx, maxx, miny, maxy, minz, maxz } = e.data.spec;
   const sliceSpec: (Slice | number)[] = [
-    slice(minz || null, maxz),
-    slice(miny || null, maxy),
-    slice(minx || null, maxx),
+    slice(minz === undefined ? null : minz, maxz),
+    slice(miny === undefined ? null : miny, maxy),
+    slice(minx === undefined ? null : minx, maxx),
   ];
   if (channelIndex > -1) {
     sliceSpec.unshift(channelIndex);


### PR DESCRIPTION
Resolve (?) #110: change relevant loading items (`OMEZarrLoader`, `IVolumeLoader`, `LoadSpec`) to allow loading of subregions from zarr arrays, including single slices.

### Changes:

- `LoadSpec` subregion fields (`minx`, `maxx`, `miny`, etc.) may be undefined to indicate loading the max extent of that axis 
- `OMEZarrLoader` now pays attention to these fields
- `FetchZarrWorker` now uses the `zarr.getRaw` method, which removes the need to de-nest typed arrays in the worker
- `IVolumeLoader` allows passing in an optional explicit `LoadSpec` on data load which overrides the one in the target `Volume`

### Does NOT (yet) change:

- Other discussed changes to `LoadSpec`: replace `subpath` with `scaleLevel`/`multiscale`, add array of channel indexes
- Replace the per-channel callback API with one based on an array of promises
- Make `Volume` aware that it contains a subset of its full extent. Currently, `OMEZarrLoader` will dutifully load a smaller-than-expected array of channel data into the full dimensions of the volume, and the volume will show up but with a lot of blank space. It's unclear how `Volume` should handle this.
- Allow loading original data types, rather than converting to uint8 (#121), though the simplifications to `FetchZarrWorker` will make this easier