### PR TITLE
fix memory leak

### DIFF
--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -105,20 +105,25 @@ export default class Channel {
     return this.imgData.data[offset];
   }
 
-  // give the channel fresh data and initialize from that data
-  // data is formatted as a texture atlas where each tile is a z slice of the volume
-  public setBits(bitsArray: Uint8Array, w: number, h: number): void {
-    this.imgData = { data: new Uint8ClampedArray(bitsArray.buffer), width: w, height: h };
+  private rebuildDataTexture(data: Uint8ClampedArray, w: number, h: number): void {
     if (this.dataTexture) {
       this.dataTexture.dispose();
     }
-    this.dataTexture = new DataTexture(this.imgData.data, w, h);
+    this.dataTexture = new DataTexture(data, w, h);
     this.dataTexture.format = RedFormat;
     this.dataTexture.type = UnsignedByteType;
     this.dataTexture.magFilter = NearestFilter;
     this.dataTexture.minFilter = NearestFilter;
     this.dataTexture.generateMipmaps = false;
     this.dataTexture.needsUpdate = true;
+  }
+
+  // give the channel fresh data and initialize from that data
+  // data is formatted as a texture atlas where each tile is a z slice of the volume
+  public setBits(bitsArray: Uint8Array, w: number, h: number): void {
+    this.imgData = { data: new Uint8ClampedArray(bitsArray.buffer), width: w, height: h };
+
+    this.rebuildDataTexture(this.imgData.data, w, h);
 
     this.loaded = true;
     this.histogram = new Histogram(bitsArray);
@@ -212,16 +217,7 @@ export default class Channel {
       }
     }
 
-    if (this.dataTexture) {
-      this.dataTexture.dispose();
-    }
-    this.dataTexture = new DataTexture(this.imgData.data, ax, ay);
-    this.dataTexture.format = RedFormat;
-    this.dataTexture.type = UnsignedByteType;
-    this.dataTexture.magFilter = NearestFilter;
-    this.dataTexture.minFilter = NearestFilter;
-    this.dataTexture.generateMipmaps = false;
-    this.dataTexture.needsUpdate = true;
+    this.rebuildDataTexture(this.imgData.data, ax, ay);
   }
 
   // lut should be an uint8array of 256*4 elements (256 rgba8 values)

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -109,6 +109,9 @@ export default class Channel {
   // data is formatted as a texture atlas where each tile is a z slice of the volume
   public setBits(bitsArray: Uint8Array, w: number, h: number): void {
     this.imgData = { data: new Uint8ClampedArray(bitsArray.buffer), width: w, height: h };
+    if (this.dataTexture) {
+      this.dataTexture.dispose();
+    }
     this.dataTexture = new DataTexture(this.imgData.data, w, h);
     this.dataTexture.format = RedFormat;
     this.dataTexture.type = UnsignedByteType;
@@ -209,6 +212,9 @@ export default class Channel {
       }
     }
 
+    if (this.dataTexture) {
+      this.dataTexture.dispose();
+    }
     this.dataTexture = new DataTexture(this.imgData.data, ax, ay);
     this.dataTexture.format = RedFormat;
     this.dataTexture.type = UnsignedByteType;

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -16,7 +16,6 @@ import {
   OneFactor,
   CustomBlending,
   MaxEquation,
-  UniformsUtils,
   Texture,
 } from "three";
 import { LinearFilter } from "three/src/constants";

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -149,7 +149,7 @@ export default class FusedChannelData {
 
     // webgl draw one mesh per channel to fuse.  clear texture to 0,0,0,0
 
-    this.fuseScene.traverse(function (node) {
+    this.fuseScene.traverse((node) => {
       if (node instanceof Mesh) {
         // materials were holding references to the channel data textures
         // causing mem leak so we must dispose before clearing the scene


### PR DESCRIPTION
Fixes a memory leak.  
Reproduce:
1. select a time series and play through time (repeatedly)
2. either observe an eventual performance degradation and exception, or observe the javascript heap graph growing using devtools profiler.

The fix is to use threejs's `dispose` in key places that hold references to the data textures that contain the volume pixels.    

An alternative future code path was already presented in a TODO comment:  allocate the Materials to be used in `gpuFuse` as members of Channel, so that they can be encapsulated alongside their DataTextures and created/destroyed in the same place.