### PR TITLE
Feature/load volume subsets

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -927,13 +927,16 @@ function onVolumeCreated(volume: Volume, isTimeSeries = false, frameNumber = 0) 
       // create the main volume and add to view (this is the only place)
       myState.volume = new Volume(myJson);
 
+      const atlasWidth = myJson.tile_width * myJson.cols;
+      const atlasHeight = myJson.tile_height * myJson.rows;
+
       // TODO: this can go in the Volume and Channel constructors!
       // preallocate some memory to be filled in later
       for (let i = 0; i < myState.volume.num_channels; ++i) {
         myState.volume.channels[i].imgData = {
-          data: new Uint8ClampedArray(myJson.atlas_width * myJson.atlas_height),
-          width: myJson.atlas_width,
-          height: myJson.atlas_height,
+          data: new Uint8ClampedArray(atlasWidth * atlasHeight),
+          width: atlasWidth,
+          height: atlasHeight,
         };
         myState.volume.channels[i].volumeData = new Uint8Array(myJson.tile_width * myJson.tile_height * myJson.tiles);
         // TODO also preallocate the Fused data texture
@@ -1100,20 +1103,15 @@ function createTestVolume() {
     height: 64,
     channels: 3,
     channel_names: ["DRAQ5", "EGFP", "SEG_Memb"],
+    // These dimensions are used to prepare the raw volume arrays for rendering as tiled texture atlases
+    // for webgl reasons, it is best for atlas width (cols*tile_width) and height (rows*tile_height)
+    // to be <= 2048 and ideally a power of 2. (adjust other dimensions accordingly)
     rows: 8,
     cols: 8,
     // tiles <= rows*cols, tiles is number of z slices
     tiles: 64,
     tile_width: 64,
     tile_height: 64,
-
-    // These dimensions are used to prepare the raw volume arrays for rendering as tiled texture atlases
-    // for webgl reasons, it is best for atlas_width and atlas_height to be <= 2048
-    // and ideally a power of 2. (adjust other dimensions accordingly)
-    // atlas_width === cols*tile_width
-    atlas_width: 512,
-    // atlas_height === rows*tile_height
-    atlas_height: 512,
 
     pixel_size_x: 1,
     pixel_size_y: 1,

--- a/public/index.ts
+++ b/public/index.ts
@@ -599,7 +599,7 @@ function updateZSliceUI(volume: Volume) {
   const zSlider = document.getElementById("zSlider") as HTMLInputElement;
   const zInput = document.getElementById("zValue") as HTMLInputElement;
 
-  const totalZSlices = volume.z;
+  const totalZSlices = volume.imageInfo.vol_size_z || volume.z;
   zSlider.max = `${totalZSlices}`;
   zInput.max = `${totalZSlices}`;
 }

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -162,7 +162,7 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
   }
 
   public updateVolumeDimensions(): void {
-    const scale = this.volume.scale;
+    const scale = this.volume.normalizedPhysicalSize;
     this.geometryMesh.scale.copy(scale);
     this.setUniform("volumeScale", scale);
     this.boxHelper.box.set(scale.clone().multiplyScalar(-0.5), scale.clone().multiplyScalar(0.5));

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -147,12 +147,9 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
     if (dirtyFlags & SettingsFlags.ROI) {
       // Normalize and set bounds
       const bounds = this.settings.bounds;
-      const boundsNormalized = {
-        bmin: new Vector3(bounds.bmin.x * 2.0, bounds.bmin.y * 2.0, bounds.bmin.z * 2.0),
-        bmax: new Vector3(bounds.bmax.x * 2.0, bounds.bmax.y * 2.0, bounds.bmax.z * 2.0),
-      };
-      this.setUniform("AABB_CLIP_MIN", boundsNormalized.bmin);
-      this.setUniform("AABB_CLIP_MAX", boundsNormalized.bmax);
+
+      this.setUniform("AABB_CLIP_MIN", bounds.bmin);
+      this.setUniform("AABB_CLIP_MAX", bounds.bmax);
       const slice = Math.floor(this.settings.zSlice);
       if (slice >= 0 && slice <= this.volume.z - 1) {
         this.setUniform("Z_SLICE", slice);

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -60,8 +60,17 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
 
     this.geometryTransformNode.add(this.boxHelper, this.geometryMesh);
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { cols, rows, tile_width, tile_height } = volume.imageInfo;
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const { cols, rows, tile_width, tile_height, tiles } = volume.imageInfo;
+    const {
+      vol_size_x = tile_width,
+      vol_size_y = tile_height,
+      vol_size_z = tiles,
+      offset_x = 0,
+      offset_y = 0,
+      offset_z = 0,
+    } = volume.imageInfo;
+    /* eslint-enable @typescript-eslint/naming-convention */
     const atlasWidth = tile_width * cols;
     const atlasHeight = tile_height * rows;
 
@@ -69,6 +78,8 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
     this.setUniform("ATLAS_Y", rows);
     this.setUniform("textureRes", new Vector2(atlasWidth, atlasHeight));
     this.setUniform("SLICES", volume.z);
+    this.setUniform("SUBSET_SCALE", new Vector3(tile_width / vol_size_x, tile_height / vol_size_y, tiles / vol_size_z));
+    this.setUniform("SUBSET_OFFSET", new Vector3(offset_x / vol_size_x, offset_y / vol_size_y, offset_z / vol_size_z));
     this.setUniform("Z_SLICE", Math.floor(volume.z / 2));
 
     this.channelData = new FusedChannelData(atlasWidth, atlasHeight);

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -28,7 +28,7 @@ const BOUNDING_BOX_DEFAULT_COLOR = new Color(0xffff00);
  * Creates a plane that renders a 2D XY slice of volume atlas data.
  */
 export default class Atlas2DSlice implements VolumeRenderImpl {
-  private settings: VolumeRenderSettings | undefined;
+  private settings: VolumeRenderSettings;
   public volume: Volume;
   private geometry: ShapeGeometry;
   protected geometryMesh: Mesh<BufferGeometry, Material>;
@@ -62,6 +62,8 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
 
     this.setUniform("Z_SLICE", Math.floor((volume.imageInfo.vol_size_z || volume.z) / 2));
     this.initChannelData();
+    this.updateVolumeDimensions();
+    this.settings = settings;
     this.updateSettings(settings, SettingsFlags.ALL);
   }
 
@@ -123,15 +125,6 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
       this.setUniform("flipVolume", this.settings.flipAxes);
     }
 
-    if (dirtyFlags & SettingsFlags.DATA_SIZE) {
-      // Set scale
-      const scale = this.settings.scale;
-      this.geometryMesh.scale.copy(scale);
-      this.setUniform("volumeScale", scale);
-      this.boxHelper.box.set(scale.clone().multiplyScalar(-0.5), scale.clone().multiplyScalar(0.5));
-      this.initChannelData();
-    }
-
     if (dirtyFlags & SettingsFlags.MATERIAL) {
       this.setUniform("DENSITY", this.settings.density);
     }
@@ -166,6 +159,14 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
       this.setUniform("maskAlpha", this.settings.maskAlpha);
       this.setUniform("maskAlpha", this.settings.maskAlpha);
     }
+  }
+
+  public updateVolumeDimensions(): void {
+    const scale = this.volume.scale;
+    this.geometryMesh.scale.copy(scale);
+    this.setUniform("volumeScale", scale);
+    this.boxHelper.box.set(scale.clone().multiplyScalar(-0.5), scale.clone().multiplyScalar(0.5));
+    this.initChannelData();
   }
 
   private createGeometry(

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -60,13 +60,18 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
 
     this.geometryTransformNode.add(this.boxHelper, this.geometryMesh);
 
-    this.setUniform("ATLAS_X", volume.imageInfo.cols);
-    this.setUniform("ATLAS_Y", volume.imageInfo.rows);
-    this.setUniform("textureRes", new Vector2(volume.imageInfo.atlas_width, volume.imageInfo.atlas_height));
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { cols, rows, tile_width, tile_height } = volume.imageInfo;
+    const atlasWidth = tile_width * cols;
+    const atlasHeight = tile_height * rows;
+
+    this.setUniform("ATLAS_X", cols);
+    this.setUniform("ATLAS_Y", rows);
+    this.setUniform("textureRes", new Vector2(atlasWidth, atlasHeight));
     this.setUniform("SLICES", volume.z);
     this.setUniform("Z_SLICE", Math.floor(volume.z / 2));
 
-    this.channelData = new FusedChannelData(volume.imageInfo.atlas_width, volume.imageInfo.atlas_height);
+    this.channelData = new FusedChannelData(atlasWidth, atlasHeight);
     this.updateSettings(settings, SettingsFlags.ALL);
   }
 

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -60,7 +60,7 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
 
     this.geometryTransformNode.add(this.boxHelper, this.geometryMesh);
 
-    this.setUniform("Z_SLICE", Math.floor(volume.z / 2));
+    this.setUniform("Z_SLICE", Math.floor((volume.imageInfo.vol_size_z || volume.z) / 2));
     this.initChannelData();
     this.updateSettings(settings, SettingsFlags.ALL);
   }
@@ -74,7 +74,7 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
     this.setUniform("ATLAS_X", cols);
     this.setUniform("ATLAS_Y", rows);
     this.setUniform("textureRes", new Vector2(atlasWidth, atlasHeight));
-    this.setUniform("SLICES", this.volume.z);
+    this.setUniform("SLICES", this.volume.imageInfo.vol_size_z || this.volume.z);
     this.setUniform("SUBSET_SCALE", this.volume.contentSize);
     this.setUniform("SUBSET_OFFSET", this.volume.contentOffset);
 
@@ -151,7 +151,8 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
       this.setUniform("AABB_CLIP_MIN", bounds.bmin);
       this.setUniform("AABB_CLIP_MAX", bounds.bmax);
       const slice = Math.floor(this.settings.zSlice);
-      if (slice >= 0 && slice <= this.volume.z - 1) {
+      const sizez = this.volume.imageInfo.vol_size_z || this.volume.z;
+      if (slice >= 0 && slice <= sizez - 1) {
         this.setUniform("Z_SLICE", slice);
       }
     }

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -27,8 +27,8 @@ import { FuseChannel } from "./types";
 // This is the owner of the fused RGBA volume texture atlas, and the mask texture atlas.
 // This module is responsible for updating the fused texture, given the read-only volume channel data.
 export default class FusedChannelData {
-  private width: number;
-  private height: number;
+  public width: number;
+  public height: number;
 
   public maskTexture: DataTexture;
 

--- a/src/MeshVolume.ts
+++ b/src/MeshVolume.ts
@@ -90,10 +90,11 @@ export default class MeshVolume {
     }
   }
 
