### PR TITLE
Rework `LoadSpec`

### DIFF
--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -130,6 +130,8 @@ export default class Volume {
   public imageInfo: ImageInfo;
   public loadSpec: LoadSpec;
   public loader?: IVolumeLoader;
+  // `LoadSpec` representing the minimum data required to display what's in the viewer (subregion, channels, etc.).
+  // Used to intelligently issue load requests whenever required by a state change. Modify with `updateRequiredData`.
   private loadSpecRequired: Required<LoadSpec>;
   public channelLoadCallback?: PerChannelCallback;
   public imageMetadata: Record<string, unknown>;

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -130,7 +130,7 @@ export default class Volume {
   public imageInfo: ImageInfo;
   public loadSpec: LoadSpec;
   public loader?: IVolumeLoader;
-  private loadSpecRequired: LoadSpec;
+  private loadSpecRequired: Required<LoadSpec>;
   public channelLoadCallback?: PerChannelCallback;
   public imageMetadata: Record<string, unknown>;
   public name: string;
@@ -161,7 +161,13 @@ export default class Volume {
     this.imageInfo = imageInfo;
     this.name = this.imageInfo.name;
     this.loadSpec = loadSpec;
-    this.loadSpecRequired = { ...loadSpec, subregion: loadSpec.subregion.clone() };
+    this.loadSpecRequired = {
+      // Fill in defaults for optional properties
+      multiscaleLevel: 0,
+      channels: Array.from({ length: this.imageInfo.numChannels }, (_val, idx) => idx),
+      ...loadSpec,
+      subregion: loadSpec.subregion.clone(),
+    };
     this.loader = loader;
     // imageMetadata to be filled in by Volume Loaders
     this.imageMetadata = {};
@@ -231,7 +237,12 @@ export default class Volume {
     ) {
       // ...clone `loadSpecRequired` into `loadSpec` and load
       this.setUnloaded();
-      this.loadSpec = { ...this.loadSpecRequired, subregion: this.loadSpecRequired.subregion.clone() };
+      this.loadSpec = {
+        ...this.loadSpecRequired,
+        subregion: this.loadSpecRequired.subregion.clone(),
+        // preserve multiscale option from original `LoadSpec`, if any
+        multiscaleLevel: this.loadSpec.multiscaleLevel,
+      };
       this.loader?.loadVolumeData(this, undefined, onChannelLoaded);
     }
   }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -6,7 +6,6 @@ export class LoadSpec {
   scene = 0;
   time = 0;
   multiscaleLevel?: number;
-  maxAtlasDimension = 4096;
   /** Subregion of volume to load. If not specified, the entire volume is loaded. Specify as floats between 0-1. */
   subregion = new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1));
   channels?: number[];
@@ -19,7 +18,7 @@ export function loadSpecToString(spec: LoadSpec): string {
 
 export class VolumeDims {
   subpath = "";
-  // shape: [t, c, z, y, x]
+  // shape: [t, c, z, y, x]n
   shape: number[] = [0, 0, 0, 0, 0];
   // spacing: [t, c, z, y, x]; generally expect 1 for non-spatial dimensions
   spacing: number[] = [1, 1, 1, 1, 1];

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -3,7 +3,6 @@ import { Box3, Vector3 } from "three";
 import Volume from "../Volume";
 
 export class LoadSpec {
-  subpath = "";
   scene = 0;
   time = 0;
   // sub-region; if not specified, the entire volume is loaded
@@ -13,7 +12,7 @@ export class LoadSpec {
 
 export function loadSpecToString(spec: LoadSpec): string {
   const { min, max } = spec.subregion;
-  return `${spec.subpath}:${spec.scene}:${spec.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
+  return `${spec.scene}:${spec.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
 }
 
 export class VolumeDims {

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -13,12 +13,12 @@ export class LoadSpec {
 
 export function loadSpecToString(spec: LoadSpec): string {
   const { min, max } = spec.subregion;
-  return `${spec.scene}:${spec.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
+  return `${spec.scene}:${spec.multiscaleLevel}:${spec.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
 }
 
 export class VolumeDims {
   subpath = "";
-  // shape: [t, c, z, y, x]n
+  // shape: [t, c, z, y, x]
   shape: number[] = [0, 0, 0, 0, 0];
   // spacing: [t, c, z, y, x]; generally expect 1 for non-spatial dimensions
   spacing: number[] = [1, 1, 1, 1, 1];

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -5,9 +5,11 @@ import Volume from "../Volume";
 export class LoadSpec {
   scene = 0;
   time = 0;
-  // sub-region; if not specified, the entire volume is loaded
-  // specify as floats between 0 and 1
+  multiscaleLevel?: number;
+  maxAtlasDimension = 4096;
+  /** Subregion of volume to load. If not specified, the entire volume is loaded. Specify as floats between 0-1. */
   subregion = new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1));
+  channels?: number[];
 }
 
 export function loadSpecToString(spec: LoadSpec): string {

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -1,4 +1,4 @@
-import { Vector2, Vector3 } from "three";
+import { Box3, Vector2, Vector3 } from "three";
 
 import { IVolumeLoader, LoadSpec, PerChannelCallback, VolumeDims } from "./IVolumeLoader";
 import { buildDefaultMetadata } from "./VolumeLoaderUtils";
@@ -162,6 +162,14 @@ class JsonImageInfoLoader implements IVolumeLoader {
     const urlPrefix = this.urls[this.time].replace(/[^/]*$/, "");
     images = images.map((element) => ({ ...element, name: urlPrefix + element.name }));
 
+    vol.loadSpec = {
+      ...loadSpec,
+      // `subregion` and `multiscaleLevel` are unused by this loader
+      subregion: new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1)),
+      multiscaleLevel: 0,
+      // include all channels in any loaded images
+      channels: images.flatMap(({ channels }) => channels),
+    };
     JsonImageInfoLoader.loadVolumeAtlasData(vol, images, onChannelLoaded);
   }
 

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -356,8 +356,9 @@ class OMEZarrLoader implements IVolumeLoader {
 
     const { nrows, ncols } = computePackedAtlasDims(regionSizePx.z, regionSizePx.x, regionSizePx.y);
 
+    const channelIndexes = vol.loadSpec.channels || Array.from({ length: numChannels }, (_val, idx) => idx);
     // do each channel on a worker
-    for (let i = 0; i < numChannels; ++i) {
+    for (const i of channelIndexes) {
       const cacheQueryDims = {
         region: regionPx,
         time: vol.loadSpec.time,

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -169,12 +169,12 @@ function pickLevelToLoad(loadSpec: LoadSpec, multiscaleDims: number[][], dimInde
     Math.max(shape[xi] * size.x, 1),
   ]);
 
-  const autoLevel = estimateLevelForAtlas(spatialDims, MAX_ATLAS_DIMENSION);
+  const optimalLevel = estimateLevelForAtlas(spatialDims, MAX_ATLAS_DIMENSION);
 
   if (loadSpec.multiscaleLevel) {
-    return Math.max(autoLevel, loadSpec.multiscaleLevel);
+    return Math.max(optimalLevel, loadSpec.multiscaleLevel);
   } else {
-    return autoLevel;
+    return optimalLevel;
   }
 }
 

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -48,7 +48,7 @@ class OpenCellLoader implements IVolumeLoader {
     };
 
     // got some data, now let's construct the volume.
-    // This loader uses no fields from `LoadSpec`. Iinitialize volume with defaults.
+    // This loader uses no fields from `LoadSpec`. Initialize volume with defaults.
     const vol = new Volume(imgdata, new LoadSpec(), this);
     vol.channelLoadCallback = onChannelLoaded;
     vol.imageMetadata = buildDefaultMetadata(imgdata);

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -17,7 +17,7 @@ class OpenCellLoader implements IVolumeLoader {
     return [d];
   }
 
-  async createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
+  async createVolume(_loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
     const numChannels = 2;
 
     // we know these are standardized to 600x600, two channels, one channel per jpg.
@@ -48,13 +48,14 @@ class OpenCellLoader implements IVolumeLoader {
     };
 
     // got some data, now let's construct the volume.
-    const vol = new Volume(imgdata, loadSpec, this);
+    // This loader uses no fields from `LoadSpec`. Iinitialize volume with defaults.
+    const vol = new Volume(imgdata, new LoadSpec(), this);
     vol.channelLoadCallback = onChannelLoaded;
     vol.imageMetadata = buildDefaultMetadata(imgdata);
     return vol;
   }
 
-  loadVolumeData(vol: Volume, _explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): void {
+  loadVolumeData(vol: Volume, _loadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): void {
     // HQTILE or LQTILE
     // make a json metadata dict for the two channels:
     const urls = [

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -99,7 +99,6 @@ class TiffLoader implements IVolumeLoader {
     const dims = getOMEDims(image0El);
 
     const d = new VolumeDims();
-    d.subpath = "";
     d.shape = [dims.sizet, dims.sizec, dims.sizez, dims.sizey, dims.sizex];
     d.spacing = [1, 1, dims.pixelsizez, dims.pixelsizey, dims.pixelsizex];
     d.spaceUnit = dims.unit ? dims.unit : "micron";
@@ -158,8 +157,6 @@ class TiffLoader implements IVolumeLoader {
   }
 
   async loadVolumeData(vol: Volume, _explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<void> {
-    vol.channelLoadCallback = onChannelLoaded;
-    //
     if (this.bytesPerSample === undefined || this.dimensionOrder === undefined) {
       const dims = await getDimsFromUrl(this.url);
 
@@ -192,7 +189,7 @@ class TiffLoader implements IVolumeLoader {
         onChannelLoaded?.(vol, channel);
         worker.terminate();
       };
-      worker.onerror = function (e) {
+      worker.onerror = (e) => {
         alert("Error: Line " + e.lineno + " in " + e.filename + ": " + e.message);
       };
       worker.postMessage(params);

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -146,7 +146,7 @@ class TiffLoader implements IVolumeLoader {
       },
     };
 
-    // This loader uses no fields from `LoadSpec`. Iinitialize volume with defaults.
+    // This loader uses no fields from `LoadSpec`. Initialize volume with defaults.
     const vol = new Volume(imgdata, new LoadSpec(), this);
     vol.channelLoadCallback = onChannelLoaded;
     vol.imageMetadata = buildDefaultMetadata(imgdata);

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -106,7 +106,7 @@ class TiffLoader implements IVolumeLoader {
     return [d];
   }
 
-  async createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
+  async createVolume(_loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
     const dims = await getDimsFromUrl(this.url);
     // compare with sizex, sizey
     //const width = image.getWidth();
@@ -146,7 +146,8 @@ class TiffLoader implements IVolumeLoader {
       },
     };
 
-    const vol = new Volume(imgdata, loadSpec, this);
+    // This loader uses no fields from `LoadSpec`. Iinitialize volume with defaults.
+    const vol = new Volume(imgdata, new LoadSpec(), this);
     vol.channelLoadCallback = onChannelLoaded;
     vol.imageMetadata = buildDefaultMetadata(imgdata);
 
@@ -156,7 +157,7 @@ class TiffLoader implements IVolumeLoader {
     return vol;
   }
 
-  async loadVolumeData(vol: Volume, _explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<void> {
+  async loadVolumeData(vol: Volume, loadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<void> {
     if (this.bytesPerSample === undefined || this.dimensionOrder === undefined) {
       const dims = await getDimsFromUrl(this.url);
 

--- a/src/workers/FetchZarrWorker.ts
+++ b/src/workers/FetchZarrWorker.ts
@@ -1,12 +1,12 @@
 import { HTTPStore, openArray, slice, TypedArray } from "zarr";
 import { RawArray } from "zarr/types/rawArray";
 import { Slice } from "zarr/types/core/types";
-
-import { LoadSpec } from "../loaders/IVolumeLoader";
+import { Box3 } from "three";
 
 export type FetchZarrMessage = {
   url: string;
-  spec: Required<LoadSpec>;
+  time: number;
+  subregion: Box3;
   channel: number;
   path: string;
   axesTCZYX: number[];
@@ -37,7 +37,7 @@ function convertChannel(channelData: TypedArray, dtype: string): Uint8Array {
 }
 
 self.onmessage = async (e: MessageEvent<FetchZarrMessage>) => {
-  const time = e.data.spec.time;
+  const time = e.data.time;
   const channelIndex = e.data.channel;
   const axesTCZYX = e.data.axesTCZYX;
 
@@ -45,7 +45,7 @@ self.onmessage = async (e: MessageEvent<FetchZarrMessage>) => {
   const level = await openArray({ store: store, path: e.data.path, mode: "r" });
 
   // build slice spec
-  const { min, max } = e.data.spec.subregion;
+  const { min, max } = e.data.subregion;
   const unorderedSpec = [time, channelIndex, slice(min.z, max.z), slice(min.y, max.y), slice(min.x, max.x)];
 
   const specLen = 3 + Number(axesTCZYX[0] > -1) + Number(axesTCZYX[1] > -1);


### PR DESCRIPTION
Fully resolves #134: reworks `LoadSpec` to have all the fields we want and none of the fields we don't.

- Removed field: `subpath`. No one wanted to use it.
- Added optional field: `multiscaleLevel`. This specifies which scale level to load (in zarr only). The loader will still pick the optimal level if `multiscaleLevel` is undefined or larger than the texture limits, so this is more like a "minimum downsampling level."
- Added optional field: `channels`. This lets you pick a subset of channel indexes to load.

Also, updated loaders to always set `Volume.loadSpec` to reflect the data that was *actually* loaded, rather than the `LoadSpec` that was passed in. E.g. no loader other than zarr can use `subregion`, so keep it set to the max. And since json loader has to load channels in static groups of (up to) four, when the user requests some subset of channels, also include all the channels that came along with the requested channel's images.