### PR TITLE
Rework `LoadSpec` 1/Use Cache 1/Time series tweaks

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -854,39 +854,7 @@ function loadImageData(jsonData, volumeData) {
   return vol;
 }
 
-// function cacheTimeSeriesImageData(jsonData, frameNumber) {
-//   const vol = new Volume(jsonData);
-//   myState.timeSeriesVolumes[frameNumber] = vol;
-//   return vol;
-// }
-
-function onChannelDataArrived(v: Volume, channelIndex: number, frameNumber = 0) {
-  // if (cacheForTimeSeries) {
-  //   if (v.isLoaded()) {
-  //     const currentVol = cacheTimeSeriesImageData(v.imageInfo, frameNumber);
-
-  //     console.log("currentVol with name " + v.name + " is loaded");
-  //     myState.numberOfVolumesCached++;
-  //     if (myState.numberOfVolumesCached >= myState.totalFrames) {
-  //       console.log("ALL FRAMES RECEIVED");
-  //     }
-
-  //     copyVolumeToVolume(v, currentVol);
-  //     if (frameNumber === 0) {
-  //       copyVolumeToVolume(v, myState.volume);
-  //       // has assumption that only 3 channels
-  //       view3D.onVolumeData(myState.volume, [0, 1, 2]);
-  //       view3D.updateActiveChannels(myState.volume);
-  //       view3D.updateLuts(myState.volume);
-
-  //       myState.volume.setIsLoaded(true);
-  //     } else {
-  //       //copyVolumeToVolume(v, currentVol);
-  //     }
-  //     return;
-  //   }
-  // }
-
+function onChannelDataArrived(v: Volume, channelIndex: number) {
   const currentVol = v; // myState.volume;
 
   currentVol.channels[channelIndex].lutGenerator_percentiles(0.5, 0.998);
@@ -904,58 +872,6 @@ function onChannelDataArrived(v: Volume, channelIndex: number, frameNumber = 0) 
 
 function onVolumeCreated(volume: Volume) {
   const myJson = volume.imageInfo;
-  // if (isTimeSeries) {
-  //   if (frameNumber === 0) {
-  //     // create the main volume and add to view (this is the only place)
-  //     myState.volume = new Volume(myJson);
-
-  //     const atlasWidth = myJson.subregionSize.x * myJson.atlasTileDims.x;
-  //     const atlasHeight = myJson.subregionSize.y * myJson.atlasTileDims.y;
-
-  //     // TODO: this can go in the Volume and Channel constructors!
-  //     // preallocate some memory to be filled in later
-  //     for (let i = 0; i < volume.imageInfo.numChannels; ++i) {
-  //       myState.volume.channels[i].imgData = {
-  //         data: new Uint8ClampedArray(atlasWidth * atlasHeight),
-  //         width: atlasWidth,
-  //         height: atlasHeight,
-  //       };
-  //       myState.volume.channels[i].volumeData = new Uint8Array(
-  //         myJson.subregionSize.x * myJson.subregionSize.y * myJson.subregionSize.z
-  //       );
-  //       // TODO also preallocate the Fused data texture
-  //     }
-
-  //     view3D.removeAllVolumes();
-  //     view3D.addVolume(myState.volume);
-  //     setInitialRenderMode();
-  //     // first 3 channels for starters
-  //     for (let ch = 0; ch < myState.volume.imageInfo.numChannels; ++ch) {
-  //       view3D.setVolumeChannelEnabled(myState.volume, ch, ch < 3);
-  //     }
-  //     view3D.setVolumeChannelAsMask(myState.volume, myJson.channelNames.indexOf("SEG_Memb"));
-  //     view3D.updateActiveChannels(myState.volume);
-  //     view3D.updateLuts(myState.volume);
-  //     view3D.updateLights(myState.lights);
-  //     view3D.updateDensity(myState.volume, densitySliderToView3D(myState.density));
-  //     view3D.updateExposure(myState.exposure);
-  //     // apply a volume transform from an external source:
-  //     if (myJson.transform) {
-  //       const alignTransform = myJson.transform;
-  //       view3D.setVolumeTranslation(
-  //         myState.volume,
-  //         myState.volume.voxelsToWorldSpace(alignTransform.translation.toArray())
-  //       );
-  //       view3D.setVolumeRotation(myState.volume, alignTransform.rotation.toArray());
-  //     }
-  //   }
-
-  //   updateTimeUI(myState.volume);
-  //   updateZSliceUI(myState.volume);
-  //   showChannelUI(myState.volume);
-  //   return;
-  // }
-
   myState.volume = volume;
 
   view3D.removeAllVolumes();
@@ -982,45 +898,6 @@ function onVolumeCreated(volume: Volume) {
   updateZSliceUI(myState.volume);
   showChannelUI(myState.volume);
 }
-
-// function copyVolumeToVolume(src, dest) {
-//   // assumes volumes already have identical dimensions!!!
-
-//   // grab references to data from each channel and put it in myState.volume
-//   for (let i = 0; i < src.num_channels; ++i) {
-//     // dest.channels[i].imgData.data.set(src.channels[i].imgData.data);
-//     // dest.channels[i].volumeData.set(src.channels[i].volumeData);
-//     // dest.channels[i].lut.set(src.channels[i].lut);
-//     dest.channels[i].imgData = {
-//       data: src.channels[i].imgData.data,
-//       width: src.channels[i].imgData.width,
-//       height: src.channels[i].imgData.height,
-//     };
-//     dest.channels[i].volumeData = src.channels[i].volumeData;
-//     dest.channels[i].lut = src.channels[i].lut;
-
-//     // danger: not a copy!
-//     dest.channels[i].histogram = src.channels[i].histogram;
-//     dest.channels[i].dataTexture = src.channels[i].dataTexture;
-//     dest.channels[i].lutTexture = src.channels[i].lutTexture;
-//     dest.channels[i].loaded = true;
-//   }
-// }
-
-// function updateViewForNewVolume() {
-//   view3D.onVolumeData(myState.volume, [0, 1, 2]);
-//   myState.volume.setIsLoaded(true);
-
-//   if (myState.isPT) {
-//     view3D.updateActiveChannels(myState.volume);
-//   } else {
-//     view3D.updateLuts(myState.volume);
-//   }
-
-//   for (let i = 0; i < myState.volume.imageInfo.numChannels; ++i) {
-//     view3D.updateIsosurface(myState.volume, i, myState.channelGui[i].isovalue);
-//   }
-// }
 
 function playTimeSeries(onNewFrameCallback: () => void) {
   window.clearTimeout(myState.timerId);
@@ -1135,9 +1012,7 @@ function createLoader(data: TestDataSpec): IVolumeLoader {
 }
 
 async function loadVolume(loadSpec: LoadSpec, loader: IVolumeLoader): Promise<void> {
-  const volume = await loader.createVolume(loadSpec, (v, channelIndex) => {
-    onChannelDataArrived(v, channelIndex, loadSpec.time);
-  });
+  const volume = await loader.createVolume(loadSpec, onChannelDataArrived);
   onVolumeCreated(volume);
   loader.loadVolumeData(volume);
 

--- a/public/index.ts
+++ b/public/index.ts
@@ -905,7 +905,7 @@ function playTimeSeries(onNewFrameCallback: () => void) {
 
   const loadNextFrame = () => {
     myState.lastFrameTime = Date.now();
-    let nextFrame = (myState.currentFrame + 1) % getNumberOfTimesteps();
+    const nextFrame = (myState.currentFrame + 1) % getNumberOfTimesteps();
 
     // TODO would be real nice if this were an `await`-able promise instead...
     view3D.setTime(myState.volume, nextFrame, (vol) => {

--- a/public/index.ts
+++ b/public/index.ts
@@ -815,7 +815,7 @@ function showChannelUI(volume: Volume) {
   }
 }
 
-function loadImageData(jsonData, volumeData) {
+function loadImageData(jsonData: ImageInfo, volumeData: Uint8Array[]) {
   const vol = new Volume(jsonData);
   myState.volume = vol;
 
@@ -841,7 +841,7 @@ function loadImageData(jsonData, volumeData) {
       view3D.setVolumeChannelEnabled(vol, ch, ch < 3);
     }
 
-    const maskChannelIndex = jsonData.channel_names.indexOf("SEG_Memb");
+    const maskChannelIndex = jsonData.channelNames.indexOf("SEG_Memb");
     view3D.setVolumeChannelAsMask(vol, maskChannelIndex);
     view3D.updateActiveChannels(vol);
     view3D.updateLuts(vol);

--- a/public/types.ts
+++ b/public/types.ts
@@ -5,14 +5,14 @@ import { ImageInfo } from "../src/Volume";
 export interface TestDataSpec {
   type: "ometiff" | "omezarr" | "jsonatlas" | "opencell" | "procedural";
   url: string;
-  tstart: number;
-  tend: number;
+  /** Optional fallback for JSON volumes which don't specify a value for `times` */
+  times?: number;
 }
 
 export interface State {
   file: string;
   volume: Volume;
-  totalFrames: number;
+  totalFrames?: number;
   currentFrame: number;
   lastFrameTime: number;
   isPlaying: boolean;

--- a/public/types.ts
+++ b/public/types.ts
@@ -12,10 +12,10 @@ export interface TestDataSpec {
 export interface State {
   file: string;
   volume: Volume;
-  timeSeriesVolumes: Volume[];
-  numberOfVolumesCached: number;
   totalFrames: number;
   currentFrame: number;
+  lastFrameTime: number;
+  isPlaying: boolean;
   timerId: number;
 
   loader: IVolumeLoader;

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -24,6 +24,7 @@ import {
   RenderMode,
 } from "./types";
 import { Axis } from "./VolumeRenderSettings";
+import { PerChannelCallback } from "./loaders/IVolumeLoader";
 
 // Constants are kept for compatibility reasons.
 export const RENDERMODE_RAYMARCH = RenderMode.RAYMARCH;
@@ -229,8 +230,9 @@ export class View3d {
     this.image?.onChannelAdded(newChannelIndex);
   }
 
-  setTime(volume: Volume, time: number): void {
-    volume.updateRequiredData({ time: Math.max(0, Math.min(time, volume.imageInfo.times)) });
+  setTime(volume: Volume, time: number, onChannelLoaded?: PerChannelCallback): void {
+    const timeClamped = Math.max(0, Math.min(time, volume.imageInfo.times));
+    volume.updateRequiredData({ time: timeClamped }, onChannelLoaded);
     this.updateTimestepIndicator(volume);
   }
 

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -231,7 +231,7 @@ export class View3d {
   }
 
   setTime(volume: Volume, time: number, onChannelLoaded?: PerChannelCallback): void {
-    const timeClamped = Math.max(0, Math.min(time, volume.imageInfo.times));
+    const timeClamped = Math.max(0, Math.min(time, volume.imageInfo.times - 1));
     volume.updateRequiredData({ time: timeClamped }, onChannelLoaded);
     this.updateTimestepIndicator(volume);
   }

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -270,7 +270,7 @@ export default class Volume {
     if (this.channels.every((element) => element.loaded)) {
       this.loaded = true;
     }
-    batch.forEach((channelIndex) => this.channelLoadCallback?.(this.loadSpec.url, this, channelIndex));
+    batch.forEach((channelIndex) => this.channelLoadCallback?.(this, channelIndex));
     this.volumeDataObservers.forEach((observer) => observer.onVolumeData(this, batch));
   }
 

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -200,6 +200,18 @@ export default class Volume {
     this.volumeDataObservers = [];
   }
 
+  private setUnloaded() {
+    this.loaded = false;
+    // TODO this will cause problems once it is possible to skip loading some channels. Come back to this then.
+    this.channels.forEach((channel) => {
+      channel.loaded = false;
+    });
+  }
+
+  isLoaded(): boolean {
+    return this.loaded;
+  }
+
   updateDimensions() {
     const { volumeSize, subregionSize, subregionOffset } = this.imageInfo;
 
@@ -218,6 +230,7 @@ export default class Volume {
       !this.loadSpec.subregion.containsBox(this.loadSpecRequired.subregion)
     ) {
       // ...clone `loadSpecRequired` into `loadSpec` and load
+      this.setUnloaded();
       this.loadSpec = { ...this.loadSpecRequired, subregion: this.loadSpecRequired.subregion.clone() };
       this.loader?.loadVolumeData(this, undefined, onChannelLoaded);
     }
@@ -423,13 +436,5 @@ export default class Volume {
 
   removeAllVolumeDataObservers(): void {
     this.volumeDataObservers = [];
-  }
-
-  isLoaded(): boolean {
-    return this.loaded;
-  }
-
-  setIsLoaded(loaded: boolean): void {
-    this.loaded = loaded;
   }
 }

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -209,7 +209,7 @@ export default class Volume {
     this.normRegionOffset = subregionOffset.clone().divide(volumeSize);
   }
 
-  updateRequiredData(required: Partial<LoadSpec>) {
+  updateRequiredData(required: Partial<LoadSpec>, onChannelLoaded?: PerChannelCallback) {
     this.loadSpecRequired = { ...this.loadSpecRequired, ...required };
     // if newly required data is not currently contained in this volume...
     if (
@@ -219,7 +219,7 @@ export default class Volume {
     ) {
       // ...clone `loadSpecRequired` into `loadSpec` and load
       this.loadSpec = { ...this.loadSpecRequired, subregion: this.loadSpecRequired.subregion.clone() };
-      this.loader?.loadVolumeData(this);
+      this.loader?.loadVolumeData(this, undefined, onChannelLoaded);
     }
   }
 

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -30,14 +30,14 @@ type CacheEntry = {
   parentArr: CacheEntry[];
 };
 
-type CacheStoreScale = {
+type CacheStoreMultiscaleLevel = {
   // Entries are indexed by T and C, then stored in lists of ZYX subsets
   data: CacheEntry[][][];
   size: Vector3;
 };
 
 export type CacheStore = {
-  scales: CacheStoreScale[];
+  scales: CacheStoreMultiscaleLevel[];
   numTimes: number;
   numChannels: number;
 };
@@ -189,7 +189,7 @@ export default class VolumeCache {
       return tArr;
     };
 
-    const scales = scaleDims.map((size): CacheStoreScale => ({ size, data: makeTCArray() }));
+    const scales = scaleDims.map((size): CacheStoreMultiscaleLevel => ({ size, data: makeTCArray() }));
     return { scales, numTimes, numChannels };
   }
 

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -156,6 +156,7 @@ export default class VolumeCache {
       return;
     }
 
+    console.log(`Cache: evict entry with size ${this.last.data.length}`);
     this.removeEntryFromStore(this.last);
 
     if (this.last.prev) {
@@ -177,6 +178,9 @@ export default class VolumeCache {
    * A `CacheStore` may only be accessed or modified by passing it to this class's methods.
    */
   public addVolume(numChannels: number, numTimes: number, scaleDims: Vector3[]): CacheStore {
+    console.log(
+      `Cache: create store with ${numChannels} channels, ${numTimes} times, ${scaleDims.length} scale levels`
+    );
     const makeTCArray = (): CacheEntry[][][] => {
       const tArr: CacheEntry[][][] = [];
       for (let i = 0; i < numTimes; i++) {
@@ -227,6 +231,12 @@ export default class VolumeCache {
       }
     }
 
+    console.log(
+      `Cache: insert entry for channel ${optDims.channel || 0}, timestep ${optDims.time || 0}, scale level ${
+        optDims.scale || 0
+      }, with size ${data.length}`
+    );
+
     // Add new entry to cache
     const newEntry: CacheEntry = { data, subregion, prev: null, next: null, parentArr: entryList };
     this.addEntryAsFirst(newEntry);
@@ -255,8 +265,17 @@ export default class VolumeCache {
     const entryList = scaleCache.data[optDims.time || 0][channel];
     const subregion = applyDefaultsToRegion(optDims.region, scaleCache.size);
 
+    const size = subregion.getSize(new Vector3());
+    const len = size.x * size.y * size.z;
+    console.log(
+      `Cache: get entry for channel ${channel}, timestep ${optDims.time || 0}, scale level ${
+        optDims.scale || 0
+      }, with size ${len}`
+    );
+
     for (const entry of entryList) {
       if (entry.subregion.equals(subregion)) {
+        console.log("HIT!");
         this.moveEntryToFirst(entry);
         return entry.data;
       }

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -156,7 +156,6 @@ export default class VolumeCache {
       return;
     }
 
-    console.log(`Cache: evict entry with size ${this.last.data.length}`);
     this.removeEntryFromStore(this.last);
 
     if (this.last.prev) {
@@ -178,9 +177,6 @@ export default class VolumeCache {
    * A `CacheStore` may only be accessed or modified by passing it to this class's methods.
    */
   public addVolume(numChannels: number, numTimes: number, scaleDims: Vector3[]): CacheStore {
-    console.log(
-      `Cache: create store with ${numChannels} channels, ${numTimes} times, ${scaleDims.length} scale levels`
-    );
     const makeTCArray = (): CacheEntry[][][] => {
       const tArr: CacheEntry[][][] = [];
       for (let i = 0; i < numTimes; i++) {
@@ -231,12 +227,6 @@ export default class VolumeCache {
       }
     }
 
-    console.log(
-      `Cache: insert entry for channel ${optDims.channel || 0}, timestep ${optDims.time || 0}, scale level ${
-        optDims.scale || 0
-      }, with size ${data.length}`
-    );
-
     // Add new entry to cache
     const newEntry: CacheEntry = { data, subregion, prev: null, next: null, parentArr: entryList };
     this.addEntryAsFirst(newEntry);
@@ -265,17 +255,8 @@ export default class VolumeCache {
     const entryList = scaleCache.data[optDims.time || 0][channel];
     const subregion = applyDefaultsToRegion(optDims.region, scaleCache.size);
 
-    const size = subregion.getSize(new Vector3());
-    const len = size.x * size.y * size.z;
-    console.log(
-      `Cache: get entry for channel ${channel}, timestep ${optDims.time || 0}, scale level ${
-        optDims.scale || 0
-      }, with size ${len}`
-    );
-
     for (const entry of entryList) {
       if (entry.subregion.equals(subregion)) {
-        console.log("HIT!");
         this.moveEntryToFirst(entry);
         return entry.data;
       }

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -30,14 +30,14 @@ type CacheEntry = {
   parentArr: CacheEntry[];
 };
 
-type CachedVolumeScale = {
+type CacheStoreScale = {
   // Entries are indexed by T and C, then stored in lists of ZYX subsets
   data: CacheEntry[][][];
   size: Vector3;
 };
 
-export type CachedVolume = {
-  scales: CachedVolumeScale[];
+export type CacheStore = {
+  scales: CacheStoreScale[];
   numTimes: number;
   numChannels: number;
 };
@@ -173,10 +173,10 @@ export default class VolumeCache {
 
   /**
    * Prepares a new cached volume with the specified channels, times, and scales.
-   * @returns {CachedVolume} A container for cache entries for this volume.
-   * A `CachedVolume` may only be accessed or modified by passing it to this class's methods.
+   * @returns {CacheStore} A container for cache entries for this volume.
+   * A `CacheStore` may only be accessed or modified by passing it to this class's methods.
    */
-  public addVolume(numChannels: number, numTimes: number, scaleDims: Vector3[]): CachedVolume {
+  public addVolume(numChannels: number, numTimes: number, scaleDims: Vector3[]): CacheStore {
     const makeTCArray = (): CacheEntry[][][] => {
       const tArr: CacheEntry[][][] = [];
       for (let i = 0; i < numTimes; i++) {
@@ -189,7 +189,7 @@ export default class VolumeCache {
       return tArr;
     };
 
-    const scales = scaleDims.map((size): CachedVolumeScale => ({ size, data: makeTCArray() }));
+    const scales = scaleDims.map((size): CacheStoreScale => ({ size, data: makeTCArray() }));
     return { scales, numTimes, numChannels };
   }
 
@@ -197,7 +197,7 @@ export default class VolumeCache {
    * Add a new array to the cache (representing a subset of a channel's extent at a given time and scale)
    * @returns {boolean} a boolean indicating whether the insertion succeeded
    */
-  public insert(volume: CachedVolume, data: Uint8Array, optDims: Partial<DataArrayExtent> = {}): boolean {
+  public insert(volume: CacheStore, data: Uint8Array, optDims: Partial<DataArrayExtent> = {}): boolean {
     const scaleCache = volume.scales[optDims.scale || 0];
     const entryList = scaleCache.data[optDims.time || 0][optDims.channel || 0];
     const subregion = applyDefaultsToRegion(optDims.region, scaleCache.size);
@@ -246,7 +246,7 @@ export default class VolumeCache {
    * which is overloaded to call this in different patterns.
    */
   private getOneChannel(
-    volume: CachedVolume,
+    volume: CacheStore,
     channel: number,
     optDims: Partial<QueryExtent> = {}
   ): Uint8Array | undefined {
@@ -266,13 +266,13 @@ export default class VolumeCache {
   }
 
   /** Attempts to get data from a single channel of a cached volume. Returns `undefined` if not present in the cache. */
-  public get(volume: CachedVolume, channel: number, optDims?: Partial<QueryExtent>): Uint8Array | undefined;
+  public get(volume: CacheStore, channel: number, optDims?: Partial<QueryExtent>): Uint8Array | undefined;
   /** Attempts to get data from multiple channels of a volume. Channels not present in the cache are `undefined`. */
-  public get(volume: CachedVolume, channel: number[], optDims?: Partial<QueryExtent>): (Uint8Array | undefined)[];
+  public get(volume: CacheStore, channel: number[], optDims?: Partial<QueryExtent>): (Uint8Array | undefined)[];
   /** Attempts to get all channels of a volume from the cache. Channels not present in the cache are `undefined`. */
-  public get(volume: CachedVolume, optDims?: Partial<QueryExtent>): (Uint8Array | undefined)[];
+  public get(volume: CacheStore, optDims?: Partial<QueryExtent>): (Uint8Array | undefined)[];
   public get(
-    volume: CachedVolume,
+    volume: CacheStore,
     channel?: number | number[] | Partial<QueryExtent>,
     optDims?: Partial<QueryExtent>
   ): Uint8Array | undefined | (Uint8Array | undefined)[] {
@@ -289,7 +289,7 @@ export default class VolumeCache {
   }
 
   /** Clears data associated with one volume from the cache */
-  public clearVolume(volume: CachedVolume): void {
+  public clearVolume(volume: CacheStore): void {
     volume.scales.forEach((scale) => {
       scale.data.forEach((time) => {
         time.forEach((channel) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { RENDERMODE_PATHTRACE, RENDERMODE_RAYMARCH, View3d } from "./View3d";
 import Volume from "./Volume";
 import Channel from "./Channel";
 import VolumeMaker from "./VolumeMaker";
+import VolumeCache from "./VolumeCache";
 import Histogram from "./Histogram";
 import { ViewportCorner } from "./types";
 import { JsonImageInfoLoader } from "./loaders/JsonImageInfoLoader";
@@ -23,6 +24,7 @@ export {
   View3d,
   Volume,
   VolumeMaker,
+  VolumeCache,
   Channel,
   Light,
   ViewportCorner,

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -64,5 +64,6 @@ export interface IVolumeLoader {
   // TODO make this return a promise that resolves when loading is done?
   // TODO this is not cancellable in the sense that any async requests initiated here are not stored
   // in a way that they can be interrupted.
+  // TODO explicitly passing a `LoadSpec` is now rarely useful. Remove?
   loadVolumeData(volume: Volume, loadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): void;
 }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -34,7 +34,7 @@ export class VolumeDims {
  * @param {Volume} volume
  * @param {number} channelindex
  */
-export type PerChannelCallback = (imageurl: string, volume: Volume, channelIndex: number) => void;
+export type PerChannelCallback = (volume: Volume, channelIndex: number) => void;
 
 /**
  * Loads volume data from a source specified by a `LoadSpec`.

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -3,7 +3,6 @@ import { Box3, Vector3 } from "three";
 import Volume from "../Volume";
 
 export class LoadSpec {
-  url = "";
   subpath = "";
   scene = 0;
   time = 0;
@@ -14,7 +13,7 @@ export class LoadSpec {
 
 export function loadSpecToString(spec: LoadSpec): string {
   const { min, max } = spec.subregion;
-  return `${spec.url}:${spec.subpath}${spec.scene}:${spec.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
+  return `${spec.subpath}:${spec.scene}:${spec.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
 }
 
 export class VolumeDims {

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -227,7 +227,7 @@ class JsonImageInfoLoader implements IVolumeLoader {
 
           for (let ch = 0; ch < Math.min(thisbatch.length, 4); ++ch) {
             volume.setChannelDataFromAtlas(thisbatch[ch], channelsBits[ch], w, h);
-            onChannelLoaded?.(url, volume, thisbatch[ch]);
+            onChannelLoaded?.(volume, thisbatch[ch]);
           }
         };
       })(batch);

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -90,12 +90,17 @@ const convertImageInfo = (json: JsonImageInfo): ImageInfo => ({
 });
 
 class JsonImageInfoLoader implements IVolumeLoader {
+  url: string;
   imageInfo: JsonImageInfo | null = null;
   imageArray: PackedChannelsImage[] = [];
 
-  async getImageInfo(loadSpec: LoadSpec): Promise<JsonImageInfo> {
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  async getImageInfo(_loadSpec: LoadSpec): Promise<JsonImageInfo> {
     if (!this.imageInfo) {
-      const response = await fetch(loadSpec.url);
+      const response = await fetch(this.url);
       const imageInfo = (await response.json()) as JsonImageInfo;
 
       imageInfo.pixel_size_unit = imageInfo.pixel_size_unit || "μm";
@@ -128,14 +133,13 @@ class JsonImageInfoLoader implements IVolumeLoader {
     return vol;
   }
 
-  async loadVolumeData(vol: Volume, explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<void> {
-    const loadSpec = explicitLoadSpec || vol.loadSpec;
+  async loadVolumeData(vol: Volume, _explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<void> {
     // if you need to adjust image paths prior to download,
     // now is the time to do it.
     // Try to figure out the urlPrefix from the LoadSpec.
     // For this format we assume the image data is in the same directory as the json file.
     // This regex removes everything after the last slash, so the url had better be simple.
-    const urlPrefix = loadSpec.url.replace(/[^/]*$/, "");
+    const urlPrefix = this.url.replace(/[^/]*$/, "");
     this.imageArray.forEach((element) => {
       element.name = urlPrefix + element.name;
     });

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -91,8 +91,8 @@ const convertImageInfo = (json: JsonImageInfo): ImageInfo => ({
 
 class JsonImageInfoLoader implements IVolumeLoader {
   urls: string[];
-  imageInfo: JsonImageInfo | null = null;
-  imageArray: PackedChannelsImage[] = [];
+  time: number;
+  jsonInfo: JsonImageInfo | null = null;
 
   constructor(urls: string | string[]) {
     if (Array.isArray(urls)) {
@@ -100,23 +100,21 @@ class JsonImageInfoLoader implements IVolumeLoader {
     } else {
       this.urls = [urls];
     }
+
+    this.time = 0;
   }
 
-  async getImageInfo(loadSpec: LoadSpec): Promise<JsonImageInfo> {
-    if (!this.imageInfo) {
-      const response = await fetch(this.urls[loadSpec.time]);
-      const imageInfo = (await response.json()) as JsonImageInfo;
+  async getJsonImageInfo(loadSpec: LoadSpec): Promise<JsonImageInfo> {
+    const response = await fetch(this.urls[loadSpec.time]);
+    const imageInfo = (await response.json()) as JsonImageInfo;
 
-      imageInfo.pixel_size_unit = imageInfo.pixel_size_unit || "μm";
-      this.imageInfo = imageInfo;
-
-      this.imageArray = imageInfo.images;
-    }
-    return this.imageInfo;
+    imageInfo.pixel_size_unit = imageInfo.pixel_size_unit || "μm";
+    imageInfo.times = imageInfo.times || this.urls.length;
+    return imageInfo;
   }
 
   async loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]> {
-    const jsonInfo = await this.getImageInfo(loadSpec);
+    const jsonInfo = await this.getJsonImageInfo(loadSpec);
 
     const d = new VolumeDims();
     d.subpath = "";
@@ -128,8 +126,9 @@ class JsonImageInfoLoader implements IVolumeLoader {
   }
 
   async createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
-    const jsonInfo = await this.getImageInfo(loadSpec);
-    const imageInfo = convertImageInfo(jsonInfo);
+    this.time = loadSpec.time;
+    this.jsonInfo = await this.getJsonImageInfo(loadSpec);
+    const imageInfo = convertImageInfo(this.jsonInfo);
 
     const vol = new Volume(imageInfo, loadSpec, this);
     vol.channelLoadCallback = onChannelLoaded;
@@ -142,13 +141,18 @@ class JsonImageInfoLoader implements IVolumeLoader {
     // now is the time to do it.
     // Try to figure out the urlPrefix from the LoadSpec.
     // For this format we assume the image data is in the same directory as the json file.
-    const time = explicitLoadSpec?.time || vol.loadSpec.time;
+    const loadSpec = explicitLoadSpec || vol.loadSpec;
+    if (this.time !== loadSpec.time) {
+      this.time = loadSpec.time;
+      this.jsonInfo = await this.getJsonImageInfo(loadSpec);
+    }
     // This regex removes everything after the last slash, so the url had better be simple.
-    const urlPrefix = this.urls[time].replace(/[^/]*$/, "");
-    this.imageArray.forEach((element) => {
-      element.name = urlPrefix + element.name;
-    });
-    JsonImageInfoLoader.loadVolumeAtlasData(vol, this.imageArray, onChannelLoaded);
+    const urlPrefix = this.urls[this.time].replace(/[^/]*$/, "");
+    const images = this.jsonInfo?.images.map((element) => ({ ...element, name: urlPrefix + element.name }));
+
+    if (images) {
+      JsonImageInfoLoader.loadVolumeAtlasData(vol, images, onChannelLoaded);
+    }
   }
 
   /**

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -390,7 +390,7 @@ class OMEZarrLoader implements IVolumeLoader {
       });
       if (cacheResult) {
         vol.setChannelDataFromVolume(i, cacheResult);
-        onChannelLoaded?.(this.url + "/" + vol.loadSpec.subpath, vol, i);
+        onChannelLoaded?.(vol, i);
       } else {
         const worker = new Worker(new URL("../workers/FetchZarrWorker", import.meta.url));
         worker.onmessage = (e) => {
@@ -403,7 +403,7 @@ class OMEZarrLoader implements IVolumeLoader {
             channel,
           });
           vol.setChannelDataFromVolume(channel, u8);
-          onChannelLoaded?.(this.url + "/" + vol.loadSpec.subpath, vol, channel);
+          onChannelLoaded?.(vol, channel);
           worker.terminate();
         };
         worker.onerror = (e) => {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -12,6 +12,7 @@ import {
 } from "./VolumeLoaderUtils";
 import Volume, { ImageInfo } from "../Volume";
 import { FetchZarrMessage } from "../workers/FetchZarrWorker";
+import VolumeCache, { CacheStore } from "../VolumeCache";
 
 const MAX_ATLAS_DIMENSION = 2048;
 
@@ -192,13 +193,22 @@ function pickLevelToLoad(
 }
 
 class OMEZarrLoader implements IVolumeLoader {
+  url: string;
   multiscaleDims?: number[][];
   metadata?: OMEZarrMetadata;
   axesTCZYX?: [number, number, number, number, number];
   maxExtent?: Box3;
 
+  cache?: VolumeCache;
+  cacheStore?: CacheStore;
+
+  constructor(url: string, cache?: VolumeCache) {
+    this.url = url;
+    this.cache = cache;
+  }
+
   async loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]> {
-    const store = new HTTPStore(loadSpec.url);
+    const store = new HTTPStore(this.url);
 
     const data = await openGroup(store, loadSpec.subpath, "r");
 
@@ -247,7 +257,7 @@ class OMEZarrLoader implements IVolumeLoader {
 
   async createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
     // Load metadata and dimensions.
-    const store = new HTTPStore(loadSpec.url);
+    const store = new HTTPStore(this.url);
     this.metadata = await loadMetadata(store, loadSpec);
     const imageIndex = imageIndexFromLoadSpec(loadSpec, this.metadata.multiscales);
     const multiscale = this.metadata.multiscales[imageIndex];
@@ -261,9 +271,12 @@ class OMEZarrLoader implements IVolumeLoader {
     const hasT = t > -1;
     const hasC = c > -1;
 
+    const shape0 = this.multiscaleDims[0];
     const levelToLoad = pickLevelToLoad(loadSpec, this.multiscaleDims, multiscale, this.axesTCZYX);
     const shapeLv = this.multiscaleDims[levelToLoad];
-    const shape0 = this.multiscaleDims[0];
+
+    const scaleSizes = this.multiscaleDims.map(([sx, sy, sz]) => new Vector3(sx, sy, sz));
+    this.cacheStore = this.cache?.addVolume(shape0[c], shape0[t], scaleSizes);
 
     // Assume all axes have the same units - we have no means of storing per-axis unit symbols
     const spaceUnitName = multiscale.axes[x].unit;
@@ -375,7 +388,7 @@ class OMEZarrLoader implements IVolumeLoader {
         const u8 = e.data.data;
         const channel = e.data.channel;
         vol.setChannelDataFromVolume(channel, u8);
-        onChannelLoaded?.(vol.loadSpec.url + "/" + vol.loadSpec.subpath, vol, channel);
+        onChannelLoaded?.(this.url + "/" + vol.loadSpec.subpath, vol, channel);
         worker.terminate();
       };
       worker.onerror = (e) => {

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -189,7 +189,7 @@ class TiffLoader implements IVolumeLoader {
         const channel = e.data.channel;
         vol.setChannelDataFromVolume(channel, u8);
         // make up a unique name? or have caller pass this in?
-        onChannelLoaded?.(this.url, vol, channel);
+        onChannelLoaded?.(vol, channel);
         worker.terminate();
       };
       worker.onerror = function (e) {

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -77,11 +77,16 @@ async function getDimsFromUrl(url: string): Promise<OMEDims> {
 const getBytesPerSample = (type: string): number => (type === "uint8" ? 1 : type === "uint16" ? 2 : 4);
 
 class TiffLoader implements IVolumeLoader {
+  url: string;
   dimensionOrder?: string;
   bytesPerSample?: number;
 
-  async loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]> {
-    const tiff = await fromUrl(loadSpec.url);
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  async loadDims(_loadSpec: LoadSpec): Promise<VolumeDims[]> {
+    const tiff = await fromUrl(this.url);
     // DO NOT DO THIS, ITS SLOW
     // const imagecount = await tiff.getImageCount();
     // read the FIRST image
@@ -103,7 +108,7 @@ class TiffLoader implements IVolumeLoader {
   }
 
   async createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
-    const dims = await getDimsFromUrl(loadSpec.url);
+    const dims = await getDimsFromUrl(this.url);
     // compare with sizex, sizey
     //const width = image.getWidth();
     //const height = image.getHeight();
@@ -152,12 +157,11 @@ class TiffLoader implements IVolumeLoader {
     return vol;
   }
 
-  async loadVolumeData(vol: Volume, explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<void> {
-    const url = explicitLoadSpec?.url || vol.loadSpec.url;
+  async loadVolumeData(vol: Volume, _explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<void> {
     vol.channelLoadCallback = onChannelLoaded;
     //
     if (this.bytesPerSample === undefined || this.dimensionOrder === undefined) {
-      const dims = await getDimsFromUrl(url);
+      const dims = await getDimsFromUrl(this.url);
 
       this.dimensionOrder = dims.dimensionorder;
       this.bytesPerSample = getBytesPerSample(dims.pixeltype);
@@ -177,15 +181,15 @@ class TiffLoader implements IVolumeLoader {
         sizez: imageInfo.volumeSize.z,
         dimensionOrder: this.dimensionOrder,
         bytesPerSample: this.bytesPerSample,
-        url: url,
+        url: this.url,
       };
       const worker = new Worker(new URL("../workers/FetchTiffWorker", import.meta.url));
-      worker.onmessage = function (e) {
+      worker.onmessage = (e) => {
         const u8 = e.data.data;
         const channel = e.data.channel;
         vol.setChannelDataFromVolume(channel, u8);
         // make up a unique name? or have caller pass this in?
-        onChannelLoaded?.(url, vol, channel);
+        onChannelLoaded?.(this.url, vol, channel);
         worker.terminate();
       };
       worker.onerror = function (e) {

--- a/src/test/VolumeCache.test.ts
+++ b/src/test/VolumeCache.test.ts
@@ -1,6 +1,6 @@
 import { Box3, Vector3 } from "three";
 import { expect } from "chai";
-import VolumeCache, { CachedVolume, DataArrayExtent } from "../VolumeCache";
+import VolumeCache, { CacheStore, DataArrayExtent } from "../VolumeCache";
 
 describe("VolumeCache", () => {
   it("creates an empty cache with the specified max size", () => {
@@ -77,7 +77,7 @@ describe("VolumeCache", () => {
      * - Volume 1 has 2 channels, 1 time, 2 scale levels: 2x1x1 and 4x2x2
      * - Volume 2 has 1 channel, 2 times, 1 scale level: 3x2x1
      */
-    function setupEvictionTest(): [VolumeCache, CachedVolume, CachedVolume] {
+    function setupEvictionTest(): [VolumeCache, CacheStore, CacheStore] {
       const cache = new VolumeCache(12);
       const id1 = cache.addVolume(2, 1, [new Vector3(2, 1, 1), new Vector3(4, 2, 2)]);
       const id2 = cache.addVolume(1, 2, [new Vector3(3, 2, 1)]);
@@ -147,7 +147,7 @@ describe("VolumeCache", () => {
   const SLICE_1_2 = [5, 6, 7, 8];
   const SLICE_2_1 = [2, 4, 6, 8];
   const SLICE_2_2 = [1, 3, 5, 7];
-  function setupGetTest(addSlices: [boolean, boolean, boolean, boolean]): [VolumeCache, CachedVolume] {
+  function setupGetTest(addSlices: [boolean, boolean, boolean, boolean]): [VolumeCache, CacheStore] {
     const cache = new VolumeCache(12);
     const vol = cache.addVolume(2, 1, [new Vector3(2, 2, 2)]);
     const insertFuncs = [
@@ -213,7 +213,7 @@ describe("VolumeCache", () => {
     region: new Box3(new Vector3(1, 1), new Vector3(2, 2)),
   };
 
-  function setupClearTest(): [VolumeCache, CachedVolume, CachedVolume] {
+  function setupClearTest(): [VolumeCache, CacheStore, CacheStore] {
     const cache = new VolumeCache();
     const id1 = cache.addVolume(2, 2, [new Vector3(1, 1, 1), new Vector3(2, 2, 2)]);
     const id2 = cache.addVolume(1, 1, [new Vector3(1, 1, 1)]);

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -5,6 +5,7 @@ import { Slice } from "zarr/types/core/types";
 import { LoadSpec } from "../loaders/IVolumeLoader";
 
 export type FetchZarrMessage = {
+  url: string;
   spec: Required<LoadSpec>;
   channel: number;
   path: string;
@@ -40,7 +41,7 @@ self.onmessage = async (e: MessageEvent<FetchZarrMessage>) => {
   const channelIndex = e.data.channel;
   const axesTCZYX = e.data.axesTCZYX;
 
-  const store = new HTTPStore(e.data.spec.url);
+  const store = new HTTPStore(e.data.url);
   const level = await openArray({ store: store, path: e.data.path, mode: "r" });
 
   // build slice spec


### PR DESCRIPTION
### TL;DR:

- Removed `url` property from `LoadSpec` in favor of passing URLs into `IVolumeLoader` constructors
- Replace test viewer's outdated time series playback with newer API
  - Allow `JsonImageInfoLoader` to accept an array of URLs to support JSON time series in the new API
- Add caching to `OMEZarrLoader` (but no other loaders so far)
- Made the API changes described in the list at the bottom of this comment

<hr />

Strap in, this one got away from me a bit.

The original intent of this PR was to address a comment in #134: now that loaders are stateful and `Volume`s may submit load requests to them at will, it makes sense to remove the `url` property from `LoadSpec` and set it in loader constructors instead.

I made this change, but this presented a problem for the example viewer. It used its own ad hoc time series playback mechanism, where a collection of JSON atlas volumes are treated as frames of a single time series. (Ideally I would have removed this when I added first class support for time series in #104, but I didn't have a means to also support JSON time series then.) All these volumes were previously loaded by the same `JsonImageInfoLoader`, but under this new stateful loader paradigm each frame would have required a new loader. In order to avoid this awkward situation, I replaced the old time series mechanism with the current `setTime` API, and supported the JSON time series by allowing `JsonImageInfoLoader` to accept an array of URLs representing time series frames. This has the added bonus of enabling new region-aware loading features in zarr time series, since the old mechanism would throw out and recreate volumes.

In order to preserve as much of the original behavior of the time series JSON as possible, my original intent was to also add cache support in this PR (partially addressing #126). I began this process with `OMEZarrLoader`, but found that `JsonImageInfoLoader` would have required more intensive changes, since its data arrives in atlased batches of (up to) four channels and is never converted to a cache-compatible format in the loader. So only zarrs get cached for now, but this at least demonstrates the API I want to extend to the other loaders and allows us to try out cache performance in the test viewer. (Note though: JSON time series frames are no longer prefetched!)

<hr />

I also made the following stray API tweaks:
- Removed the `url` parameter from the `PerChannelCallback` type. All callbacks passed to loaders ignored this parameter, both in the test viewer and in website-3d-cell-viewer.
- `setTime` accepts an optional `PerChannelCallback` like a loader method call would.
- Volumes now properly mark themselves as "unloaded" when loading new data
- Rename: `CachedVolume` -> `CacheStore` for clarity