-  setScale(scale: Vector3): void {
+  setScale(scale: Vector3, position = new Vector3(0, 0, 0)): void {
     this.scale = scale;
 
-    this.meshRoot.scale.copy(new Vector3(0.5 * scale.x, 0.5 * scale.y, 0.5 * scale.z));
+    this.meshRoot.scale.copy(scale).multiplyScalar(0.5);
+    this.meshRoot.position.copy(position);
   }
 
   setFlipAxes(flipX: number, flipY: number, flipZ: number): void {

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -375,26 +375,20 @@ export default class PathTracedVolume implements VolumeRenderImpl {
     }
 
     // update bounds
-    if (dirtyFlags & SettingsFlags.ROI) {
+    if (dirtyFlags & SettingsFlags.ROI || dirtyFlags & SettingsFlags.DATA_SIZE) {
       const { normalizedPhysicalSize: physicalSize, contentSize, contentOffset } = this.volume;
       const { bmin, bmax } = this.settings.bounds;
-      // this.pathTracingUniforms.gClippedAaBbMin.value = new Vector3(
-      //   bmin.x * physicalSize.x,
-      //   bmin.y * physicalSize.y,
-      //   bmin.z * physicalSize.z
-      // );
+
       const clipMin = bmin.clone().multiply(physicalSize);
       const boundsMin = contentOffset.clone().subScalar(0.5).multiply(physicalSize);
-      console.log(clipMin, boundsMin);
       this.pathTracingUniforms.gClippedAaBbMin.value = clipMin.max(boundsMin);
 
       const clipMax = bmax.clone().multiply(physicalSize);
       const boundsMax = contentOffset.clone().add(contentSize).subScalar(0.5).multiply(physicalSize);
-      this.pathTracingUniforms.gClippedAaBbMax.value = new Vector3(
-        bmax.x * physicalSize.x,
-        bmax.y * physicalSize.y,
-        bmax.z * physicalSize.z
-      );
+      this.pathTracingUniforms.gClippedAaBbMax.value = clipMax.min(boundsMax);
+
+      const volCenter = contentSize.clone().divideScalar(2).add(contentOffset).subScalar(0.5).multiply(physicalSize);
+      this.pathTracingUniforms.gVolCenter.value = volCenter;
     }
 
     if (dirtyFlags & SettingsFlags.CAMERA) {

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -387,8 +387,7 @@ export default class PathTracedVolume implements VolumeRenderImpl {
       const boundsMax = contentOffset.clone().add(contentSize).subScalar(0.5).multiply(physicalSize);
       this.pathTracingUniforms.gClippedAaBbMax.value = clipMax.min(boundsMax);
 
-      const volCenter = contentSize.clone().divideScalar(2).add(contentOffset).subScalar(0.5).multiply(physicalSize);
-      this.pathTracingUniforms.gVolCenter.value = volCenter;
+      this.pathTracingUniforms.gVolCenter.value = this.volume.getCenter();
     }
 
     if (dirtyFlags & SettingsFlags.CAMERA) {

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -388,7 +388,7 @@ export default class PathTracedVolume implements VolumeRenderImpl {
       const clipMax = bmax.clone().multiply(physicalSize);
       this.pathTracingUniforms.gClippedAaBbMax.value = clipMax.clamp(sizeMin, sizeMax);
 
-      this.pathTracingUniforms.gVolCenter.value = this.volume.getCenter();
+      this.pathTracingUniforms.gVolCenter.value = this.volume.getContentCenter();
     }
 
     if (dirtyFlags & SettingsFlags.CAMERA) {

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -314,7 +314,7 @@ export default class PathTracedVolume implements VolumeRenderImpl {
       1.0 / physicalSize.x,
       1.0 / physicalSize.y,
       1.0 / physicalSize.z
-    );
+    ).divide(volume.contentSize);
     this.updateLightsSecondary();
 
     // Update settings
@@ -376,16 +376,24 @@ export default class PathTracedVolume implements VolumeRenderImpl {
 
     // update bounds
     if (dirtyFlags & SettingsFlags.ROI) {
-      const physicalSize = this.volume.normalizedPhysicalSize;
-      this.pathTracingUniforms.gClippedAaBbMin.value = new Vector3(
-        this.settings.bounds.bmin.x * physicalSize.x,
-        this.settings.bounds.bmin.y * physicalSize.y,
-        this.settings.bounds.bmin.z * physicalSize.z
-      );
+      const { normalizedPhysicalSize: physicalSize, contentSize, contentOffset } = this.volume;
+      const { bmin, bmax } = this.settings.bounds;
+      // this.pathTracingUniforms.gClippedAaBbMin.value = new Vector3(
+      //   bmin.x * physicalSize.x,
+      //   bmin.y * physicalSize.y,
+      //   bmin.z * physicalSize.z
+      // );
+      const clipMin = bmin.clone().multiply(physicalSize);
+      const boundsMin = contentOffset.clone().subScalar(0.5).multiply(physicalSize);
+      console.log(clipMin, boundsMin);
+      this.pathTracingUniforms.gClippedAaBbMin.value = clipMin.max(boundsMin);
+
+      const clipMax = bmax.clone().multiply(physicalSize);
+      const boundsMax = contentOffset.clone().add(contentSize).subScalar(0.5).multiply(physicalSize);
       this.pathTracingUniforms.gClippedAaBbMax.value = new Vector3(
-        this.settings.bounds.bmax.x * physicalSize.x,
-        this.settings.bounds.bmax.y * physicalSize.y,
-        this.settings.bounds.bmax.z * physicalSize.z
+        bmax.x * physicalSize.x,
+        bmax.y * physicalSize.y,
+        bmax.z * physicalSize.z
       );
     }
 

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -379,13 +379,14 @@ export default class PathTracedVolume implements VolumeRenderImpl {
       const { normalizedPhysicalSize: physicalSize, contentSize, contentOffset } = this.volume;
       const { bmin, bmax } = this.settings.bounds;
 
+      const sizeMin = contentOffset.clone().subScalar(0.5).multiply(physicalSize);
+      const sizeMax = contentOffset.clone().add(contentSize).subScalar(0.5).multiply(physicalSize);
+
       const clipMin = bmin.clone().multiply(physicalSize);
-      const boundsMin = contentOffset.clone().subScalar(0.5).multiply(physicalSize);
-      this.pathTracingUniforms.gClippedAaBbMin.value = clipMin.max(boundsMin);
+      this.pathTracingUniforms.gClippedAaBbMin.value = clipMin.clamp(sizeMin, sizeMax);
 
       const clipMax = bmax.clone().multiply(physicalSize);
-      const boundsMax = contentOffset.clone().add(contentSize).subScalar(0.5).multiply(physicalSize);
-      this.pathTracingUniforms.gClippedAaBbMax.value = clipMax.min(boundsMax);
+      this.pathTracingUniforms.gClippedAaBbMax.value = clipMax.clamp(sizeMin, sizeMax);
 
       this.pathTracingUniforms.gVolCenter.value = this.volume.getCenter();
     }

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -375,7 +375,7 @@ export default class PathTracedVolume implements VolumeRenderImpl {
     }
 
     // update bounds
-    if (dirtyFlags & SettingsFlags.ROI || dirtyFlags & SettingsFlags.DATA_SIZE) {
+    if (dirtyFlags & SettingsFlags.ROI) {
       const { normalizedPhysicalSize: physicalSize, contentSize, contentOffset } = this.volume;
       const { bmin, bmax } = this.settings.bounds;
 
@@ -411,6 +411,10 @@ export default class PathTracedVolume implements VolumeRenderImpl {
     }
 
     this.resetProgress();
+  }
+
+  public updateVolumeDimensions(): void {
+    this.updateSettings(this.settings, SettingsFlags.ROI);
   }
 
   public doRender(canvas: ThreeJsPanel): void {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -180,6 +180,7 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
       const offsetToCenter = contentSize.clone().divideScalar(2).add(contentOffset).subScalar(0.5);
       const bmin = bounds.bmin.clone().sub(offsetToCenter).divide(contentSize).clampScalar(-0.5, 0.5);
       const bmax = bounds.bmax.clone().sub(offsetToCenter).divide(contentSize).clampScalar(-0.5, 0.5);
+
       this.setUniform("AABB_CLIP_MIN", bmin);
       this.setUniform("AABB_CLIP_MAX", bmax);
     }

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -73,12 +73,18 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
 
     this.geometryTransformNode.add(this.boxHelper, this.tickMarksMesh, this.geometryMesh);
 
-    this.setUniform("ATLAS_X", volume.imageInfo.cols);
-    this.setUniform("ATLAS_Y", volume.imageInfo.rows);
-    this.setUniform("textureRes", new Vector2(volume.imageInfo.atlas_width, volume.imageInfo.atlas_height));
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { cols, rows, tile_width, tile_height } = volume.imageInfo;
+    const atlasWidth = tile_width * cols;
+    const atlasHeight = tile_height * rows;
+
+    this.setUniform("ATLAS_X", cols);
+    this.setUniform("ATLAS_Y", rows);
+
+    this.setUniform("textureRes", new Vector2(atlasWidth, atlasHeight));
     this.setUniform("SLICES", volume.z);
 
-    this.channelData = new FusedChannelData(volume.imageInfo.atlas_width, volume.imageInfo.atlas_height);
+    this.channelData = new FusedChannelData(atlasWidth, atlasHeight);
     this.updateSettings(settings, SettingsFlags.ALL);
   }
 

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -183,15 +183,18 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
   }
 
   public updateVolumeDimensions(): void {
-    const { scale, contentSize } = this.volume;
+    const { normalizedPhysicalSize, contentSize } = this.volume;
     // Set offset
     this.geometryMesh.position.copy(this.volume.getContentCenter());
     // Set scale
-    this.geometryMesh.scale.copy(contentSize).multiply(scale);
-    this.setUniform("volumeScale", scale);
-    this.boxHelper.box.set(scale.clone().multiplyScalar(-0.5), scale.clone().multiplyScalar(0.5));
+    this.geometryMesh.scale.copy(contentSize).multiply(normalizedPhysicalSize);
+    this.setUniform("volumeScale", normalizedPhysicalSize);
+    this.boxHelper.box.set(
+      normalizedPhysicalSize.clone().multiplyScalar(-0.5),
+      normalizedPhysicalSize.clone().multiplyScalar(0.5)
+    );
     // TODO do tickmarks need to be regenerated here to remain accurate?
-    this.tickMarksMesh.scale.copy(scale);
+    this.tickMarksMesh.scale.copy(normalizedPhysicalSize);
     this.settings && this.updateSettings(this.settings, SettingsFlags.ROI);
     // Reset uniforms and channel data
     this.initChannelData();

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -154,7 +154,7 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
       this.geometryMesh.scale.copy(contentSize).multiply(scale);
       this.setUniform("volumeScale", scale);
       this.boxHelper.box.set(scale.clone().multiplyScalar(-0.5), scale.clone().multiplyScalar(0.5));
-      this.tickMarksMesh = this.createTickMarks();
+      // TODO do tickmarks need to be regenerated here to remain accurate?
       this.tickMarksMesh.scale.copy(scale);
       // Reset uniforms and channel data
       this.initChannelData();

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -146,8 +146,9 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
 
     if (dirtyFlags & SettingsFlags.TRANSFORM) {
       // Set scale
-      const scale = this.settings.scale;
-      this.geometryMesh.scale.copy(scale);
+      const { scale, contentSize, contentOffset } = this.settings;
+      this.geometryMesh.scale.copy(contentSize).multiply(scale);
+      this.geometryMesh.position.copy(contentSize).divideScalar(2).add(contentOffset).subScalar(0.5).multiply(scale);
       this.setUniform("volumeScale", scale);
       this.boxHelper.box.set(
         new Vector3(-0.5 * scale.x, -0.5 * scale.y, -0.5 * scale.z),

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -176,10 +176,12 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
     if (dirtyFlags & SettingsFlags.ROI) {
       // Normalize and set bounds
       const bounds = this.settings.bounds;
-      const { contentSize } = this.volume;
-      const contentCenter = this.volume.getContentCenter();
-      this.setUniform("AABB_CLIP_MIN", bounds.bmin.clone().sub(contentCenter).divide(contentSize));
-      this.setUniform("AABB_CLIP_MAX", bounds.bmax.clone().sub(contentCenter).divide(contentSize));
+      const { contentSize, contentOffset } = this.volume;
+      const offsetToCenter = contentSize.clone().divideScalar(2).add(contentOffset).subScalar(0.5);
+      const bmin = bounds.bmin.clone().sub(offsetToCenter).divide(contentSize).clampScalar(-0.5, 0.5);
+      const bmax = bounds.bmax.clone().sub(offsetToCenter).divide(contentSize).clampScalar(-0.5, 0.5);
+      this.setUniform("AABB_CLIP_MIN", bmin);
+      this.setUniform("AABB_CLIP_MAX", bmax);
     }
 
     if (dirtyFlags & SettingsFlags.SAMPLING) {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -177,8 +177,9 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
       // Normalize and set bounds
       const bounds = this.settings.bounds;
       const { contentSize } = this.volume;
-      this.setUniform("AABB_CLIP_MIN", bounds.bmin.clone().sub(this.volume.getContentCenter()).divide(contentSize));
-      this.setUniform("AABB_CLIP_MAX", bounds.bmax.clone().sub(this.volume.getContentCenter()).divide(contentSize));
+      const contentCenter = this.volume.getContentCenter();
+      this.setUniform("AABB_CLIP_MIN", bounds.bmin.clone().sub(contentCenter).divide(contentSize));
+      this.setUniform("AABB_CLIP_MAX", bounds.bmax.clone().sub(contentCenter).divide(contentSize));
     }
 
     if (dirtyFlags & SettingsFlags.SAMPLING) {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -73,8 +73,17 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
 
     this.geometryTransformNode.add(this.boxHelper, this.tickMarksMesh, this.geometryMesh);
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { cols, rows, tile_width, tile_height } = volume.imageInfo;
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const { cols, rows, tile_width, tile_height, tiles } = volume.imageInfo;
+    const {
+      vol_size_x = tile_width,
+      vol_size_y = tile_height,
+      vol_size_z = tiles,
+      offset_x = 0,
+      offset_y = 0,
+      offset_z = 0,
+    } = volume.imageInfo;
+    /* eslint-enable @typescript-eslint/naming-convention */
     const atlasWidth = tile_width * cols;
     const atlasHeight = tile_height * rows;
 
@@ -83,6 +92,9 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
 
     this.setUniform("textureRes", new Vector2(atlasWidth, atlasHeight));
     this.setUniform("SLICES", volume.z);
+
+    this.setUniform("SUBSET_SCALE", new Vector3(tile_width / vol_size_x, tile_height / vol_size_y, tiles / vol_size_z));
+    this.setUniform("SUBSET_OFFSET", new Vector3(offset_x / vol_size_x, offset_y / vol_size_y, offset_z / vol_size_z));
 
     this.channelData = new FusedChannelData(atlasWidth, atlasHeight);
     this.updateSettings(settings, SettingsFlags.ALL);

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -74,6 +74,7 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
     this.geometryTransformNode.add(this.boxHelper, this.tickMarksMesh, this.geometryMesh);
 
     this.initChannelData();
+    this.updateVolumeDimensions();
     this.settings = settings;
     this.updateSettings(settings, SettingsFlags.ALL);
   }

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -149,7 +149,7 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
     if (dirtyFlags & SettingsFlags.DATA_SIZE) {
       const { scale, contentSize } = this.settings;
       // Set offset
-      this.geometryMesh.position.copy(this.volume.getCenter());
+      this.geometryMesh.position.copy(this.volume.getContentCenter());
       // Set scale
       this.geometryMesh.scale.copy(contentSize).multiply(scale);
       this.setUniform("volumeScale", scale);
@@ -177,8 +177,8 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
       // Normalize and set bounds
       const bounds = this.settings.bounds;
       const { contentSize } = this.volume;
-      this.setUniform("AABB_CLIP_MIN", bounds.bmin.clone().sub(this.volume.getCenter()).divide(contentSize));
-      this.setUniform("AABB_CLIP_MAX", bounds.bmax.clone().sub(this.volume.getCenter()).divide(contentSize));
+      this.setUniform("AABB_CLIP_MIN", bounds.bmin.clone().sub(this.volume.getContentCenter()).divide(contentSize));
+      this.setUniform("AABB_CLIP_MAX", bounds.bmax.clone().sub(this.volume.getContentCenter()).divide(contentSize));
     }
 
     if (dirtyFlags & SettingsFlags.SAMPLING) {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -147,9 +147,9 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
     }
 
     if (dirtyFlags & SettingsFlags.DATA_SIZE) {
-      const { scale, contentSize, contentOffset } = this.settings;
+      const { scale, contentSize } = this.settings;
       // Set offset
-      this.geometryMesh.position.copy(contentSize).divideScalar(2).add(contentOffset).subScalar(0.5).multiply(scale);
+      this.geometryMesh.position.copy(this.volume.getCenter());
       // Set scale
       this.geometryMesh.scale.copy(contentSize).multiply(scale);
       this.setUniform("volumeScale", scale);

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -176,12 +176,9 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
     if (dirtyFlags & SettingsFlags.ROI) {
       // Normalize and set bounds
       const bounds = this.settings.bounds;
-      const boundsNormalized = {
-        bmin: bounds.bmin.clone().multiplyScalar(2),
-        bmax: bounds.bmax.clone().multiplyScalar(2),
-      };
-      this.setUniform("AABB_CLIP_MIN", boundsNormalized.bmin);
-      this.setUniform("AABB_CLIP_MAX", boundsNormalized.bmax);
+      const { contentSize } = this.volume;
+      this.setUniform("AABB_CLIP_MIN", bounds.bmin.clone().sub(this.volume.getCenter()).divide(contentSize));
+      this.setUniform("AABB_CLIP_MAX", bounds.bmax.clone().sub(this.volume.getCenter()).divide(contentSize));
     }
 
     if (dirtyFlags & SettingsFlags.SAMPLING) {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -73,17 +73,8 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
 
     this.geometryTransformNode.add(this.boxHelper, this.tickMarksMesh, this.geometryMesh);
 
-    /* eslint-disable @typescript-eslint/naming-convention */
-    const { cols, rows, tile_width, tile_height, tiles } = volume.imageInfo;
-    const {
-      vol_size_x = tile_width,
-      vol_size_y = tile_height,
-      vol_size_z = tiles,
-      offset_x = 0,
-      offset_y = 0,
-      offset_z = 0,
-    } = volume.imageInfo;
-    /* eslint-enable @typescript-eslint/naming-convention */
+    /* eslint-disable-next-line @typescript-eslint/naming-convention */
+    const { cols, rows, tile_width, tile_height } = volume.imageInfo;
     const atlasWidth = tile_width * cols;
     const atlasHeight = tile_height * rows;
 
@@ -92,9 +83,6 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
 
     this.setUniform("textureRes", new Vector2(atlasWidth, atlasHeight));
     this.setUniform("SLICES", volume.z);
-
-    this.setUniform("SUBSET_SCALE", new Vector3(tile_width / vol_size_x, tile_height / vol_size_y, tiles / vol_size_z));
-    this.setUniform("SUBSET_OFFSET", new Vector3(offset_x / vol_size_x, offset_y / vol_size_y, offset_z / vol_size_z));
 
     this.channelData = new FusedChannelData(atlasWidth, atlasHeight);
     this.updateSettings(settings, SettingsFlags.ALL);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -218,6 +218,8 @@ export class View3d {
 
   // channels is an array of channel indices for which new data just arrived.
   onVolumeData(volume: Volume, channels: number[]): void {
+    this.image?.setScale(volume.scale);
+    this.image?.setContentPosition(volume.contentSize, volume.contentOffset);
     this.image?.onChannelLoaded(channels);
     if (volume.isLoaded()) {
       this.tweakpane = this.setupGui(this.canvas3d.containerdiv);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -218,7 +218,7 @@ export class View3d {
 
   // channels is an array of channel indices for which new data just arrived.
   onVolumeData(volume: Volume, channels: number[]): void {
-    this.image?.setScale(volume.scale, volume.contentSize, volume.contentOffset);
+    this.image?.updateScale();
     this.image?.onChannelLoaded(channels);
     if (volume.isLoaded()) {
       this.tweakpane = this.setupGui(this.canvas3d.containerdiv);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -218,8 +218,7 @@ export class View3d {
 
   // channels is an array of channel indices for which new data just arrived.
   onVolumeData(volume: Volume, channels: number[]): void {
-    this.image?.setScale(volume.scale);
-    this.image?.setContentPosition(volume.contentSize, volume.contentOffset);
+    this.image?.setScale(volume.scale, volume.contentSize, volume.contentOffset);
     this.image?.onChannelLoaded(channels);
     if (volume.isLoaded()) {
       this.tweakpane = this.setupGui(this.canvas3d.containerdiv);

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -289,9 +289,10 @@ export default class Volume {
 
     const physSizeMin = Math.min(this.pixel_size[0], this.pixel_size[1], this.pixel_size[2]);
     const pixelsMax = Math.max(this.imageInfo.width, this.imageInfo.height, this.z);
+    const sizez = this.imageInfo.vol_size_z || this.z;
     const sx = ((this.pixel_size[0] / physSizeMin) * this.imageInfo.width) / pixelsMax;
     const sy = ((this.pixel_size[1] / physSizeMin) * this.imageInfo.height) / pixelsMax;
-    const sz = ((this.pixel_size[2] / physSizeMin) * this.z) / pixelsMax;
+    const sz = ((this.pixel_size[2] / physSizeMin) * sizez) / pixelsMax;
 
     // this works because image was scaled down in x and y but not z.
     // so use original x and y dimensions from imageInfo.
@@ -310,6 +311,7 @@ export default class Volume {
 
     // sx, sy, sz should be same as normalizedPhysicalSize
     this.scale = new Vector3(sx, sy, sz);
+    console.log(this.scale, this.physicalSize);
   }
 
   setUnitSymbol(symbol: string): void {

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -241,6 +241,13 @@ export default class Volume {
     this.volumeDataObservers = [];
   }
 
+  updateDimensions() {
+    this.x = this.imageInfo.tile_width;
+    this.y = this.imageInfo.tile_height;
+    this.z = this.imageInfo.tiles;
+    this.setVoxelSize(this.pixel_size);
+  }
+
   // we calculate the physical size of the volume (voxels*pixel_size)
   // and then normalize to the max physical dimension
   setVoxelSize(values: number[]): void {

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -10,17 +10,42 @@ export interface ImageInfo {
   name: string;
   version: string;
 
+  /** X size of the *original* (not downsampled) volume, in pixels */
   width: number;
+  /** Y size of the *original* (not downsampled) volume, in pixels */
   height: number;
+  /** Number of rows of z-slice tiles in the texture atlas */
   rows: number;
+  /** Number of columns of z-slice tiles in the texture atlas */
   cols: number;
+  /** Width of a single atlas tile in pixels */
   tile_width: number;
+  /** Height of a single atlas tile in pixels */
   tile_height: number;
+  /** Number of tiles in the texture atlas (or number of z-slices in the volume segment) */
   tiles: number;
+  /** Physical x size of a single *original* (not downsampled) pixel */
   pixel_size_x: number;
+  /** Physical y size of a single *original* (not downsampled) pixel */
   pixel_size_y: number;
+  /** Physical z size of a single pixel */
   pixel_size_z: number;
+  /** Symbol of physical unit used by `pixel_size_(x|y|z)` fields */
   pixel_size_unit: string;
+
+  // backwards compatibility: these are optional
+  /** Full x size of the volume. `tile_width` will be used if unspecified */
+  vol_size_x?: number;
+  /** Full y size of the volume. `tile_height` will be used if unspecified */
+  vol_size_y?: number;
+  /** Full z size of the volume. `tiles` will be used if unspecified */
+  vol_size_z?: number;
+  /** x offset of the volume subset into the volume */
+  offset_x?: number;
+  /** y offset of the volume subset into the volume */
+  offset_y?: number;
+  /** z offset of the volume subset into the volume */
+  offset_z?: number;
 
   channels: number;
   channel_names: string[];

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -9,29 +9,31 @@ import { LoadSpec } from "./loaders/IVolumeLoader";
 export interface ImageInfo {
   name: string;
   version: string;
+
   width: number;
   height: number;
-  channels: number;
+  rows: number;
+  cols: number;
+  tile_width: number;
+  tile_height: number;
   tiles: number;
   pixel_size_x: number;
   pixel_size_y: number;
   pixel_size_z: number;
   pixel_size_unit: string;
+
+  channels: number;
   channel_names: string[];
   channel_colors?: [number, number, number][];
-  rows: number;
-  cols: number;
-  tile_width: number;
-  tile_height: number;
-  atlas_width: number;
-  atlas_height: number;
+
+  times: number;
+  time_scale: number;
+  time_unit: string;
+
   transform: {
     translation: [number, number, number];
     rotation: [number, number, number];
   };
-  times: number;
-  time_scale: number;
-  time_unit: string;
   userData?: Record<string, unknown>;
 }
 
@@ -53,8 +55,6 @@ export const getDefaultImageInfo = (): ImageInfo => {
     cols: 1,
     tile_width: 1,
     tile_height: 1,
-    atlas_width: 1,
-    atlas_height: 1,
     transform: {
       translation: [0, 0, 0],
       rotation: [0, 0, 0],
@@ -135,9 +135,6 @@ export default class Volume {
   public x: number;
   public y: number;
   public z: number;
-  private t: number;
-  private atlasSize: [number, number];
-  private volumeSize: [number, number, number];
   public channels: Channel[];
   private volumeDataObservers: VolumeDataObserver[];
   public scale: Vector3;
@@ -176,7 +173,6 @@ export default class Volume {
     this.x = this.imageInfo.tile_width;
     this.y = this.imageInfo.tile_height;
     this.z = this.imageInfo.tiles;
-    this.t = 1;
 
     this.num_channels = this.imageInfo.channels;
 
@@ -190,9 +186,6 @@ export default class Volume {
         this.channel_colors_default[i] = getColorByChannelIndex(i);
       }
     }
-
-    this.atlasSize = [this.imageInfo.atlas_width, this.imageInfo.atlas_height];
-    this.volumeSize = [this.x, this.y, this.z];
 
     this.channels = [];
     for (let i = 0; i < this.num_channels; ++i) {
@@ -321,8 +314,8 @@ export default class Volume {
       this.x,
       this.y,
       this.z,
-      this.atlasSize[0],
-      this.atlasSize[1]
+      this.imageInfo.cols * this.imageInfo.tile_width,
+      this.imageInfo.rows * this.imageInfo.tile_height
     );
     this.onChannelLoaded([channelIndex]);
   }

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -318,6 +318,7 @@ export default class Volume {
 
   /** Computes the center of the volume subset */
   getContentCenter(): Vector3 {
+    // center point: (contentSize / 2 + contentOffset - 0.5) / scale;
     return this.contentSize.clone().divideScalar(2).add(this.contentOffset).subScalar(0.5).multiply(this.scale);
   }
 

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -316,6 +316,11 @@ export default class Volume {
     this.physicalUnitSymbol = symbol;
   }
 
+  /** Computes the center of the volume subset */
+  getCenter(): Vector3 {
+    return this.contentSize.clone().divideScalar(2).add(this.contentOffset).subScalar(0.5).multiply(this.scale);
+  }
+
   cleanup(): void {
     // no op
   }

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -163,6 +163,8 @@ export default class Volume {
   public channels: Channel[];
   private volumeDataObservers: VolumeDataObserver[];
   public scale: Vector3;
+  public contentSize: Vector3;
+  public contentOffset: Vector3;
   private physicalSize: Vector3;
   public physicalScale: number;
   public physicalUnitSymbol: string;
@@ -180,6 +182,8 @@ export default class Volume {
     // imageMetadata to be filled in by Volume Loaders
     this.imageMetadata = {};
     this.scale = new Vector3(1, 1, 1);
+    this.contentSize = new Vector3(1, 1, 1);
+    this.contentOffset = new Vector3(0, 0, 0);
     this.physicalSize = new Vector3(1, 1, 1);
     this.physicalScale = 1;
     this.normalizedPhysicalSize = new Vector3(1, 1, 1);
@@ -246,6 +250,22 @@ export default class Volume {
     this.y = this.imageInfo.tile_height;
     this.z = this.imageInfo.tiles;
     this.setVoxelSize(this.pixel_size);
+
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const {
+      tile_width,
+      tile_height,
+      tiles,
+      vol_size_x = tile_width,
+      vol_size_y = tile_height,
+      vol_size_z = tiles,
+      offset_x = 0,
+      offset_y = 0,
+      offset_z = 0,
+    } = this.imageInfo;
+    /* eslint-enable @typescript-eslint/naming-convention */
+    this.contentSize = new Vector3(tile_width / vol_size_x, tile_height / vol_size_y, tiles / vol_size_z);
+    this.contentOffset = new Vector3(offset_x / vol_size_x, offset_y / vol_size_y, offset_z / vol_size_z);
   }
 
   // we calculate the physical size of the volume (voxels*pixel_size)

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -287,9 +287,9 @@ export default class Volume {
       this.pixel_size[2] = values[2];
     }
 
-    const physSizeMin = Math.min(this.pixel_size[0], this.pixel_size[1], this.pixel_size[2]);
-    const pixelsMax = Math.max(this.imageInfo.width, this.imageInfo.height, this.z);
     const sizez = this.imageInfo.vol_size_z || this.z;
+    const physSizeMin = Math.min(this.pixel_size[0], this.pixel_size[1], this.pixel_size[2]);
+    const pixelsMax = Math.max(this.imageInfo.width, this.imageInfo.height, sizez);
     const sx = ((this.pixel_size[0] / physSizeMin) * this.imageInfo.width) / pixelsMax;
     const sy = ((this.pixel_size[1] / physSizeMin) * this.imageInfo.height) / pixelsMax;
     const sz = ((this.pixel_size[2] / physSizeMin) * sizez) / pixelsMax;
@@ -299,7 +299,7 @@ export default class Volume {
     this.physicalSize = new Vector3(
       this.imageInfo.width * this.pixel_size[0],
       this.imageInfo.height * this.pixel_size[1],
-      this.z * this.pixel_size[2]
+      sizez * this.pixel_size[2]
     );
     // Volume is scaled such that its largest physical dimension is 1 world unit - save that dimension for conversions
     this.physicalScale = Math.max(this.physicalSize.x, this.physicalSize.y, this.physicalSize.z);
@@ -311,7 +311,6 @@ export default class Volume {
 
     // sx, sy, sz should be same as normalizedPhysicalSize
     this.scale = new Vector3(sx, sy, sz);
-    console.log(this.scale, this.physicalSize);
   }
 
   setUnitSymbol(symbol: string): void {

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -317,7 +317,7 @@ export default class Volume {
   }
 
   /** Computes the center of the volume subset */
-  getCenter(): Vector3 {
+  getContentCenter(): Vector3 {
     return this.contentSize.clone().divideScalar(2).add(this.contentOffset).subScalar(0.5).multiply(this.scale);
   }
 

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -308,7 +308,7 @@ export default class Volume {
 
   /** Computes the center of the volume subset */
   getContentCenter(): Vector3 {
-    // center point: (contentSize / 2 + contentOffset - 0.5) / scale;
+    // center point: (contentSize / 2 + contentOffset - 0.5) * normalizedPhysicalSize;
     return this.contentSize
       .clone()
       .divideScalar(2)

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -227,7 +227,7 @@ export default class VolumeDrawable {
     this.settings.scale = scale;
     this.settings.contentSize = size;
     this.settings.contentOffset = offset;
-    this.meshVolume.setScale(scale.clone().multiply(size), this.volume.getCenter());
+    this.meshVolume.setScale(scale.clone().multiply(size), this.volume.getContentCenter());
     this.volumeRendering.updateSettings(this.settings, SettingsFlags.DATA_SIZE);
     this.fuse();
   }

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -227,7 +227,7 @@ export default class VolumeDrawable {
     this.settings.scale = scale;
     this.settings.contentSize = size;
     this.settings.contentOffset = offset;
-    this.meshVolume.setScale(scale);
+    this.meshVolume.setScale(scale.clone().multiply(size), this.volume.getCenter());
     this.volumeRendering.updateSettings(this.settings, SettingsFlags.DATA_SIZE);
     this.fuse();
   }

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -216,22 +216,20 @@ export default class VolumeDrawable {
     this.volumeRendering.updateSettings(this.settings, SettingsFlags.SAMPLING);
   }
 
-  setScale(scale: Vector3): void {
-    if (this.settings.scale.equals(scale)) {
+  setScale(scale: Vector3, size = this.settings.contentSize, offset = this.settings.contentOffset): void {
+    if (
+      this.settings.scale.equals(scale) &&
+      this.settings.contentSize.equals(size) &&
+      this.settings.contentOffset.equals(offset)
+    ) {
       return;
     }
     this.settings.scale = scale;
-    this.meshVolume.setScale(scale);
-    this.volumeRendering.updateSettings(this.settings, SettingsFlags.TRANSFORM);
-  }
-
-  setContentPosition(size: Vector3, offset: Vector3): void {
-    if (this.settings.contentSize.equals(size) && this.settings.contentOffset.equals(offset)) {
-      return;
-    }
     this.settings.contentSize = size;
     this.settings.contentOffset = offset;
-    this.volumeRendering.updateSettings(this.settings, SettingsFlags.TRANSFORM);
+    this.meshVolume.setScale(scale);
+    this.volumeRendering.updateSettings(this.settings, SettingsFlags.DATA_SIZE);
+    this.fuse();
   }
 
   setOrthoScale(value: number): void {

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -723,7 +723,8 @@ export default class VolumeDrawable {
   }
 
   setZSlice(slice: number): boolean {
-    if (this.settings.zSlice !== slice && slice < this.volume.z && slice > 0) {
+    const sizez = this.volume.imageInfo.vol_size_z || this.volume.z;
+    if (this.settings.zSlice !== slice && slice < sizez && slice > 0) {
       this.settings.zSlice = slice;
       this.volumeRendering.updateSettings(this.settings, SettingsFlags.ROI);
       return true;

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -221,7 +221,6 @@ export default class VolumeDrawable {
       return;
     }
     this.settings.scale = scale;
-    this.settings.currentScale = scale.clone();
     this.meshVolume.setScale(scale);
     this.volumeRendering.updateSettings(this.settings, SettingsFlags.TRANSFORM);
   }

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -97,7 +97,7 @@ export default class VolumeDrawable {
 
     this.sceneRoot.position.set(0, 0, 0);
 
-    this.setScale(this.volume.scale);
+    this.updateScale();
 
     // apply the volume's default transformation
     this.settings.translation = new Vector3().fromArray(this.volume.getTranslation());
@@ -124,9 +124,6 @@ export default class VolumeDrawable {
       this.setAxisClip(Axis.X, options.clipBounds[0], options.clipBounds[1]);
       this.setAxisClip(Axis.Y, options.clipBounds[2], options.clipBounds[3]);
       this.setAxisClip(Axis.Z, options.clipBounds[4], options.clipBounds[5]);
-    }
-    if (options.scale !== undefined) {
-      this.setScale(new Vector3().fromArray(options.scale));
     }
     if (options.translation !== undefined) {
       this.setTranslation(new Vector3().fromArray(options.translation));
@@ -216,20 +213,10 @@ export default class VolumeDrawable {
     this.volumeRendering.updateSettings(this.settings, SettingsFlags.SAMPLING);
   }
 
-  setScale(scale: Vector3, size = this.settings.contentSize, offset = this.settings.contentOffset): void {
-    if (
-      this.settings.scale.equals(scale) &&
-      this.settings.contentSize.equals(size) &&
-      this.settings.contentOffset.equals(offset)
-    ) {
-      return;
-    }
-    this.settings.scale = scale;
-    this.settings.contentSize = size;
-    this.settings.contentOffset = offset;
-    this.meshVolume.setScale(scale.clone().multiply(size), this.volume.getContentCenter());
-    this.volumeRendering.updateSettings(this.settings, SettingsFlags.DATA_SIZE | SettingsFlags.ROI);
-    this.fuse();
+  updateScale(): void {
+    const { scale, contentSize } = this.volume;
+    this.meshVolume.setScale(scale.clone().multiply(contentSize), this.volume.getContentCenter());
+    this.volumeRendering.updateVolumeDimensions();
   }
 
   setOrthoScale(value: number): void {
@@ -444,7 +431,7 @@ export default class VolumeDrawable {
 
   setVoxelSize(values: number[]): void {
     this.volume.setVoxelSize(values);
-    this.setScale(this.volume.scale);
+    this.updateScale();
   }
 
   cleanup(): void {

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -214,8 +214,8 @@ export default class VolumeDrawable {
   }
 
   updateScale(): void {
-    const { scale, contentSize } = this.volume;
-    this.meshVolume.setScale(scale.clone().multiply(contentSize), this.volume.getContentCenter());
+    const { normalizedPhysicalSize, contentSize } = this.volume;
+    this.meshVolume.setScale(normalizedPhysicalSize.clone().multiply(contentSize), this.volume.getContentCenter());
     this.volumeRendering.updateVolumeDimensions();
   }
 

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -228,7 +228,7 @@ export default class VolumeDrawable {
     this.settings.contentSize = size;
     this.settings.contentOffset = offset;
     this.meshVolume.setScale(scale.clone().multiply(size), this.volume.getContentCenter());
-    this.volumeRendering.updateSettings(this.settings, SettingsFlags.DATA_SIZE);
+    this.volumeRendering.updateSettings(this.settings, SettingsFlags.DATA_SIZE | SettingsFlags.ROI);
     this.fuse();
   }
 

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -217,12 +217,21 @@ export default class VolumeDrawable {
   }
 
   setScale(scale: Vector3): void {
-    if (this.settings.scale === scale) {
+    if (this.settings.scale.equals(scale)) {
       return;
     }
     this.settings.scale = scale;
     this.settings.currentScale = scale.clone();
     this.meshVolume.setScale(scale);
+    this.volumeRendering.updateSettings(this.settings, SettingsFlags.TRANSFORM);
+  }
+
+  setContentPosition(size: Vector3, offset: Vector3): void {
+    if (this.settings.contentSize.equals(size) && this.settings.contentOffset.equals(offset)) {
+      return;
+    }
+    this.settings.contentSize = size;
+    this.settings.contentOffset = offset;
     this.volumeRendering.updateSettings(this.settings, SettingsFlags.TRANSFORM);
   }
 

--- a/src/VolumeRenderImpl.ts
+++ b/src/VolumeRenderImpl.ts
@@ -17,6 +17,7 @@ export interface VolumeRenderImpl {
 
   get3dObject: () => Object3D;
   doRender: (_canvas: ThreeJsPanel) => void;
+  updateVolumeDimensions: () => void;
   cleanup: () => void;
   viewpointMoved: () => void;
   setRenderUpdateListener: (_listener?: (iteration: number) => void) => void;

--- a/src/VolumeRenderSettings.ts
+++ b/src/VolumeRenderSettings.ts
@@ -6,23 +6,25 @@ import { Bounds } from "./types";
  * Marks groups of related settings that may have changed.
  */
 export enum SettingsFlags {
-  /** parameters: translation, rotation, scale, contentSize, contentOffset, flipAxes */
-  TRANSFORM = 0b00000001,
+  /** parameters: translation, rotation, flipAxes */
+  TRANSFORM = 0b000000001,
   /** parameters: gammaMin, gammaLevel, gammaMax, brightness*/
-  CAMERA = 0b00000010,
+  CAMERA = 0b000000010,
   /** parameters: showBoundingBox, boundingBoxColor */
-  BOUNDING_BOX = 0b00000100,
+  BOUNDING_BOX = 0b000000100,
   /** parameters: bounds, zSlice */
-  ROI = 0b00001000,
+  ROI = 0b000001000,
   /** parameters: maskChannelIndex, maskAlpha */
-  MASK = 0b00010000,
+  MASK = 0b000010000,
   /** parameters: density, specular, emissive, glossiness */
-  MATERIAL = 0b00100000,
+  MATERIAL = 0b000100000,
   /** parameters: resolution, useInterpolation, pixelSamplingRate, primaryRayStepSize, secondaryRayStepSize*/
-  SAMPLING = 0b01000000,
+  SAMPLING = 0b001000000,
   /** parameters: isOrtho, orthoScale, viewAxis, visible, maxProjectMode */
-  VIEW = 0b10000000,
-  ALL = 0b11111111,
+  VIEW = 0b010000000,
+  /** parameters: scale, contentSize, contentOffset */
+  DATA_SIZE = 0b100000000,
+  ALL = 0b111111111,
 }
 
 export enum Axis {

--- a/src/VolumeRenderSettings.ts
+++ b/src/VolumeRenderSettings.ts
@@ -6,7 +6,7 @@ import { Bounds } from "./types";
  * Marks groups of related settings that may have changed.
  */
 export enum SettingsFlags {
-  /** parameters: translation, rotation, scale, currentScale, contentSize, contentOffset, flipAxes */
+  /** parameters: translation, rotation, scale, contentSize, contentOffset, flipAxes */
   TRANSFORM = 0b00000001,
   /** parameters: gammaMin, gammaLevel, gammaMax, brightness*/
   CAMERA = 0b00000010,
@@ -45,7 +45,6 @@ export class VolumeRenderSettings {
   public scale: Vector3;
   public contentSize: Vector3;
   public contentOffset: Vector3;
-  public currentScale: Vector3;
   public flipAxes: Vector3;
 
   // VIEW
@@ -95,7 +94,6 @@ export class VolumeRenderSettings {
     this.scale = new Vector3(1, 1, 1);
     this.contentSize = new Vector3(1, 1, 1);
     this.contentOffset = new Vector3(0, 0, 0);
-    this.currentScale = new Vector3(1, 1, 1);
     this.isOrtho = false;
     this.viewAxis = Axis.NONE;
     this.orthoScale = 1.0;

--- a/src/VolumeRenderSettings.ts
+++ b/src/VolumeRenderSettings.ts
@@ -6,7 +6,7 @@ import { Bounds } from "./types";
  * Marks groups of related settings that may have changed.
  */
 export enum SettingsFlags {
-  /** parameters: translation, rotation, scale, currentScale, flipAxes */
+  /** parameters: translation, rotation, scale, currentScale, contentSize, contentOffset, flipAxes */
   TRANSFORM = 0b00000001,
   /** parameters: gammaMin, gammaLevel, gammaMax, brightness*/
   CAMERA = 0b00000010,
@@ -43,6 +43,8 @@ export class VolumeRenderSettings {
   public translation: Vector3;
   public rotation: Euler;
   public scale: Vector3;
+  public contentSize: Vector3;
+  public contentOffset: Vector3;
   public currentScale: Vector3;
   public flipAxes: Vector3;
 
@@ -91,6 +93,8 @@ export class VolumeRenderSettings {
     this.translation = new Vector3(0, 0, 0);
     this.rotation = new Euler();
     this.scale = new Vector3(1, 1, 1);
+    this.contentSize = new Vector3(1, 1, 1);
+    this.contentOffset = new Vector3(0, 0, 0);
     this.currentScale = new Vector3(1, 1, 1);
     this.isOrtho = false;
     this.viewAxis = Axis.NONE;

--- a/src/VolumeRenderSettings.ts
+++ b/src/VolumeRenderSettings.ts
@@ -7,23 +7,21 @@ import { Bounds } from "./types";
  */
 export enum SettingsFlags {
   /** parameters: translation, rotation, flipAxes */
-  TRANSFORM = 0b000000001,
+  TRANSFORM = 0b00000001,
   /** parameters: gammaMin, gammaLevel, gammaMax, brightness*/
-  CAMERA = 0b000000010,
+  CAMERA = 0b00000010,
   /** parameters: showBoundingBox, boundingBoxColor */
-  BOUNDING_BOX = 0b000000100,
+  BOUNDING_BOX = 0b00000100,
   /** parameters: bounds, zSlice */
-  ROI = 0b000001000,
+  ROI = 0b00001000,
   /** parameters: maskChannelIndex, maskAlpha */
-  MASK = 0b000010000,
+  MASK = 0b00010000,
   /** parameters: density, specular, emissive, glossiness */
-  MATERIAL = 0b000100000,
+  MATERIAL = 0b00100000,
   /** parameters: resolution, useInterpolation, pixelSamplingRate, primaryRayStepSize, secondaryRayStepSize*/
-  SAMPLING = 0b001000000,
+  SAMPLING = 0b01000000,
   /** parameters: isOrtho, orthoScale, viewAxis, visible, maxProjectMode */
-  VIEW = 0b010000000,
-  /** parameters: scale, contentSize, contentOffset */
-  DATA_SIZE = 0b100000000,
+  VIEW = 0b10000000,
   ALL = 0b111111111,
 }
 
@@ -44,9 +42,6 @@ export class VolumeRenderSettings {
   // TRANSFORM
   public translation: Vector3;
   public rotation: Euler;
-  public scale: Vector3;
-  public contentSize: Vector3;
-  public contentOffset: Vector3;
   public flipAxes: Vector3;
 
   // VIEW
@@ -93,9 +88,6 @@ export class VolumeRenderSettings {
   constructor(volume?: Volume) {
     this.translation = new Vector3(0, 0, 0);
     this.rotation = new Euler();
-    this.scale = new Vector3(1, 1, 1);
-    this.contentSize = new Vector3(1, 1, 1);
-    this.contentOffset = new Vector3(0, 0, 0);
     this.isOrtho = false;
     this.viewAxis = Axis.NONE;
     this.orthoScale = 1.0;

--- a/src/constants/shaders/pathtrace.frag
+++ b/src/constants/shaders/pathtrace.frag
@@ -58,6 +58,7 @@ uniform Light gLights[2];
 
 uniform vec3 gClippedAaBbMin;
 uniform vec3 gClippedAaBbMax;
+uniform vec3 gVolCenter;
 uniform float gDensityScale;
 uniform float gStepSize;
 uniform float gStepSizeShadow;
@@ -258,7 +259,7 @@ bool IntersectBox(in Ray R, out float pNearT, out float pFarT)
 // transform p to range from 0,0,0 to 1,1,1 for volume texture sampling.
 // optionally invert axes
 vec3 PtoVolumeTex(vec3 p) {
-  vec3 uvw = p*gInvAaBbMax + vec3(0.5, 0.5, 0.5);
+  vec3 uvw = (p - gVolCenter) * gInvAaBbMax + vec3(0.5, 0.5, 0.5);
   // if flipVolume = 1, uvw is unchanged.
   // if flipVolume = -1, uvw = 1 - uvw
   uvw = (flipVolume*(uvw - 0.5) + 0.5);

--- a/src/constants/shaders/raymarch.frag
+++ b/src/constants/shaders/raymarch.frag
@@ -221,7 +221,7 @@ vec4 integrateVolume(vec4 eye_o,vec4 eye_d,
     // scaling is handled by model transform and already accounted for before we get here.
     // AABB clip is independent of this and is only used to determine tnear and tfar.
     pos.xyz = (pos.xyz-(-0.5))/((0.5)-(-0.5)); //0.5 * (pos + 1.0); // map position from [boxMin, boxMax] to [0, 1] coordinates
-    pos.xyz = (pos.xyz - SUBSET_OFFSET) / SUBSET_SCALE;
+    // pos.xyz = (pos.xyz - SUBSET_OFFSET) / SUBSET_SCALE;
 
     vec4 col = interpolationEnabled ? sampleAtlasLinear(textureAtlas, pos) : sampleAtlasNearest(textureAtlas, pos);
 

--- a/src/constants/shaders/raymarch.frag
+++ b/src/constants/shaders/raymarch.frag
@@ -19,6 +19,8 @@ uniform vec3 AABB_CLIP_MIN;
 uniform float CLIP_NEAR;
 uniform vec3 AABB_CLIP_MAX;
 uniform float CLIP_FAR;
+uniform vec3 SUBSET_SCALE;
+uniform vec3 SUBSET_OFFSET;
 uniform sampler2D textureAtlas;
 uniform sampler2D textureAtlasMask;
 uniform int BREAK_STEPS;
@@ -213,12 +215,13 @@ vec4 integrateVolume(vec4 eye_o,vec4 eye_d,
   // in order to make the final color invariant to the step size(?)
   // use maxSteps (a constant) as the numerator... Not sure if this is sound.
   float s = 0.5 * float(maxSteps) / csteps;
-  for(int i=0; i<maxSteps; i++) {
+  for (int i = 0; i < maxSteps; i++) {
     pos = eye_o + eye_d*t;
     // !!! assume box bounds are -0.5 .. 0.5.  pos = (pos-min)/(max-min)
     // scaling is handled by model transform and already accounted for before we get here.
     // AABB clip is independent of this and is only used to determine tnear and tfar.
     pos.xyz = (pos.xyz-(-0.5))/((0.5)-(-0.5)); //0.5 * (pos + 1.0); // map position from [boxMin, boxMax] to [0, 1] coordinates
+    pos.xyz = (pos.xyz - SUBSET_OFFSET) / SUBSET_SCALE;
 
     vec4 col = interpolationEnabled ? sampleAtlasLinear(textureAtlas, pos) : sampleAtlasNearest(textureAtlas, pos);
 

--- a/src/constants/shaders/raymarch.frag
+++ b/src/constants/shaders/raymarch.frag
@@ -19,8 +19,6 @@ uniform vec3 AABB_CLIP_MIN;
 uniform float CLIP_NEAR;
 uniform vec3 AABB_CLIP_MAX;
 uniform float CLIP_FAR;
-uniform vec3 SUBSET_SCALE;
-uniform vec3 SUBSET_OFFSET;
 uniform sampler2D textureAtlas;
 uniform sampler2D textureAtlasMask;
 uniform int BREAK_STEPS;
@@ -221,7 +219,6 @@ vec4 integrateVolume(vec4 eye_o,vec4 eye_d,
     // scaling is handled by model transform and already accounted for before we get here.
     // AABB clip is independent of this and is only used to determine tnear and tfar.
     pos.xyz = (pos.xyz-(-0.5))/((0.5)-(-0.5)); //0.5 * (pos + 1.0); // map position from [boxMin, boxMax] to [0, 1] coordinates
-    // pos.xyz = (pos.xyz - SUBSET_OFFSET) / SUBSET_SCALE;
 
     vec4 col = interpolationEnabled ? sampleAtlasLinear(textureAtlas, pos) : sampleAtlasNearest(textureAtlas, pos);
 

--- a/src/constants/shaders/slice.frag
+++ b/src/constants/shaders/slice.frag
@@ -14,6 +14,8 @@ uniform float ATLAS_X;
 uniform float ATLAS_Y;
 uniform vec3 AABB_CLIP_MIN;
 uniform vec3 AABB_CLIP_MAX;
+uniform vec3 SUBSET_SCALE;
+uniform vec3 SUBSET_OFFSET;
 uniform sampler2D textureAtlas;
 uniform sampler2D textureAtlasMask;
 uniform int Z_SLICE;
@@ -131,6 +133,7 @@ void main() {
 
   // Normalize z-slice by total slices
   vec4 pos = vec4(vUv, float(Z_SLICE) / (SLICES - 1.0), 0.0);
+  pos.xyz = (pos.xyz - SUBSET_OFFSET) / SUBSET_SCALE;
 
   vec4 C;
   if(interpolationEnabled) {

--- a/src/constants/volumePTshader.ts
+++ b/src/constants/volumePTshader.ts
@@ -24,6 +24,7 @@ export const pathTracingUniforms = () => {
     ///////////////////////////
     gClippedAaBbMin: { type: "v3", value: new Vector3(0, 0, 0) },
     gClippedAaBbMax: { type: "v3", value: new Vector3(1, 1, 1) },
+    gVolCenter: { type: "v3", value: new Vector3(0, 0, 0) },
     gDensityScale: { type: "f", value: 50.0 },
     gStepSize: { type: "f", value: 1.0 },
     gStepSizeShadow: { type: "f", value: 1.0 },

--- a/src/constants/volumeRayMarchShader.ts
+++ b/src/constants/volumeRayMarchShader.ts
@@ -79,14 +79,6 @@ export const rayMarchingShaderUniforms = () => {
       type: "v3",
       value: new Vector3(0.5, 0.5, 0.5),
     },
-    SUBSET_SCALE: {
-      type: "v3",
-      value: new Vector3(1, 1, 1),
-    },
-    SUBSET_OFFSET: {
-      type: "v3",
-      value: new Vector3(0, 0, 0),
-    },
     inverseModelViewMatrix: {
       type: "m4",
       value: new Matrix4(),

--- a/src/constants/volumeRayMarchShader.ts
+++ b/src/constants/volumeRayMarchShader.ts
@@ -79,6 +79,14 @@ export const rayMarchingShaderUniforms = () => {
       type: "v3",
       value: new Vector3(0.5, 0.5, 0.5),
     },
+    SUBSET_SCALE: {
+      type: "v3",
+      value: new Vector3(1, 1, 1),
+    },
+    SUBSET_OFFSET: {
+      type: "v3",
+      value: new Vector3(0, 0, 0),
+    },
     inverseModelViewMatrix: {
       type: "m4",
       value: new Matrix4(),

--- a/src/constants/volumeSliceShader.ts
+++ b/src/constants/volumeSliceShader.ts
@@ -84,6 +84,14 @@ export const sliceShaderUniforms = () => {
       type: "v3",
       value: new Vector3(0.5, 0.5, 0.5),
     },
+    SUBSET_SCALE: {
+      type: "v3",
+      value: new Vector3(1, 1, 1),
+    },
+    SUBSET_OFFSET: {
+      type: "v3",
+      value: new Vector3(0, 0, 0),
+    },
     inverseModelViewMatrix: {
       type: "m4",
       value: new Matrix4(),

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -77,6 +77,12 @@ export function fitLoadSpecRegionToExtent<T extends Partial<LoadSpecExtent>>(
   };
 }
 
+export const getExtentSize = (extent: LoadSpecExtent): [number, number, number] => [
+  extent.maxx - extent.minx,
+  extent.maxy - extent.miny,
+  extent.maxz - extent.minz,
+];
+
 export class VolumeDims {
   subpath = "";
   // shape: [t, c, z, y, x]

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -35,12 +35,12 @@ export function convertLoadSpecRegionToPixels<T extends Partial<LoadSpecExtent>>
   sizey: number,
   sizez: number
 ): T & LoadSpecExtent {
-  const minx = loadSpec.minx ? Math.floor(sizex * loadSpec.minx) : 0;
-  let maxx = loadSpec.maxx ? Math.ceil(sizex * loadSpec.maxx) : sizex;
-  const miny = loadSpec.miny ? Math.floor(sizey * loadSpec.miny) : 0;
-  let maxy = loadSpec.maxy ? Math.ceil(sizey * loadSpec.maxy) : sizey;
-  const minz = loadSpec.minz ? Math.floor(sizez * loadSpec.minz) : 0;
-  let maxz = loadSpec.maxz ? Math.ceil(sizez * loadSpec.maxz) : sizez;
+  const minx = loadSpec.minx !== undefined ? Math.floor(sizex * loadSpec.minx) : 0;
+  let maxx = loadSpec.maxx !== undefined ? Math.ceil(sizex * loadSpec.maxx) : sizex;
+  const miny = loadSpec.miny !== undefined ? Math.floor(sizey * loadSpec.miny) : 0;
+  let maxy = loadSpec.maxy !== undefined ? Math.ceil(sizey * loadSpec.maxy) : sizey;
+  const minz = loadSpec.minz !== undefined ? Math.floor(sizez * loadSpec.minz) : 0;
+  let maxz = loadSpec.maxz !== undefined ? Math.ceil(sizez * loadSpec.maxz) : sizez;
 
   // ensure it's always valid to specify the same number at both ends and get a single slice
   if (minx === maxx && minx < sizex) {

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -42,7 +42,9 @@ export class VolumeDims {
   shape: number[] = [0, 0, 0, 0, 0];
   // spacing: [t, c, z, y, x]; generally expect 1 for non-spatial dimensions
   spacing: number[] = [1, 1, 1, 1, 1];
-  spatialUnit = "micron";
+  spaceUnit = "μm";
+  timeUnit = "s";
+  // TODO make this an enum?
   dataType = "uint8";
 }
 

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -6,6 +6,7 @@ export class LoadSpec {
   scene = 0;
   time = 0;
   // sub-region; if not specified, the entire volume is loaded
+  // specify as floats between 0 and 1
   minx?: number;
   miny?: number;
   minz?: number;
@@ -16,6 +17,23 @@ export class LoadSpec {
   toString(): string {
     return `${this.url}:${this.subpath}${this.scene}:${this.time}:x(${this.minx},${this.maxx}):y(${this.miny},${this.maxy}):z(${this.minz},${this.maxz})`;
   }
+}
+
+/** Converts `LoadSpec` sub-region fields (`minx`, `maxy`, etc.) from 0-1 range to pixels */
+export function convertLoadSpecRegionToPixels(
+  loadSpec: LoadSpec,
+  sizex: number,
+  sizey: number,
+  sizez: number
+): Required<LoadSpec> {
+  const minx = loadSpec.minx ? Math.floor(sizex * loadSpec.minx) : 0;
+  const maxx = loadSpec.maxx ? Math.ceil(sizex * loadSpec.maxx) : sizex;
+  const miny = loadSpec.miny ? Math.floor(sizey * loadSpec.miny) : 0;
+  const maxy = loadSpec.maxy ? Math.ceil(sizey * loadSpec.maxy) : sizey;
+  const minz = loadSpec.minz ? Math.floor(sizez * loadSpec.minz) : 0;
+  const maxz = loadSpec.maxz ? Math.ceil(sizez * loadSpec.maxz) : sizez;
+
+  return { ...loadSpec, minx, maxx, miny, maxy, minz, maxz };
 }
 
 export class VolumeDims {

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -34,7 +34,7 @@ class JsonImageInfoLoader implements IVolumeLoader {
     d.subpath = "";
     d.shape = [imageInfo.times, imageInfo.channels, imageInfo.tiles, imageInfo.tile_height, imageInfo.tile_width];
     d.spacing = [1, 1, imageInfo.pixel_size_z, imageInfo.pixel_size_y, imageInfo.pixel_size_x];
-    d.spatialUnit = imageInfo.pixel_size_unit;
+    d.spaceUnit = imageInfo.pixel_size_unit;
     d.dataType = "uint8";
     return [d];
   }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -426,12 +426,13 @@ class OMEZarrLoader implements IVolumeLoader {
       tile_width: tw,
       tile_height: th,
       tiles: tz,
-      vol_size_x: vx,
-      vol_size_y: vy,
-      vol_size_z: vz,
       offset_x: offset.minx,
       offset_y: offset.miny,
       offset_z: offset.minz,
+      // scale level may have changed
+      vol_size_x: vx,
+      vol_size_y: vy,
+      vol_size_z: vz,
     };
     /* eslint-enable @typescript-eslint/naming-convention */
     vol.updateDimensions();

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -358,7 +358,7 @@ class OMEZarrLoader implements IVolumeLoader {
     return vol;
   }
 
-  loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback, explicitLoadSpec?: LoadSpec) {
+  loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback, explicitLoadSpec?: LoadSpec): void {
     if (
       this.axesTCZYX === undefined ||
       this.metadata === undefined ||

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -407,11 +407,11 @@ class OMEZarrLoader implements IVolumeLoader {
       const msg: FetchZarrMessage = {
         spec: {
           ...pxSpec,
-          time: this.axesTCZYX[0] > -1 ? Math.min(normLoadSpec.time, times) : -1,
+          time: Math.min(normLoadSpec.time, times),
         },
-        channel: this.axesTCZYX[1] > -1 ? i : -1,
+        channel: i,
         path: storepath,
-        axesZYX: this.axesTCZYX.slice(-3),
+        axesTCZYX: this.axesTCZYX,
       };
       worker.postMessage(msg);
     }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -297,12 +297,10 @@ class OMEZarrLoader implements IVolumeLoader {
       rows: nrows,
       cols: ncols,
       tiles: tz,
+      // for webgl reasons, it is best for total atlas width and height to be <= 2048 and ideally a power of 2.
+      //   This generally implies downsampling the original volume data for display in this viewer.
       tile_width: tw,
       tile_height: th,
-      // for webgl reasons, it is best for atlas_width and atlas_height to be <= 2048
-      // and ideally a power of 2.  This generally implies downsampling the original volume data for display in this viewer.
-      atlas_width: atlaswidth,
-      atlas_height: atlasheight,
       pixel_size_x: scale5d[spatialAxes[2]],
       pixel_size_y: scale5d[spatialAxes[1]],
       pixel_size_z: scale5d[spatialAxes[0]],

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -186,9 +186,11 @@ function pickLevelToLoad(
   const zSize = maxz - minz;
   const [zi, yi, xi] = dimIndexes.slice(-3);
 
-  const spatialDims = multiscaleDims.map((shape) => {
-    return [shape[zi] * zSize, shape[yi] * ySize, shape[xi] * xSize];
-  });
+  const spatialDims = multiscaleDims.map((shape) => [
+    Math.max(shape[zi] * zSize, 1),
+    Math.max(shape[yi] * ySize, 1),
+    Math.max(shape[xi] * xSize, 1),
+  ]);
   const optimalLevel = estimateLevelForAtlas(spatialDims, MAX_ATLAS_DIMENSION);
   // assume all levels are decreasing in size.  If a larger level is optimal then use it:
   if (optimalLevel < levelToLoad) {

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -10,7 +10,7 @@ class OpenCellLoader implements IVolumeLoader {
     d.subpath = "";
     d.shape = [1, 2, 27, 600, 600];
     d.spacing = [1, 1, 2, 1, 1];
-    d.spatialUnit = ""; // unknown unit.
+    d.spaceUnit = ""; // unknown unit.
     d.dataType = "uint8";
     return [d];
   }

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -30,12 +30,10 @@ class OpenCellLoader implements IVolumeLoader {
       rows: 27,
       cols: 1,
       tiles: 27,
+      // for webgl reasons, it is best for total atlas width and height to be <= 2048 and ideally a power of 2.
+      //   This generally implies downsampling the original volume data for display in this viewer.
       tile_width: 600,
       tile_height: 600,
-      // for webgl reasons, it is best for atlas_width and atlas_height to be <= 2048
-      // and ideally a power of 2.  This generally implies downsampling the original volume data for display in this viewer.
-      atlas_width: 600,
-      atlas_height: 16200,
       pixel_size_x: 1,
       pixel_size_y: 1,
       pixel_size_z: 2,

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -96,7 +96,7 @@ class TiffLoader implements IVolumeLoader {
     d.subpath = "";
     d.shape = [dims.sizet, dims.sizec, dims.sizez, dims.sizey, dims.sizex];
     d.spacing = [1, 1, dims.pixelsizez, dims.pixelsizey, dims.pixelsizex];
-    d.spatialUnit = dims.unit ? dims.unit : "micron";
+    d.spaceUnit = dims.unit ? dims.unit : "micron";
     d.dataType = dims.pixeltype ? dims.pixeltype : "uint8";
     return [d];
   }

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -123,15 +123,13 @@ class TiffLoader implements IVolumeLoader {
       height: dims.sizey,
       channels: dims.sizec,
       channel_names: dims.channelnames,
+      // for webgl reasons, it is best for total atlas width and height to be <= 2048 and ideally a power of 2.
+      //   This generally implies downsampling the original volume data for display in this viewer.
       rows: nrows,
       cols: ncols,
       tiles: dims.sizez,
       tile_width: tilesizex,
       tile_height: tilesizey,
-      // for webgl reasons, it is best for atlas_width and atlas_height to be <= 2048
-      // and ideally a power of 2.  This generally implies downsampling the original volume data for display in this viewer.
-      atlas_width: tilesizex * ncols,
-      atlas_height: tilesizey * nrows,
       pixel_size_x: dims.pixelsizex,
       pixel_size_y: dims.pixelsizey,
       pixel_size_z: dims.pixelsizez,

--- a/src/test/volume.test.js
+++ b/src/test/volume.test.js
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { Vector3 } from "three";
 
 import Volume from "../Volume";
 import VolumeMaker from "../VolumeMaker";
@@ -67,11 +68,6 @@ function checkVolumeConstruction(v, imgdata) {
   const mx = Math.max(Math.max(v.normalizedPhysicalSize.x, v.normalizedPhysicalSize.y), v.normalizedPhysicalSize.z);
   expect(mx).to.equal(1.0);
 
-  const epsilon = 0.0000001;
-  expect(v.scale.x).to.be.closeTo(v.normalizedPhysicalSize.x, epsilon);
-  expect(v.scale.y).to.be.closeTo(v.normalizedPhysicalSize.y, epsilon);
-  expect(v.scale.z).to.be.closeTo(v.normalizedPhysicalSize.z, epsilon);
-
   expect(v.x).to.equal(imgdata.tile_width);
   expect(v.y).to.equal(imgdata.tile_height);
   expect(v.z).to.equal(imgdata.tiles);
@@ -113,6 +109,30 @@ describe("test volume", () => {
 
       expect(v.getIntensity(1, Math.floor(v.x / 2), Math.floor(v.y / 2), Math.floor(v.z / 2))).to.equal(255);
       expect(v.getIntensity(1, 0, 0, 0)).to.equal(0);
+    });
+  });
+
+  describe("property validation", () => {
+    it("has a correct value for normalizedPhysicalSize", () => {
+      // `Volume` formerly derived a `scale` property by a different means than `normalizedPhysicalSize`, but depended
+      // on `scale` and `normalizedPhysicalSize` being equal. With `scale` gone, this test ensures the equality stays.
+      const v = new Volume(testimgdata);
+      /* eslint-disable-next-line @typescript-eslint/naming-convention */
+      const { height, width, vol_size_z, tiles } = v.imageInfo;
+      const sizez = vol_size_z || tiles;
+      const sizemax = Math.max(height, width, sizez);
+
+      const [pxx, pxy, pxz] = v.pixel_size;
+      const pxmin = Math.min(pxx, pxy, pxz);
+
+      const sx = ((pxx / pxmin) * width) / sizemax;
+      const sy = ((pxy / pxmin) * height) / sizemax;
+      const sz = ((pxz / pxmin) * sizez) / sizemax;
+
+      const EPSILON = 0.000000001;
+      expect(v.normalizedPhysicalSize.x).to.be.closeTo(sx, EPSILON);
+      expect(v.normalizedPhysicalSize.y).to.be.closeTo(sy, EPSILON);
+      expect(v.normalizedPhysicalSize.z).to.be.closeTo(sz, EPSILON);
     });
   });
 });

--- a/src/test/volume.test.js
+++ b/src/test/volume.test.js
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import { Vector3 } from "three";
 
 import Volume from "../Volume";
 import VolumeMaker from "../VolumeMaker";

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,6 @@ export interface VolumeDisplayOptions {
   maskChannelIndex?: number;
   maskAlpha?: number;
   clipBounds?: [number, number, number, number, number, number];
-  scale?: [number, number, number];
   maxProjection?: boolean;
   renderMode?: RenderMode;
   shadingMethod?: number;

--- a/src/workers/FetchTiffWorker.ts
+++ b/src/workers/FetchTiffWorker.ts
@@ -115,5 +115,5 @@ self.onmessage = async function (e) {
     out[j] = ((src[j] - chmin) / (chmax - chmin)) * 255;
   }
   const results = { data: out, channel: channelIndex };
-  postMessage(results, [results.data.buffer]);
+  (self as unknown as Worker).postMessage(results, [results.data.buffer]);
 };

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -1,6 +1,7 @@
 import { HTTPStore, openArray, slice, TypedArray } from "zarr";
 import { RawArray } from "zarr/types/rawArray";
 import { Slice } from "zarr/types/core/types";
+
 import { LoadSpec, convertLoadSpecRegionToPixels } from "../loaders/IVolumeLoader";
 
 export type FetchZarrMessage = {

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -8,7 +8,7 @@ export type FetchZarrMessage = {
   spec: LoadSpec;
   channel: number;
   path: string;
-  axesZYX: [number, number, number];
+  axesZYX: number[];
 };
 
 function convertChannel(channelData: TypedArray, dtype: string): Uint8Array {

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -60,5 +60,5 @@ self.onmessage = async (e: MessageEvent<FetchZarrMessage>) => {
 
   const u8 = convertChannel(channel.data, channel.dtype);
   const results = { data: u8, channel: channelIndex === -1 ? 0 : channelIndex };
-  postMessage(results, [results.data.buffer]);
+  (self as unknown as Worker).postMessage(results, [results.data.buffer]);
 };

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -2,10 +2,10 @@ import { HTTPStore, openArray, slice, TypedArray } from "zarr";
 import { RawArray } from "zarr/types/rawArray";
 import { Slice } from "zarr/types/core/types";
 
-import { LoadSpec, convertLoadSpecRegionToPixels } from "../loaders/IVolumeLoader";
+import { LoadSpec } from "../loaders/IVolumeLoader";
 
 export type FetchZarrMessage = {
-  spec: LoadSpec;
+  spec: Required<LoadSpec>;
   channel: number;
   path: string;
   axesZYX: number[];
@@ -42,10 +42,7 @@ self.onmessage = async (e: MessageEvent<FetchZarrMessage>) => {
   const level = await openArray({ store: store, path: e.data.path, mode: "r" });
 
   // build slice spec
-  const [iz, iy, ix] = e.data.axesZYX;
-  const { shape } = level.meta;
-  const pxSpec = convertLoadSpecRegionToPixels(e.data.spec, shape[ix], shape[iy], shape[iz]);
-  const { minx, maxx, miny, maxy, minz, maxz } = pxSpec;
+  const { minx, maxx, miny, maxy, minz, maxz } = e.data.spec;
   // assuming ZYX are the last three dimensions:
   // TODO spatial dimension indexes are now avaliable to the worker. use those?
   const sliceSpec: (Slice | number)[] = [slice(minz, maxz), slice(miny, maxy), slice(minx, maxx)];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,17 +15,8 @@
     "sourceMap": true,
     "strict": true,
     "target": "ES6",
-    "typeRoots": ["src/types", "node_modules/@types"],
+    "typeRoots": ["src/types", "node_modules/@types"]
   },
-  "files": [
-    "src/index.ts",
-    "public/index.ts"
-  ],
-  "include": [
-    "src/**/*",
-    "public/**/*"
-  ],
-  "exclude": [
-    "src/workers/**/*",
-  ]
+  "files": ["src/index.ts", "public/index.ts"],
+  "include": ["src/**/*", "public/**/*"]
 }


### PR DESCRIPTION
Adds support for volumes which contain a subset of their full source data, and enables `OMEZarrLoader` to take advantage of these features. This enables several future optimizations, most immediately the ability to load single slices (resolves #110).

### Changes to `OmeZarrLoader`

- `OmeZarrLoader` is now *stateful*: it caches information on its data source (multiscale sizes, metadata, etc.) when `createVolume` is called and assumes that `loadVolumeData` will only be called on this source.
- `createVolume` now also treats the extent fields of `LoadSpec` (`minx`, `maxy`, etc.) differently to `loadVolumeData`.
  - Fields passed into `createVolume` define the size of the `Volume` object relative to the size of the data source, and are cached for use in `loadVolumeData`. This could be used, for example, to load single cell views directly out of full field zarr images.
  - Fields passed into `loadVolumeData` define the size of the subset relative to the volume, as in the screenshot below.
- As before, `createVolume` and `loadVolumeData` pick a scale level based on a fixed memory limitation. This means requesting a smaller subset may mean automatically loading a larger scale level. Extent fields are therefore floats in the range 0-1 rather than pixel values to remain agnostic of scale level.

### Changes to `Volume`

Volumes are still assumed to have a fixed total size (i.e. the size of their bounding box), but may contain a smaller chunk of actual volume data. This chunk will be packed densely into the texture (that is, without inserting gaps to fill the entire volume). This works like this:
- The `ImageInfo` interface has new fields: `vol_size_`(`x`/`y`/`z`), which represents the total size of the volume; and `offset_`(`x`/`y`/`z`), which represents the offset of the subset into the total volume area. For backwards compatibility with `JsonImageInfoLoader`, which loads `ImageInfo` objects and atlased textures directly from a remote source, these new fields are optional. When not specified, `vol_size` fields default to the values of `tile_width`, `tile_height`, and `tiles`, which represent the size of the data; and `offset` fields default to 0.
- While I was there, I added docstrings to all `ImageInfo` fields for clarity, and removed the derivable `atlas_width` and `atlas_height` properties.
- When `ImageInfo` is updated, `Volume` derives new properties, all `Vector3`s in the range 0-1: `contentSize` and `contentOffset`, and the function `getContentCenter` which calculates the center point of the subset.
- `VolumeRenderImpl`s use the above fields to show volumes with subsets properly.

### Steps to verify

I tested this by manually modifying the `LoadSpec` in the test app. The place to do this is in public/index.ts, in `loadVolume`, between `loader.createVolume` and `loader.loadVolumeData` (line 1160). Drop some lines like `loadSpec.maxy = 0.9;` in there and see what happens. It's possible I could modify the dat.gui or tweakpane UI to add some reload capability and make testing easier, but I didn't consider it worth working out how that would work at the moment.

Note that, because channels load one at a time, doing a load of a different extent into a volume briefly puts the volume into a state where the dimensions of some channels don't align with the dimensions of the volume. This isn't ideal, but I didn't find this to be too disruptive in my testing. There's plenty we could do down the line to mitigate this effect, but I considered it out of scope for now.

### Screenshots

![image](https://github.com/allen-cell-animated/volume-viewer/assets/53030214/d8e96f03-f621-449c-888e-6cf74e5a1859)
![image](https://github.com/allen-cell-animated/volume-viewer/assets/53030214/0cc7af57-34e2-4939-a29f-66cb9d0e62b3)
