### PR TITLE
Region-aware loading

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -1154,11 +1154,11 @@ function createLoader(type: string): IVolumeLoader {
 }
 
 async function loadVolume(loadSpec: LoadSpec, loader: IVolumeLoader, cacheTimeSeries: boolean): Promise<void> {
-  const volume = await loader.createVolume(loadSpec);
-  onVolumeCreated(volume, cacheTimeSeries, loadSpec.time);
-  loader.loadVolumeData(volume, (url, v, channelIndex) => {
+  const volume = await loader.createVolume(loadSpec, (url, v, channelIndex) => {
     onChannelDataArrived(url, v, channelIndex, cacheTimeSeries, loadSpec.time);
   });
+  onVolumeCreated(volume, cacheTimeSeries, loadSpec.time);
+  loader.loadVolumeData(volume);
 
   myState.currentImageStore = loadSpec.url;
   myState.currentImageName = loadSpec.url;

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -61,6 +61,7 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
     this.geometryTransformNode.add(this.boxHelper, this.geometryMesh);
 
     this.setUniform("Z_SLICE", Math.floor(volume.imageInfo.volumeSize.z / 2));
+    volume.updateRequiredData({ subregion: new Box3(new Vector3(0, 0, 0.5), new Vector3(1, 1, 0.5)) });
     this.updateVolumeDimensions();
     this.settings = settings;
     this.updateSettings(settings, SettingsFlags.ALL);
@@ -151,6 +152,10 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
       const sizez = this.volume.imageInfo.volumeSize.z;
       if (slice >= 0 && slice <= sizez - 1) {
         this.setUniform("Z_SLICE", slice);
+        const sliceRatio = slice / sizez;
+        this.volume.updateRequiredData({
+          subregion: new Box3(new Vector3(0, 0, sliceRatio), new Vector3(1, 1, sliceRatio)),
+        });
       }
     }
 

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -1,4 +1,5 @@
 import {
+  Box3,
   DataTexture,
   Data3DTexture,
   FloatType,
@@ -80,6 +81,7 @@ export default class PathTracedVolume implements VolumeRenderImpl {
   constructor(volume: Volume, settings: VolumeRenderSettings = new VolumeRenderSettings(volume)) {
     this.pathTracingUniforms = pathTracingUniforms();
     this.volume = volume;
+    this.volume.updateRequiredData({ subregion: new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1)) });
     this.viewChannels = [-1, -1, -1, -1];
 
     // create volume texture

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -53,6 +53,7 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
    */
   constructor(volume: Volume, settings: VolumeRenderSettings = new VolumeRenderSettings(volume)) {
     this.volume = volume;
+    this.volume.updateRequiredData({ subregion: new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1)) });
 
     this.uniforms = rayMarchingShaderUniforms();
     [this.geometry, this.geometryMesh] = this.createGeometry(this.uniforms);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -230,10 +230,9 @@ export class View3d {
     this.image?.onChannelAdded(newChannelIndex);
   }
 
-  setTime(volume: Volume, time: number, loader: IVolumeLoader, onChannelLoaded?: PerChannelCallback): void {
-    volume.loadSpec.time = Math.max(0, Math.min(volume.imageInfo.times, time));
+  setTime(volume: Volume, time: number): void {
+    volume.updateRequiredData({ time: Math.max(0, Math.min(time, volume.imageInfo.times)) });
     this.updateTimestepIndicator(volume);
-    loader.loadVolumeData(volume, onChannelLoaded);
   }
 
   /**

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -15,7 +15,6 @@ import { ThreeJsPanel } from "./ThreeJsPanel";
 import lightSettings from "./constants/lights";
 import VolumeDrawable from "./VolumeDrawable";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light";
-import { IVolumeLoader, PerChannelCallback } from "./loaders/IVolumeLoader";
 import Volume from "./Volume";
 import {
   VolumeChannelDisplayOptions,

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -3,7 +3,7 @@ import { Vector2, Vector3 } from "three";
 import Channel from "./Channel";
 import Histogram from "./Histogram";
 import { getColorByChannelIndex } from "./constants/colors";
-import { IVolumeLoader, LoadSpec } from "./loaders/IVolumeLoader";
+import { IVolumeLoader, LoadSpec, PerChannelCallback } from "./loaders/IVolumeLoader";
 
 export type ImageInfo = Readonly<{
   name: string;
@@ -131,6 +131,7 @@ export default class Volume {
   public loadSpec: LoadSpec;
   public loader?: IVolumeLoader;
   private loadSpecRequired: LoadSpec;
+  public channelLoadCallback?: PerChannelCallback;
   public imageMetadata: Record<string, unknown>;
   public name: string;
 
@@ -269,9 +270,8 @@ export default class Volume {
     if (this.channels.every((element) => element.loaded)) {
       this.loaded = true;
     }
-    for (let i = 0; i < this.volumeDataObservers.length; ++i) {
-      this.volumeDataObservers[i].onVolumeData(this, batch);
-    }
+    batch.forEach((channelIndex) => this.channelLoadCallback?.(this.loadSpec.url, this, channelIndex));
+    this.volumeDataObservers.forEach((observer) => observer.onVolumeData(this, batch));
   }
 
   /**

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -53,7 +53,7 @@ export interface IVolumeLoader {
    * May cache some values for use on only the next call to `loadVolumeData`; callers should guarantee that the next
    * call to this loader's `loadVolumeData` is made on the returned `Volume` before the volume's state is changed.
    */
-  createVolume(loadSpec: LoadSpec): Promise<Volume>;
+  createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume>;
 
   /**
    * Begin loading a volume's data, as specified in its `LoadSpec`.
@@ -62,5 +62,5 @@ export interface IVolumeLoader {
   // TODO make this return a promise that resolves when loading is done?
   // TODO this is not cancellable in the sense that any async requests initiated here are not stored
   // in a way that they can be interrupted.
-  loadVolumeData(volume: Volume, onChannelLoaded?: PerChannelCallback, loadSpec?: LoadSpec): void;
+  loadVolumeData(volume: Volume, loadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): void;
 }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -10,11 +10,11 @@ export class LoadSpec {
   // sub-region; if not specified, the entire volume is loaded
   // specify as floats between 0 and 1
   subregion = new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1));
+}
 
-  toString(): string {
-    const { min, max } = this.subregion;
-    return `${this.url}:${this.subpath}${this.scene}:${this.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
-  }
+export function loadSpecToString(spec: LoadSpec): string {
+  const { min, max } = spec.subregion;
+  return `${spec.url}:${spec.subpath}${spec.scene}:${spec.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
 }
 
 export class VolumeDims {

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -122,7 +122,7 @@ class JsonImageInfoLoader implements IVolumeLoader {
     const jsonInfo = await this.getImageInfo(loadSpec);
     const imageInfo = convertImageInfo(jsonInfo);
 
-    const vol = new Volume(imageInfo, loadSpec);
+    const vol = new Volume(imageInfo, loadSpec, this);
     vol.imageMetadata = buildDefaultMetadata(imageInfo);
     return vol;
   }

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -118,16 +118,17 @@ class JsonImageInfoLoader implements IVolumeLoader {
     return [d];
   }
 
-  async createVolume(loadSpec: LoadSpec): Promise<Volume> {
+  async createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
     const jsonInfo = await this.getImageInfo(loadSpec);
     const imageInfo = convertImageInfo(jsonInfo);
 
     const vol = new Volume(imageInfo, loadSpec, this);
+    vol.channelLoadCallback = onChannelLoaded;
     vol.imageMetadata = buildDefaultMetadata(imageInfo);
     return vol;
   }
 
-  async loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback, explicitLoadSpec?: LoadSpec): Promise<void> {
+  async loadVolumeData(vol: Volume, explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<void> {
     const loadSpec = explicitLoadSpec || vol.loadSpec;
     // if you need to adjust image paths prior to download,
     // now is the time to do it.
@@ -163,7 +164,7 @@ class JsonImageInfoLoader implements IVolumeLoader {
   static loadVolumeAtlasData(
     volume: Volume,
     imageArray: PackedChannelsImage[],
-    onChannelLoaded: PerChannelCallback
+    onChannelLoaded?: PerChannelCallback
   ): PackedChannelsImageRequests {
     const numImages = imageArray.length;
 
@@ -217,7 +218,7 @@ class JsonImageInfoLoader implements IVolumeLoader {
 
           for (let ch = 0; ch < Math.min(thisbatch.length, 4); ++ch) {
             volume.setChannelDataFromAtlas(thisbatch[ch], channelsBits[ch], w, h);
-            onChannelLoaded(url, volume, thisbatch[ch]);
+            onChannelLoaded?.(url, volume, thisbatch[ch]);
           }
         };
       })(batch);

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -328,7 +328,7 @@ class OMEZarrLoader implements IVolumeLoader {
     };
 
     // got some data, now let's construct the volume.
-    const vol = new Volume(imgdata, fullExtentLoadSpec);
+    const vol = new Volume(imgdata, fullExtentLoadSpec, this);
     vol.imageMetadata = buildDefaultMetadata(imgdata);
     return vol;
   }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -245,7 +245,7 @@ class OMEZarrLoader implements IVolumeLoader {
     return Promise.all(dimsPromises);
   }
 
-  async createVolume(loadSpec: LoadSpec): Promise<Volume> {
+  async createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
     // Load metadata and dimensions.
     const store = new HTTPStore(loadSpec.url);
     this.metadata = await loadMetadata(store, loadSpec);
@@ -329,11 +329,12 @@ class OMEZarrLoader implements IVolumeLoader {
 
     // got some data, now let's construct the volume.
     const vol = new Volume(imgdata, fullExtentLoadSpec, this);
+    vol.channelLoadCallback = onChannelLoaded;
     vol.imageMetadata = buildDefaultMetadata(imgdata);
     return vol;
   }
 
-  loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback, explicitLoadSpec?: LoadSpec): void {
+  loadVolumeData(vol: Volume, explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): void {
     if (
       this.axesTCZYX === undefined ||
       this.metadata === undefined ||
@@ -374,10 +375,7 @@ class OMEZarrLoader implements IVolumeLoader {
         const u8 = e.data.data;
         const channel = e.data.channel;
         vol.setChannelDataFromVolume(channel, u8);
-        if (onChannelLoaded) {
-          // make up a unique name? or have caller pass this in?
-          onChannelLoaded(vol.loadSpec.url + "/" + vol.loadSpec.subpath, vol, channel);
-        }
+        onChannelLoaded?.(vol.loadSpec.url + "/" + vol.loadSpec.subpath, vol, channel);
         worker.terminate();
       };
       worker.onerror = (e) => {

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -17,7 +17,7 @@ class OpenCellLoader implements IVolumeLoader {
     return [d];
   }
 
-  async createVolume(_: LoadSpec): Promise<Volume> {
+  async createVolume(loadSpec: LoadSpec): Promise<Volume> {
     const numChannels = 2;
 
     // we know these are standardized to 600x600, two channels, one channel per jpg.
@@ -48,7 +48,7 @@ class OpenCellLoader implements IVolumeLoader {
     };
 
     // got some data, now let's construct the volume.
-    const vol = new Volume(imgdata);
+    const vol = new Volume(imgdata, loadSpec, this);
     vol.imageMetadata = buildDefaultMetadata(imgdata);
     return vol;
   }

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -17,7 +17,7 @@ class OpenCellLoader implements IVolumeLoader {
     return [d];
   }
 
-  async createVolume(loadSpec: LoadSpec): Promise<Volume> {
+  async createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
     const numChannels = 2;
 
     // we know these are standardized to 600x600, two channels, one channel per jpg.
@@ -49,11 +49,12 @@ class OpenCellLoader implements IVolumeLoader {
 
     // got some data, now let's construct the volume.
     const vol = new Volume(imgdata, loadSpec, this);
+    vol.channelLoadCallback = onChannelLoaded;
     vol.imageMetadata = buildDefaultMetadata(imgdata);
     return vol;
   }
 
-  loadVolumeData(vol: Volume, onChannelLoaded: PerChannelCallback): void {
+  loadVolumeData(vol: Volume, _explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): void {
     // HQTILE or LQTILE
     // make a json metadata dict for the two channels:
     const urls = [

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -142,7 +142,7 @@ class TiffLoader implements IVolumeLoader {
       },
     };
 
-    const vol = new Volume(imgdata, loadSpec);
+    const vol = new Volume(imgdata, loadSpec, this);
     vol.imageMetadata = buildDefaultMetadata(imgdata);
 
     this.dimensionOrder = dims.dimensionorder;

--- a/src/test/RequestQueue.test.ts
+++ b/src/test/RequestQueue.test.ts
@@ -3,7 +3,7 @@ import { Vector3 } from "three";
 import { TypedArray } from "zarr";
 
 import RequestQueue, { Request } from "../utils/RequestQueue";
-import { LoadSpec } from "../loaders/IVolumeLoader";
+import { LoadSpec, loadSpecToString } from "../loaders/IVolumeLoader";
 
 /**
  * Returns a promise that resolves once the timeout (give in ms) is completed.
@@ -18,16 +18,16 @@ describe("test RequestQueue", () => {
       const rq = new RequestQueue();
       const loadSpec = new LoadSpec();
       let actionIsRun = false;
-      rq.addRequest(loadSpec.toString(), async () => {
+      rq.addRequest(loadSpecToString(loadSpec), async () => {
         // do something
         await sleep(10);
         actionIsRun = true;
         return null;
       });
-      expect(rq.hasRequest(loadSpec.toString())).to.be.true;
+      expect(rq.hasRequest(loadSpecToString(loadSpec))).to.be.true;
       await sleep(15);
       expect(actionIsRun).to.be.true;
-      expect(rq.hasRequest(loadSpec.toString())).to.be.false;
+      expect(rq.hasRequest(loadSpecToString(loadSpec))).to.be.false;
     });
 
     it("only runs request once", async () => {
@@ -39,8 +39,8 @@ describe("test RequestQueue", () => {
         await sleep(100);
         count++;
       };
-      promises.push(rq.addRequest(loadSpec.toString(), work));
-      promises.push(rq.addRequest(loadSpec.toString(), work));
+      promises.push(rq.addRequest(loadSpecToString(loadSpec), work));
+      promises.push(rq.addRequest(loadSpecToString(loadSpec), work));
       await Promise.all(promises);
       expect(count).to.equal(1);
     });
@@ -80,8 +80,8 @@ describe("test RequestQueue", () => {
         await sleep(100);
         count++;
       };
-      const promise1 = rq.addRequest(loadSpec1.toString(), work);
-      const promise2 = rq.addRequest(loadSpec2.toString(), work);
+      const promise1 = rq.addRequest(loadSpecToString(loadSpec1), work);
+      const promise2 = rq.addRequest(loadSpecToString(loadSpec2), work);
       // Check that the promises are the same instance
       expect(promise1).to.deep.equal(promise2);
       promises.push(promise1);
@@ -362,7 +362,7 @@ describe("test RequestQueue", () => {
         loadSpec.subregion.max.set(xDim, yDim, i + 1);
 
         requests.push({
-          key: loadSpec.toString(),
+          key: loadSpecToString(loadSpec),
           requestAction: () => {
             return action(loadSpec as Required<LoadSpec>);
           },
@@ -381,7 +381,7 @@ describe("test RequestQueue", () => {
 
       const action = async (loadSpec: Required<LoadSpec>) => {
         // Check if the work we were going to do has been cancelled.
-        if (rq.hasRequest(loadSpec.toString())) {
+        if (rq.hasRequest(loadSpecToString(loadSpec))) {
           const ret = await mockLoader(loadSpec, maxDelayMs);
           workCount++;
           return ret;


### PR DESCRIPTION
Add a basic API to `Volume` to track what data is currently needed to draw the image given the state of the viewer, and use it to enable context-aware single-slice loading (!!).

- `Volume` gets new properties: `loader`, `channelLoadCallback`, and `loadSpecRequired`. The first two of these allow `Volume`s to issue load requests all by themselves. `loadSpecRequired` is a second `loadSpec` that tracks the subset of data which is necessary to display the current image.
- `Volume` gets a new method: `updateRequiredData`. This applies changes to `loadSpecRequired`, and issues a load request when new data is needed.
- `View3d`'s `setTime` method now makes use of `updateRequiredData`
- `VolumeRenderImpl`s call `updateRequiredData` to allow single-slice loading: `Atlas2DSlice` calls it on construction and when z-slice changes to request a single z-slice, and all other implementations call it on construction to reset the required data to the full extent of the volume.
- To accommodate `Volume`'s new data loading responsibilities, `IVolumeLoader` gets a new API: callbacks for when single channels load are passed into `createVolume`, rather than `loadVolumeData`, so that `Volume` can store them. It is still possible to pass a callback to `loadVolumeData`, in which case both will run. But only the callback passed to `createVolume` will be run when a volume decides to load new data via `updateRequiredData`, which should almost always be the right behavior for such a callback.