### PR TITLE
Subregion type part 2: `VolumeCache`

### DIFF
--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -48,18 +48,20 @@ function applyDefaultsToRegion(region: Box3 | undefined, size: Vector3): Box3 {
     return new Box3(new Vector3(), size.clone());
   }
 
-  const min = new Vector3(
-    isFinite(region.min.x) ? region.min.x : 0,
-    isFinite(region.min.y) ? region.min.y : 0,
-    isFinite(region.min.z) ? region.min.z : 0
+  const { min, max } = region;
+
+  const newMin = new Vector3(
+    isFinite(min.x) && min.x >= 0 ? min.x : 0,
+    isFinite(min.y) && min.y >= 0 ? min.y : 0,
+    isFinite(min.z) && min.z >= 0 ? min.z : 0
   );
-  const max = new Vector3(
-    region.max.x > 0 ? region.max.x : size.x,
-    region.max.y > 0 ? region.max.y : size.y,
-    region.max.z > 0 ? region.max.z : size.z
+  const newMax = new Vector3(
+    isFinite(max.x) && max.x > 0 ? max.x : size.x,
+    isFinite(max.y) && max.y > 0 ? max.y : size.y,
+    isFinite(max.z) && max.z > 0 ? max.z : size.z
   );
 
-  return new Box3(min, max);
+  return new Box3(newMin, newMax);
 }
 
 const anyComponentGreater = (a: Vector3, b: Vector3) => a.x > b.x || a.y > b.y || a.z > b.z;

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -20,7 +20,7 @@ type CacheEntry = {
   /** The data contained in this entry */
   // TODO allow more types of `TypedArray` to be stored together in the cache?
   data: Uint8Array;
-  /** The subset of the volume covered by this entry */
+  /** The subset of the volume covered by this entry, in pixels */
   subregion: Box3;
   /** The previous entry in the LRU list (more recently used) */
   prev: MaybeCacheEntry;

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -45,7 +45,7 @@ export type CachedVolume = {
 /** Fill in partially-specified, invalid, or missing `Box3` with reasonable defaults */
 function applyDefaultsToRegion(region: Box3 | undefined, size: Vector3): Box3 {
   if (!region) {
-    return new Box3(new Vector3(), size.clone().subScalar(1));
+    return new Box3(new Vector3(), size.clone());
   }
 
   const min = new Vector3(
@@ -62,7 +62,7 @@ function applyDefaultsToRegion(region: Box3 | undefined, size: Vector3): Box3 {
   return new Box3(min, max);
 }
 
-const anyComponentGreaterOrEqual = (a: Vector3, b: Vector3) => a.x >= b.x || a.y >= b.y || a.z >= b.z;
+const anyComponentGreater = (a: Vector3, b: Vector3) => a.x > b.x || a.y > b.y || a.z > b.z;
 
 /** Default: 250MB. Should be large enough to be useful but safe for most any computer that can run the app */
 const CACHE_MAX_SIZE_DEFAULT = 250_000_000;
@@ -201,12 +201,13 @@ export default class VolumeCache {
     const region = applyDefaultsToRegion(optDims.region, scaleCache.size);
 
     // Validate input
-    const extentSize = region.getSize(new Vector3()).addScalar(1);
+    const extentSize = region.getSize(new Vector3());
     if (extentSize.x * extentSize.y * extentSize.z !== data.length) {
       console.error("VolumeCache: attempt to insert data which does not match the provided dimensions");
       return false;
     }
-    if (region.isEmpty() || anyComponentGreaterOrEqual(region.max, scaleCache.size)) {
+    // `isEmpty` also captures the case where `min` > `max` (component-wise)
+    if (region.isEmpty() || anyComponentGreater(region.max, scaleCache.size)) {
       console.error("VolumeCache: attempt to insert data with bad extent");
       return false;
     }

--- a/src/test/VolumeCache.test.ts
+++ b/src/test/VolumeCache.test.ts
@@ -28,7 +28,7 @@ describe("VolumeCache", () => {
         scale: 1,
         time: 1,
         channel: 1,
-        region: new Box3(new Vector3(0, 0, 1), new Vector3(1, 1, 1)),
+        region: new Box3(new Vector3(0, 0, 1), new Vector3(2, 2, 2)),
       };
       const insertionResult = cache.insert(vol, new Uint8Array(4), extent);
       expect(insertionResult).to.be.true;
@@ -64,7 +64,7 @@ describe("VolumeCache", () => {
 
     it("does not insert an entry if the extent is out of range", () => {
       const region = new Box3();
-      region.max.z = 2;
+      region.max.z = 3;
       testInsertFails(12, { region });
     });
 
@@ -86,8 +86,8 @@ describe("VolumeCache", () => {
 
     it("evicts the least recently used entry when above its size limit", () => {
       const [cache, id1] = setupEvictionTest(); // max: 12
-      const region1 = new Box3(new Vector3(0), new Vector3(1));
-      const region2 = new Box3(new Vector3(2), new Vector3(3));
+      const region1 = new Box3(new Vector3(0), new Vector3(2));
+      const region2 = new Box3(new Vector3(2), new Vector3(4));
       cache.insert(id1, new Uint8Array(8), { scale: 1, region: region1 }); // 8 < 12
       cache.insert(id1, new Uint8Array(2)); // 10 < 12
       cache.insert(id1, new Uint8Array(8), { scale: 1, region: region2 }); // 18 > 12! evict 1!
@@ -112,7 +112,7 @@ describe("VolumeCache", () => {
 
     it("evicts as many entries as it takes to get below max size", () => {
       const [cache, id1, id2] = setupEvictionTest();
-      const region = new Box3(new Vector3(0), new Vector3(1));
+      const region = new Box3(new Vector3(0), new Vector3(2));
       cache.insert(id2, new Uint8Array(6)); // 6
       cache.insert(id2, new Uint8Array(6), { time: 1 }); // 12
       cache.insert(id1, new Uint8Array(8), { scale: 1, region }); // 20!
@@ -125,11 +125,14 @@ describe("VolumeCache", () => {
 
     it("reuses any entries that match the provided extent rather than growing the cache with duplicates", () => {
       const [cache, id1] = setupEvictionTest();
-      const region1 = new Box3(new Vector3(0), new Vector3(0));
-      const region2 = new Box3(new Vector3(1), new Vector3(2));
+      const region1 = new Box3(new Vector3(0), new Vector3(1));
+      const region2 = new Box3(new Vector3(1), new Vector3(3));
       cache.insert(id1, new Uint8Array([1, 2, 3, 4]), { scale: 1, region: region1 }); // 4
+      // console.log(cache.size);
       cache.insert(id1, new Uint8Array(8), { scale: 1, region: region2 }); // 12
+      // console.log(cache.size);
       cache.insert(id1, new Uint8Array([5, 6, 7, 8]), { scale: 1, region: region1 }); // still 12
+      // console.log(cache.size);
       expect(cache.size).to.equal(12);
       expect(cache.numberOfEntries).to.equal(2);
       expect(cache.get(id1, 0, { scale: 1, region: region2 })).to.deep.equal(new Uint8Array(8));
@@ -137,8 +140,8 @@ describe("VolumeCache", () => {
     });
   });
 
-  const region1 = new Box3(new Vector3(+Infinity, +Infinity, 0), new Vector3(-Infinity, -Infinity, 0));
-  const region2 = new Box3(new Vector3(+Infinity, +Infinity, 1), new Vector3(-Infinity, -Infinity, 1));
+  const region1 = new Box3(new Vector3(+Infinity, +Infinity, 0), new Vector3(-Infinity, -Infinity, 1));
+  const region2 = new Box3(new Vector3(+Infinity, +Infinity, 1), new Vector3(-Infinity, -Infinity, 2));
 
   const SLICE_1_1 = [1, 2, 3, 4];
   const SLICE_1_2 = [5, 6, 7, 8];
@@ -162,7 +165,7 @@ describe("VolumeCache", () => {
   describe("get", () => {
     it("gets a single channel when provided a channel index", () => {
       const [cache, id] = setupGetTest([false, false, false, true]);
-      const region = new Box3(new Vector3(0, 0, 1), new Vector3(1, 1, 1));
+      const region = new Box3(new Vector3(0, 0, 1), new Vector3(2, 2, 2));
       const result = cache.get(id, 1, { scale: 0, time: 0, region });
       expect(result).to.deep.equal(new Uint8Array(SLICE_2_2));
     });
@@ -207,7 +210,7 @@ describe("VolumeCache", () => {
     time: 1,
     channel: 1,
     scale: 1,
-    region: new Box3(new Vector3(1, 1), new Vector3(1, 1)),
+    region: new Box3(new Vector3(1, 1), new Vector3(2, 2)),
   };
 
   function setupClearTest(): [VolumeCache, CachedVolume, CachedVolume] {


### PR DESCRIPTION
Addresses #132: there are currently two unconnected areas of the app that care about subregions of the volume, and 
they use unrelated types to express these subregions. Eventually we will connect these two systems, and it would be nice if they both spoke the same language when we do. This PR and its counterpart (#136) convert both to use three.js's native `Box3` type.

This PR adapts the (as yet unused) `VolumeCache` class to use `Box3` rather than a custom subregion type, and updates its tests. Note that it also introduces a minor behavior change: ranges were previously treated as inclusive on both ends (i.e. a range with an x min of 1 and max of 2 would be understood as a subregion containing rows 1 and 2 of the volume), but are now inclusive in min and exclusive in max (i.e. x min of 1 and max of 2 means a volume containing only row 1).