### PR TITLE
Fix tickmark size being overwritten after being picked

### DIFF
--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -163,6 +163,7 @@ export default class Volume {
     this.physicalScale = 1;
     this.normPhysicalSize = new Vector3(1, 1, 1);
     this.physicalPixelSize = this.imageInfo.physicalPixelSize;
+    this.tickMarkPhysicalLength = 1;
     this.setVoxelSize(this.physicalPixelSize);
 
     this.numChannels = this.imageInfo.numChannels;
@@ -186,7 +187,6 @@ export default class Volume {
     }
 
     this.physicalUnitSymbol = this.imageInfo.spatialUnit;
-    this.tickMarkPhysicalLength = 1;
 
     this.volumeDataObservers = [];
   }


### PR DESCRIPTION
Corrects a tiny silly bug I introduced in #135: bounding box tick marks are currently always 1 physical unit (e.g. 1μm) regardless of the actual size of the volume, resulting in potentially useless tickmark spacings.

### Screenshots:

#### Before
![image](https://github.com/allen-cell-animated/volume-viewer/assets/53030214/629a824c-c4c9-4cad-b628-4845a65ac730)

#### After
![image](https://github.com/allen-cell-animated/volume-viewer/assets/53030214/f356dd9f-855f-4ec1-9881-164c74e9b36f)
