### PR TITLE
Simplify Cache

### DIFF
--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -12,8 +12,6 @@ type CacheEntry = {
   key: string;
 };
 
-// Entries are indexed by T and C, then stored in lists of ZYX chunks
-// type CacheStore = CacheEntry[][][][];
 export type CacheStore = Map<string, CacheEntry>;
 
 /** Default: 250MB. Should be large enough to be useful but safe for most any computer that can run the app */
@@ -40,12 +38,12 @@ export default class VolumeCache {
   }
 
   // Hide these behind getters so they're definitely never set from the outside
-  /** The size of all data arrays currently stored in this cache, in bytes */
+  /** The size of all data arrays currently stored in this cache, in bytes. */
   public get size() {
     return this.currentSize;
   }
 
-  /** The number of entries currently stored in this cache */
+  /** The number of entries currently stored in this cache. */
   public get numberOfEntries() {
     return this.currentEntries;
   }
@@ -80,7 +78,7 @@ export default class VolumeCache {
     }
   }
 
-  /** Adds an entry which is *not currently in the list* to the front of the list */
+  /** Adds an entry which is *not currently in the list* to the front of the list. */
   private addEntryAsFirst(entry: CacheEntry): void {
     if (this.first) {
       this.first.prev = entry;
@@ -92,14 +90,14 @@ export default class VolumeCache {
     this.first = entry;
   }
 
-  /** Moves an entry which is *currently in the list* to the front of the list */
+  /** Moves an entry which is *currently in the list* to the front of the list. */
   private moveEntryToFirst(entry: CacheEntry): void {
     if (entry === this.first) return;
     this.removeEntryFromList(entry);
     this.addEntryAsFirst(entry);
   }
 
-  /** Evicts the least recently used entry from the cache */
+  /** Evicts the least recently used entry from the cache. */
   private evictLast(): void {
     if (!this.last) {
       console.error("VolumeCache: attempt to evict last entry from cache when no last entry is set");
@@ -114,15 +112,15 @@ export default class VolumeCache {
     this.last = this.last.prev;
   }
 
-  /** Evicts a specific entry from the cache */
+  /** Evicts a specific entry from the cache. */
   private evict(entry: CacheEntry): void {
     this.removeEntryFromStore(entry);
     this.removeEntryFromList(entry);
   }
 
   /**
-   * Add a new array to the cache (representing a subset of a channel's extent at a given time and scale)
-   * @returns {boolean} a boolean indicating whether the insertion succeeded
+   * Add a new entry to the cache.
+   * @returns {boolean} a boolean indicating whether the insertion succeeded.
    */
   public insert(parentStore: CacheStore, key: string, data: ArrayBuffer): boolean {
     if (data.byteLength > this.maxSize) {
@@ -166,14 +164,14 @@ export default class VolumeCache {
     return this.getEntry(store, key)?.data;
   }
 
-  /** Clears data associated with one store from the cache */
+  /** Clears data associated with one store from the cache. */
   public clearStore(store: CacheStore): void {
     for (const entry of store.values()) {
       this.evict(entry);
     }
   }
 
-  /** Clears all data from the cache */
+  /** Clears all data from the cache. */
   public clear(): void {
     while (this.last) {
       this.evictLast();

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -140,7 +140,6 @@ export default class VolumeCache {
   }
 
   /** Evicts a specific entry from the cache */
-  // TODO use this to intelligently evict redundant data
   private evict(entry: CacheEntry): void {
     this.removeEntryFromStore(entry);
     this.removeEntryFromList(entry);
@@ -210,15 +209,8 @@ export default class VolumeCache {
     return true;
   }
 
-  /**
-   * Attempts to get data from a single channel. Internal implementation of `get`,
-   * which is overloaded to call this in different patterns.
-   */
-  private getOneChannel(
-    volume: CacheStore,
-    channel: number,
-    optDims: Partial<QueryExtent> = {}
-  ): ArrayBuffer | undefined {
+  /** Attempt to get a single entry from the cache. */
+  private get(volume: CacheStore, channel: number, optDims: Partial<QueryExtent> = {}): ArrayBuffer | undefined {
     // TODO allow searching through a range of scales and picking the highest available one
     const scaleCache = volume.scales[optDims.scale || 0];
     const entryList = scaleCache.data[optDims.time || 0][channel];
@@ -232,29 +224,6 @@ export default class VolumeCache {
     }
 
     return undefined;
-  }
-
-  /** Attempts to get data from a single channel of a cached volume. Returns `undefined` if not present in the cache. */
-  public get(volume: CacheStore, channel: number, optDims?: Partial<QueryExtent>): ArrayBuffer | undefined;
-  /** Attempts to get data from multiple channels of a volume. Channels not present in the cache are `undefined`. */
-  public get(volume: CacheStore, channel: number[], optDims?: Partial<QueryExtent>): (ArrayBuffer | undefined)[];
-  /** Attempts to get all channels of a volume from the cache. Channels not present in the cache are `undefined`. */
-  public get(volume: CacheStore, optDims?: Partial<QueryExtent>): (ArrayBuffer | undefined)[];
-  public get(
-    volume: CacheStore,
-    channel?: number | number[] | Partial<QueryExtent>,
-    optDims?: Partial<QueryExtent>
-  ): ArrayBuffer | undefined | (ArrayBuffer | undefined)[] {
-    if (Array.isArray(channel)) {
-      return channel.map((c) => this.getOneChannel(volume, c, optDims));
-    }
-
-    if (typeof channel === "object" || channel === undefined) {
-      const channelKeys = [...Array(volume.numChannels).keys()];
-      return channelKeys.map((c) => this.getOneChannel(volume, c, channel));
-    }
-
-    return this.getOneChannel(volume, channel, optDims);
   }
 
   /** Clears data associated with one volume from the cache */

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -159,6 +159,14 @@ export default class VolumeCache {
     return this.getEntry(key)?.data;
   }
 
+  public clearWithPrefix(prefix: string): void {
+    for (const [key, entry] of this.entries.entries()) {
+      if (key.startsWith(prefix)) {
+        this.evict(entry);
+      }
+    }
+  }
+
   /** Clears all data from the cache. */
   public clear(): void {
     while (this.last) {

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -6,7 +6,7 @@ type CacheEntry = {
   prev: MaybeCacheEntry;
   /** The next entry in the LRU list (less recently used) */
   next: MaybeCacheEntry;
-  /** The key which indexes this entry within `parentStore */
+  /** The key which indexes this entry */
   key: string;
 };
 

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -115,7 +115,7 @@ export default class VolumeCache {
   }
 
   /**
-   * Add a new entry to the cache.
+   * Adds a new entry to the cache.
    * @returns {boolean} a boolean indicating whether the insertion succeeded.
    */
   public insert(key: string, data: ArrayBuffer): boolean {
@@ -154,11 +154,12 @@ export default class VolumeCache {
     return result;
   }
 
-  /** Attempt to get a single entry from the cache. */
+  /** Attempts to get a single entry from the cache. */
   public get(key: string): ArrayBuffer | undefined {
     return this.getEntry(key)?.data;
   }
 
+  /** Clears all cache entries whose keys begin with the specified prefix. */
   public clearWithPrefix(prefix: string): void {
     for (const [key, entry] of this.entries.entries()) {
       if (key.startsWith(prefix)) {

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -132,7 +132,9 @@ export default class VolumeCache {
 
     // Check if entry is already in cache
     // This will move the entry to the front of the LRU list, if present
-    if (this.get(parentStore, key) !== undefined) {
+    const getResult = this.getEntry(parentStore, key);
+    if (getResult !== undefined) {
+      getResult.data = data;
       return true;
     }
 
@@ -150,14 +152,18 @@ export default class VolumeCache {
     return true;
   }
 
-  /** Attempt to get a single entry from the cache. */
-  public get(store: CacheStore, key: string): ArrayBuffer | undefined {
+  /** Internal implementation of `get`. Returns all entry metadata, not just the raw data. */
+  private getEntry(store: CacheStore, key: string): CacheEntry | undefined {
     const result = store.get(key);
     if (result) {
       this.moveEntryToFirst(result);
-      return result.data;
     }
-    return undefined;
+    return result;
+  }
+
+  /** Attempt to get a single entry from the cache. */
+  public get(store: CacheStore, key: string): ArrayBuffer | undefined {
+    return this.getEntry(store, key)?.data;
   }
 
   /** Clears data associated with one store from the cache */

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -30,9 +30,7 @@ type CacheEntry = {
 };
 
 // Entries are indexed by T and C, then stored in lists of ZYX chunks
-type CacheStoreMultiscaleLevel = CacheEntry[][][];
-
-export type CacheStore = CacheStoreMultiscaleLevel[];
+type CacheStore = CacheEntry[][][][];
 
 /** Default: 250MB. Should be large enough to be useful but safe for most any computer that can run the app */
 const CACHE_MAX_SIZE_DEFAULT = 250_000_000;
@@ -156,7 +154,7 @@ export default class VolumeCache {
       return tArr;
     };
 
-    const scales = scaleDims.map((size): CacheStoreMultiscaleLevel => makeTCArray());
+    const scales = scaleDims.map((size): CacheEntry[][][] => makeTCArray());
     return scales;
   }
 

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -29,11 +29,8 @@ type CacheEntry = {
   parentArr: CacheEntry[];
 };
 
-type CacheStoreMultiscaleLevel = {
-  // Entries are indexed by T and C, then stored in lists of ZYX chunks
-  data: CacheEntry[][][];
-  size: Vector3;
-};
+// Entries are indexed by T and C, then stored in lists of ZYX chunks
+type CacheStoreMultiscaleLevel = CacheEntry[][][];
 
 export type CacheStore = CacheStoreMultiscaleLevel[];
 
@@ -159,7 +156,7 @@ export default class VolumeCache {
       return tArr;
     };
 
-    const scales = scaleDims.map((size): CacheStoreMultiscaleLevel => ({ size, data: makeTCArray() }));
+    const scales = scaleDims.map((size): CacheStoreMultiscaleLevel => makeTCArray());
     return scales;
   }
 
@@ -169,7 +166,7 @@ export default class VolumeCache {
    */
   public insert(volume: CacheStore, data: ArrayBuffer, optDims: Partial<DataArrayExtent> = {}): boolean {
     const scaleCache = volume[optDims.scale || 0];
-    const entryList = scaleCache.data[optDims.time || 0][optDims.channel || 0];
+    const entryList = scaleCache[optDims.time || 0][optDims.channel || 0];
     const chunk = optDims.chunk ?? new Vector3(0, 0, 0);
 
     if (data.byteLength > this.maxSize) {
@@ -204,7 +201,7 @@ export default class VolumeCache {
   private get(volume: CacheStore, channel: number, optDims: Partial<QueryExtent> = {}): ArrayBuffer | undefined {
     // TODO allow searching through a range of scales and picking the highest available one
     const scaleCache = volume[optDims.scale || 0];
-    const entryList = scaleCache.data[optDims.time || 0][channel];
+    const entryList = scaleCache[optDims.time || 0][channel];
     const chunk = optDims.chunk ?? new Vector3(0, 0, 0);
 
     for (const entry of entryList) {
@@ -220,7 +217,7 @@ export default class VolumeCache {
   /** Clears data associated with one volume from the cache */
   public clearVolume(volume: CacheStore): void {
     volume.forEach((scale) => {
-      scale.data.forEach((time) => {
+      scale.forEach((time) => {
         time.forEach((channel) => {
           channel.forEach((entry) => {
             this.evict(entry);

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -1,20 +1,3 @@
-import { Vector3 } from "three";
-
-// The following two very similar types are kept separate because we may later want to allow more
-// complex queries with respect to scale, e.g. "get the largest available scale within this range"
-export type DataArrayExtent = {
-  chunk: Vector3;
-  scale: number;
-  time: number;
-  channel: number;
-};
-
-export type QueryExtent = {
-  chunk: Vector3;
-  scale: number;
-  time: number;
-};
-
 type MaybeCacheEntry = CacheEntry | null;
 type CacheEntry = {
   /** The data contained in this entry */
@@ -187,7 +170,7 @@ export default class VolumeCache {
   }
 
   /** Clears data associated with one store from the cache */
-  public clearVolume(store: CacheStore): void {
+  public clearStore(store: CacheStore): void {
     for (const entry of store.values()) {
       this.evict(entry);
     }

--- a/src/VolumeCache.ts
+++ b/src/VolumeCache.ts
@@ -121,15 +121,6 @@ export default class VolumeCache {
   }
 
   /**
-   * Prepares a new cached volume with the specified channels, times, and scales.
-   * @returns {CacheStore} A container for cache entries for this volume.
-   * A `CacheStore` may only be accessed or modified by passing it to this class's methods.
-   */
-  public addVolume(): CacheStore {
-    return new Map();
-  }
-
-  /**
    * Add a new array to the cache (representing a subset of a channel's extent at a given time and scale)
    * @returns {boolean} a boolean indicating whether the insertion succeeded
    */

--- a/src/test/VolumeCache.test.ts
+++ b/src/test/VolumeCache.test.ts
@@ -112,19 +112,19 @@ describe("VolumeCache", () => {
     return cache;
   }
 
-  // describe("clearVolume", () => {
-  //   it("clears all entries associated with one volume from the cache", () => {
-  //     const cache = setupClearTest();
-  //     cache.clearStore(store0);
+  describe("clearWithPrefix", () => {
+    it("clears all entries from the cache whose keys have the specified prefix", () => {
+      const cache = setupClearTest();
+      cache.clearWithPrefix("0/");
 
-  //     expect(cache.size).to.equal(1);
-  //     expect(cache.numberOfEntries).to.equal(1);
+      expect(cache.size).to.equal(1);
+      expect(cache.numberOfEntries).to.equal(1);
 
-  //     expect(cache.get(store0, "0")).to.be.undefined;
-  //     expect(cache.get(store0, "1")).to.be.undefined;
-  //     expect(cache.get(store1, "0")).to.deep.equal(new Uint8Array(1));
-  //   });
-  // });
+      expect(cache.get("0/0")).to.be.undefined;
+      expect(cache.get("0/1")).to.be.undefined;
+      expect(cache.get("1/0")).to.deep.equal(new Uint8Array(1));
+    });
+  });
 
   describe("clear", () => {
     it("clears all entries from the cache", () => {

--- a/src/test/VolumeCache.test.ts
+++ b/src/test/VolumeCache.test.ts
@@ -1,8 +1,5 @@
-import { Vector3 } from "three";
 import { expect } from "chai";
-import VolumeCache, { CacheStore } from "../VolumeCache";
-
-const setupEvictionTest = (): [VolumeCache, CacheStore, CacheStore] => [new VolumeCache(12), new Map(), new Map()];
+import VolumeCache from "../VolumeCache";
 
 describe("VolumeCache", () => {
   it("creates an empty cache with the specified max size", () => {
@@ -14,79 +11,62 @@ describe("VolumeCache", () => {
   describe("insert", () => {
     it("adds a new entry to the cache", () => {
       const cache = new VolumeCache();
-      const store: CacheStore = new Map();
-      expect(cache.get(store, "1")).to.be.undefined;
+      expect(cache.get("1")).to.be.undefined;
 
-      const insertionResult = cache.insert(store, "1", new Uint8Array(4));
+      const insertionResult = cache.insert("1", new Uint8Array(4));
       expect(insertionResult).to.be.true;
-      expect(cache.get(store, "1")).to.deep.equal(new Uint8Array(4));
+      expect(cache.get("1")).to.deep.equal(new Uint8Array(4));
     });
 
     it("does not insert an entry if it is too big for the cache", () => {
       const cache = new VolumeCache(6);
-      const store: CacheStore = new Map();
-      const insertionResult = cache.insert(store, "1", new Uint8Array(8));
+      const insertionResult = cache.insert("1", new Uint8Array(8));
       expect(insertionResult).to.be.false;
-      expect(cache.get(store, "1")).to.be.undefined;
+      expect(cache.get("1")).to.be.undefined;
     });
 
     it("evicts the least recently used entry when above its size limit", () => {
-      const [cache, store0] = setupEvictionTest(); // max: 12
+      const cache = new VolumeCache(12); // max: 12
 
-      cache.insert(store0, "0", new Uint8Array(8)); // 8 < 12
-      cache.insert(store0, "1", new Uint8Array(2)); // 10 < 12
-      cache.insert(store0, "2", new Uint8Array(8)); // 18 > 12! evict 1!
+      cache.insert("0", new Uint8Array(8)); // 8 < 12
+      cache.insert("1", new Uint8Array(2)); // 10 < 12
+      cache.insert("2", new Uint8Array(8)); // 18 > 12! evict 1!
 
       expect(cache.size).to.equal(10);
       expect(cache.numberOfEntries).to.equal(2);
 
-      expect(cache.get(store0, "0")).to.be.undefined;
-      expect(cache.get(store0, "1")).to.deep.equal(new Uint8Array(2));
-      expect(cache.get(store0, "2")).to.deep.equal(new Uint8Array(8));
-    });
-
-    it("evicts the least recently used entry regardless of which volume it's in", () => {
-      const [cache, store0, store1] = setupEvictionTest();
-
-      cache.insert(store0, "0", new Uint8Array(2)); // 2
-      cache.insert(store1, "0", new Uint8Array(6)); // 8
-      cache.insert(store1, "1", new Uint8Array(6)); // 14!
-
-      expect(cache.size).to.equal(12);
-      expect(cache.numberOfEntries).to.equal(2);
-
-      expect(cache.get(store0, "0")).to.be.undefined;
-      expect(cache.get(store1, "0")).to.deep.equal(new Uint8Array(6));
-      expect(cache.get(store1, "1")).to.deep.equal(new Uint8Array(6));
+      expect(cache.get("0")).to.be.undefined;
+      expect(cache.get("1")).to.deep.equal(new Uint8Array(2));
+      expect(cache.get("2")).to.deep.equal(new Uint8Array(8));
     });
 
     it("evicts as many entries as it takes to get below max size", () => {
-      const [cache, store0, store1] = setupEvictionTest();
+      const cache = new VolumeCache(12);
 
-      cache.insert(store1, "0", new Uint8Array(6)); // 6
-      cache.insert(store1, "1", new Uint8Array(6)); // 12
-      cache.insert(store0, "0", new Uint8Array(8)); // 20!
+      cache.insert("0", new Uint8Array(6)); // 6
+      cache.insert("1", new Uint8Array(6)); // 12
+      cache.insert("2", new Uint8Array(8)); // 20!
 
       expect(cache.size).to.equal(8);
       expect(cache.numberOfEntries).to.equal(1);
 
-      expect(cache.get(store1, "0")).to.be.undefined;
-      expect(cache.get(store1, "1")).to.be.undefined;
-      expect(cache.get(store0, "0")).to.deep.equal(new Uint8Array(8));
+      expect(cache.get("0")).to.be.undefined;
+      expect(cache.get("1")).to.be.undefined;
+      expect(cache.get("2")).to.deep.equal(new Uint8Array(8));
     });
 
     it("reuses any entries that match the provided key", () => {
-      const [cache, store0] = setupEvictionTest();
+      const cache = new VolumeCache(12);
 
-      cache.insert(store0, "0", new Uint8Array([1, 2, 3, 4])); // 4
-      cache.insert(store0, "1", new Uint8Array(8)); // 12
-      cache.insert(store0, "0", new Uint8Array([5, 6, 7, 8])); // still 12
+      cache.insert("0", new Uint8Array([1, 2, 3, 4])); // 4
+      cache.insert("1", new Uint8Array(8)); // 12
+      cache.insert("0", new Uint8Array([5, 6, 7, 8])); // still 12
 
       expect(cache.size).to.equal(12);
       expect(cache.numberOfEntries).to.equal(2);
 
-      expect(cache.get(store0, "1")).to.deep.equal(new Uint8Array(8));
-      expect(cache.get(store0, "0")).to.deep.equal(new Uint8Array([5, 6, 7, 8]));
+      expect(cache.get("1")).to.deep.equal(new Uint8Array(8));
+      expect(cache.get("0")).to.deep.equal(new Uint8Array([5, 6, 7, 8]));
     });
   });
 
@@ -94,71 +74,70 @@ describe("VolumeCache", () => {
   const SLICE_1 = [5, 6, 7, 8];
   const SLICE_2 = [2, 4, 6, 8];
   const SLICE_3 = [1, 3, 5, 7];
-  function setupGetTest(): [VolumeCache, CacheStore] {
+  function setupGetTest(): VolumeCache {
     const cache = new VolumeCache(12);
-    const store: CacheStore = new Map();
-    cache.insert(store, "0", new Uint8Array(SLICE_0));
-    cache.insert(store, "1", new Uint8Array(SLICE_1));
-    cache.insert(store, "2", new Uint8Array(SLICE_2));
-    return [cache, store];
+    cache.insert("0", new Uint8Array(SLICE_0));
+    cache.insert("1", new Uint8Array(SLICE_1));
+    cache.insert("2", new Uint8Array(SLICE_2));
+    return cache;
   }
 
   describe("get", () => {
     it("gets an entry when provided a key", () => {
-      const [cache, store] = setupGetTest();
-      const result = cache.get(store, "1");
+      const cache = setupGetTest();
+      const result = cache.get("1");
       expect(result).to.deep.equal(new Uint8Array(SLICE_1));
     });
 
     it("moves returned entries to the front of the LRU queue", () => {
-      const [cache, id] = setupGetTest(); // size: 12; max: 12
+      const cache = setupGetTest(); // size: 12; max: 12
 
-      cache.get(id, "0"); // SLICE_0 moves from last to first; SLICE_1 is now last
-      cache.insert(id, "3", new Uint8Array(SLICE_3)); // 16! evict SLICE_1
+      cache.get("0"); // SLICE_0 moves from last to first; SLICE_1 is now last
+      cache.insert("3", new Uint8Array(SLICE_3)); // 16! evict SLICE_1
 
-      expect(cache.get(id, "0")).to.deep.equal(new Uint8Array(SLICE_0));
-      expect(cache.get(id, "1")).to.be.undefined;
-      expect(cache.get(id, "2")).to.deep.equal(new Uint8Array(SLICE_2));
-      expect(cache.get(id, "3")).to.deep.equal(new Uint8Array(SLICE_3));
+      expect(cache.get("0")).to.deep.equal(new Uint8Array(SLICE_0));
+      expect(cache.get("1")).to.be.undefined;
+      expect(cache.get("2")).to.deep.equal(new Uint8Array(SLICE_2));
+      expect(cache.get("3")).to.deep.equal(new Uint8Array(SLICE_3));
     });
   });
 
-  function setupClearTest(): [VolumeCache, CacheStore, CacheStore] {
-    const [cache, store0, store1] = setupEvictionTest();
+  function setupClearTest(): VolumeCache {
+    const cache = new VolumeCache(12);
 
-    cache.insert(store0, "0", new Uint8Array(1));
-    cache.insert(store0, "1", new Uint8Array(2));
-    cache.insert(store1, "0", new Uint8Array(1));
+    cache.insert("0/0", new Uint8Array(1));
+    cache.insert("0/1", new Uint8Array(2));
+    cache.insert("1/0", new Uint8Array(1));
 
-    return [cache, store0, store1];
+    return cache;
   }
 
-  describe("clearVolume", () => {
-    it("clears all entries associated with one volume from the cache", () => {
-      const [cache, store0, store1] = setupClearTest();
-      cache.clearStore(store0);
+  // describe("clearVolume", () => {
+  //   it("clears all entries associated with one volume from the cache", () => {
+  //     const cache = setupClearTest();
+  //     cache.clearStore(store0);
 
-      expect(cache.size).to.equal(1);
-      expect(cache.numberOfEntries).to.equal(1);
+  //     expect(cache.size).to.equal(1);
+  //     expect(cache.numberOfEntries).to.equal(1);
 
-      expect(cache.get(store0, "0")).to.be.undefined;
-      expect(cache.get(store0, "1")).to.be.undefined;
-      expect(cache.get(store1, "0")).to.deep.equal(new Uint8Array(1));
-    });
-  });
+  //     expect(cache.get(store0, "0")).to.be.undefined;
+  //     expect(cache.get(store0, "1")).to.be.undefined;
+  //     expect(cache.get(store1, "0")).to.deep.equal(new Uint8Array(1));
+  //   });
+  // });
 
   describe("clear", () => {
     it("clears all entries from the cache", () => {
-      const [cache, store0, store1] = setupClearTest();
+      const cache = setupClearTest();
 
       cache.clear();
 
       expect(cache.size).to.equal(0);
       expect(cache.numberOfEntries).to.equal(0);
 
-      expect(cache.get(store0, "0")).to.be.undefined;
-      expect(cache.get(store0, "1")).to.be.undefined;
-      expect(cache.get(store1, "0")).to.be.undefined;
+      expect(cache.get("0/0")).to.be.undefined;
+      expect(cache.get("0/1")).to.be.undefined;
+      expect(cache.get("1/0")).to.be.undefined;
     });
   });
 });

--- a/src/test/VolumeCache.test.ts
+++ b/src/test/VolumeCache.test.ts
@@ -35,7 +35,7 @@ describe("VolumeCache", () => {
 
       cache.insert(store0, "0", new Uint8Array(8)); // 8 < 12
       cache.insert(store0, "1", new Uint8Array(2)); // 10 < 12
-      cache.insert(store0, "1", new Uint8Array(8)); // 18 > 12! evict 1!
+      cache.insert(store0, "2", new Uint8Array(8)); // 18 > 12! evict 1!
 
       expect(cache.size).to.equal(10);
       expect(cache.numberOfEntries).to.equal(2);


### PR DESCRIPTION
Resolves #152: `VolumeCache` used to be set up to store arbitrary volume subsets, but is now used to represent a fixed set of volume chunks. We're not likely to ever use the more "advanced" dimension-aware indexing again, so there's no point keeping it around.

This PR changes `VolumeCache` to just index entries by string keys, updates loaders to get and insert using string keys, and updates tests.