### PR TITLE
allow tiffs to load from server that doesn't support range requests

### DIFF
--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -61,7 +61,7 @@ function getOMEDims(imageEl: Element): OMEDims {
 }
 
 async function getDimsFromUrl(url: string): Promise<OMEDims> {
-  const tiff = await fromUrl(url);
+  const tiff = await fromUrl(url, { allowFullFile: true });
   // DO NOT DO THIS, ITS SLOW
   // const imagecount = await tiff.getImageCount();
   // read the FIRST image
@@ -86,7 +86,7 @@ class TiffLoader implements IVolumeLoader {
   }
 
   async loadDims(_loadSpec: LoadSpec): Promise<VolumeDims[]> {
-    const tiff = await fromUrl(this.url);
+    const tiff = await fromUrl(this.url, { allowFullFile: true });
     // DO NOT DO THIS, ITS SLOW
     // const imagecount = await tiff.getImageCount();
     // read the FIRST image

--- a/src/workers/FetchTiffWorker.ts
+++ b/src/workers/FetchTiffWorker.ts
@@ -53,7 +53,7 @@ self.onmessage = async function (e) {
   const dimensionOrder = e.data.dimensionOrder;
   const bytesPerSample = e.data.bytesPerSample;
 
-  const tiff = await fromUrl(e.data.url);
+  const tiff = await fromUrl(e.data.url, { allowFullFile: true });
 
   // load the images of this channel from the tiff
   // today assume TCZYX so the slices are already in order.


### PR DESCRIPTION
to support Amil's use case, he is running from a http server that doesn't support range requests.  This is a stopgap to just allow the whole tiff file to be downloaded in absence of range reqs.
