### PR TITLE
Load single slices at higher resolution

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -978,6 +978,9 @@ function createTestVolume() {
     timeScale: 1,
     timeUnit: "",
 
+    numMultiscaleLevels: 1,
+    multiscaleLevel: 0,
+
     transform: { translation: new Vector3(0, 0, 0), rotation: new Vector3(0, 0, 0) },
   };
 

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -240,7 +240,6 @@ export default class Volume {
     this.loadSpecRequired = { ...this.loadSpecRequired, ...required };
     let noReload =
       this.loadSpec.time === this.loadSpecRequired.time &&
-      this.loadSpec.scene === this.loadSpecRequired.scene &&
       this.loadSpec.subregion.containsBox(this.loadSpecRequired.subregion);
 
     // An update to `subregion` should trigger a reload when the new subregion is not contained in the old one

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -250,9 +250,7 @@ export default class Volume {
       const minScale = this.loadSpec.multiscaleLevel ?? 0;
       // Loaders should cache loaded dimensions so that this call blocks no more than once per valid `LoadSpec`.
       const dims = await this.loader?.loadDims(this.loadSpecRequired);
-      if (dims && currentScale > minScale && dims[currentScale - 1].canLoad) {
-        noReload = false;
-      }
+      noReload = !dims || currentScale <= minScale || !dims[currentScale - 1].canLoad;
     }
 
     // if newly required data is not currently contained in this volume...

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -253,7 +253,7 @@ export default class Volume {
       const dims = await this.loader?.loadDims(this.loadSpecRequired);
       if (dims) {
         const loadableLevel = estimateLevelForAtlas(dims.map(({ shape }) => [shape[2], shape[3], shape[4]]));
-        noReload = !dims || currentScale <= Math.max(loadableLevel, minLevel);
+        noReload = currentScale <= Math.max(loadableLevel, minLevel);
       }
     }
 

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -22,7 +22,6 @@ export class VolumeDims {
   spacing: number[] = [1, 1, 1, 1, 1];
   spaceUnit = "μm";
   timeUnit = "s";
-  canLoad = true;
   // TODO make this an enum?
   dataType = "uint8";
 }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -17,13 +17,13 @@ export function loadSpecToString(spec: LoadSpec): string {
 }
 
 export class VolumeDims {
-  subpath = "";
   // shape: [t, c, z, y, x]
   shape: number[] = [0, 0, 0, 0, 0];
   // spacing: [t, c, z, y, x]; generally expect 1 for non-spatial dimensions
   spacing: number[] = [1, 1, 1, 1, 1];
   spaceUnit = "μm";
   timeUnit = "s";
+  canLoad = true;
   // TODO make this an enum?
   dataType = "uint8";
 }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -3,7 +3,6 @@ import { Box3, Vector3 } from "three";
 import Volume from "../Volume";
 
 export class LoadSpec {
-  scene = 0;
   time = 0;
   multiscaleLevel?: number;
   /** Subregion of volume to load. If not specified, the entire volume is loaded. Specify as floats between 0-1. */
@@ -13,7 +12,7 @@ export class LoadSpec {
 
 export function loadSpecToString(spec: LoadSpec): string {
   const { min, max } = spec.subregion;
-  return `${spec.scene}:${spec.multiscaleLevel}:${spec.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
+  return `${spec.multiscaleLevel}:${spec.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
 }
 
 export class VolumeDims {

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -121,7 +121,6 @@ class JsonImageInfoLoader implements IVolumeLoader {
     const jsonInfo = await this.getJsonImageInfo(loadSpec);
 
     const d = new VolumeDims();
-    d.subpath = "";
     d.shape = [jsonInfo.times || 1, jsonInfo.channels, jsonInfo.tiles, jsonInfo.tile_height, jsonInfo.tile_width];
     d.spacing = [1, 1, jsonInfo.pixel_size_z, jsonInfo.pixel_size_y, jsonInfo.pixel_size_x];
     d.spaceUnit = jsonInfo.pixel_size_unit || "μm";

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -80,6 +80,9 @@ const convertImageInfo = (json: JsonImageInfo): ImageInfo => ({
   timeScale: json.time_scale || 1,
   timeUnit: json.time_unit || "s",
 
+  numMultiscaleLevels: 1,
+  multiscaleLevel: 0,
+
   transform: {
     translation: json.transform?.translation
       ? new Vector3().fromArray(json.transform.translation)

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -348,9 +348,9 @@ class OMEZarrLoader implements IVolumeLoader {
     const maxLevel = pickLevelToLoad(
       { ...loadSpec, subregion, multiscaleLevel: undefined },
       this.scaleLevels,
-      regionSize.z,
-      regionSize.y,
-      regionSize.x
+      this.axesTCZYX[2],
+      this.axesTCZYX[3],
+      this.axesTCZYX[4]
     );
 
     const result = this.scaleLevels.map((level, i) => {
@@ -361,7 +361,7 @@ class OMEZarrLoader implements IVolumeLoader {
       dims.timeUnit = timeUnit;
       dims.shape = [-1, -1, -1, -1, -1];
       dims.spacing = [1, 1, 1, 1, 1];
-      dims.canLoad = i <= maxLevel;
+      dims.canLoad = i >= maxLevel;
 
       this.axesTCZYX.forEach((val, idx) => {
         if (val > -1) {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -337,7 +337,7 @@ class OMEZarrLoader implements IVolumeLoader {
   }
 
   private getLevelShapesZYX(): [number, number, number][] {
-    const [_t, _c, z, y, x] = this.axesTCZYX;
+    const [z, y, x] = this.axesTCZYX.slice(-3);
     return this.scaleLevels.map(({ shape }) => [shape[z], shape[y], shape[x]]);
   }
 

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -348,7 +348,6 @@ class OMEZarrLoader implements IVolumeLoader {
     const subregion = composeSubregion(loadSpec.subregion, maxExtent);
     const regionSize = subregion.getSize(new Vector3());
     const regionArr = [1, 1, regionSize.z, regionSize.y, regionSize.x];
-    const maxLevel = pickLevelToLoad({ ...loadSpec, subregion, multiscaleLevel: undefined }, this.getLevelShapesZYX());
 
     const result = this.scaleLevels.map((level, i) => {
       const scale = this.getScale(i);
@@ -358,7 +357,6 @@ class OMEZarrLoader implements IVolumeLoader {
       dims.timeUnit = timeUnit;
       dims.shape = [-1, -1, -1, -1, -1];
       dims.spacing = [1, 1, 1, 1, 1];
-      dims.canLoad = i >= maxLevel;
 
       this.axesTCZYX.forEach((val, idx) => {
         if (val > -1) {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -17,7 +17,6 @@ import {
   unitNameToSymbol,
 } from "./VolumeLoaderUtils";
 
-const MAX_ATLAS_DIMENSION = 2048;
 const CHUNK_REQUEST_CANCEL_REASON = "chunk request cancelled";
 
 type CoordinateTransformation =

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -345,6 +345,13 @@ class OMEZarrLoader implements IVolumeLoader {
     const subregion = composeSubregion(loadSpec.subregion, maxExtent);
     const regionSize = subregion.getSize(new Vector3());
     const regionArr = [1, 1, regionSize.z, regionSize.y, regionSize.x];
+    const maxLevel = pickLevelToLoad(
+      { ...loadSpec, subregion, multiscaleLevel: undefined },
+      this.scaleLevels,
+      regionSize.z,
+      regionSize.y,
+      regionSize.x
+    );
 
     const result = this.scaleLevels.map((level, i) => {
       const scale = this.getScale(i);
@@ -352,9 +359,9 @@ class OMEZarrLoader implements IVolumeLoader {
 
       dims.spaceUnit = spaceUnit;
       dims.timeUnit = timeUnit;
-      dims.subpath = level.path ?? "";
       dims.shape = [-1, -1, -1, -1, -1];
       dims.spacing = [1, 1, 1, 1, 1];
+      dims.canLoad = i <= maxLevel;
 
       this.axesTCZYX.forEach((val, idx) => {
         if (val > -1) {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -420,6 +420,8 @@ class OMEZarrLoader implements IVolumeLoader {
       times,
       timeScale,
       timeUnit,
+      numMultiscaleLevels: this.scaleLevels.length,
+      multiscaleLevel: levelToLoad,
 
       transform: {
         translation: new Vector3(0, 0, 0),
@@ -465,6 +467,7 @@ class OMEZarrLoader implements IVolumeLoader {
       volumeSize: volSizePx,
       subregionSize: regionSizePx,
       subregionOffset: regionPx.min,
+      multiscaleLevel: levelIdx,
     };
     vol.updateDimensions();
 

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -338,7 +338,7 @@ class OMEZarrLoader implements IVolumeLoader {
     return scale;
   }
 
-  async loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]> {
+  loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]> {
     const [spaceUnit, timeUnit] = this.getUnitSymbols();
     // Compute subregion size so we can factor that in
     const maxExtent = this.maxExtent ?? new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1));
@@ -373,7 +373,7 @@ class OMEZarrLoader implements IVolumeLoader {
       return dims;
     });
 
-    return result;
+    return Promise.resolve(result);
   }
 
   async createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -40,6 +40,9 @@ class OpenCellLoader implements IVolumeLoader {
       timeScale: 1,
       timeUnit: "",
 
+      numMultiscaleLevels: 1,
+      multiscaleLevel: 0,
+
       transform: {
         translation: new Vector3(0, 0, 0),
         rotation: new Vector3(0, 0, 0),

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -9,7 +9,6 @@ import { JsonImageInfoLoader } from "./JsonImageInfoLoader";
 class OpenCellLoader implements IVolumeLoader {
   async loadDims(_: LoadSpec): Promise<VolumeDims[]> {
     const d = new VolumeDims();
-    d.subpath = "";
     d.shape = [1, 2, 27, 600, 600];
     d.spacing = [1, 1, 2, 1, 1];
     d.spaceUnit = ""; // unknown unit.

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -60,20 +60,6 @@ function getOMEDims(imageEl: Element): OMEDims {
   return dims;
 }
 
-async function getDimsFromUrl(url: string): Promise<OMEDims> {
-  const tiff = await fromUrl(url, { allowFullFile: true });
-  // DO NOT DO THIS, ITS SLOW
-  // const imagecount = await tiff.getImageCount();
-  // read the FIRST image
-  const image = await tiff.getImage();
-
-  const tiffimgdesc = prepareXML(image.getFileDirectory().ImageDescription);
-  const omeEl = getOME(tiffimgdesc);
-
-  const image0El = omeEl.getElementsByTagName("Image")[0];
-  return getOMEDims(image0El);
-}
-
 const getBytesPerSample = (type: string): number => (type === "uint8" ? 1 : type === "uint16" ? 2 : 4);
 
 class TiffLoader implements IVolumeLoader {
@@ -86,7 +72,17 @@ class TiffLoader implements IVolumeLoader {
 
   private async loadOmeDims(): Promise<OMEDims> {
     if (!this.dims) {
-      this.dims = await getDimsFromUrl(this.url);
+      const tiff = await fromUrl(this.url, { allowFullFile: true });
+      // DO NOT DO THIS, ITS SLOW
+      // const imagecount = await tiff.getImageCount();
+      // read the FIRST image
+      const image = await tiff.getImage();
+
+      const tiffimgdesc = prepareXML(image.getFileDirectory().ImageDescription);
+      const omeEl = getOME(tiffimgdesc);
+
+      const image0El = omeEl.getElementsByTagName("Image")[0];
+      this.dims = getOMEDims(image0El);
     }
     return this.dims;
   }

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -132,6 +132,9 @@ class TiffLoader implements IVolumeLoader {
       timeScale: 1,
       timeUnit: "",
 
+      numMultiscaleLevels: 1,
+      multiscaleLevel: 0,
+
       transform: {
         translation: new Vector3(0, 0, 0),
         rotation: new Vector3(0, 0, 0),

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -79,8 +79,11 @@ export function computePackedAtlasDims(z: number, tw: number, th: number): Vecto
 
 /** Picks the largest scale level that can fit into a texture atlas */
 export function estimateLevelForAtlas(spatialDimsZYX: [number, number, number][], maxAtlasEdge = MAX_ATLAS_EDGE) {
-  // update levelToLoad after we get size info about multiscales.
-  // decide to max out at a 4k x 4k texture.
+  if (spatialDimsZYX.length <= 1) {
+    return 0;
+  }
+
+  // update levelToLoad after we get size info about multiscales
   let levelToLoad = spatialDimsZYX.length - 1;
   for (let i = 0; i < spatialDimsZYX.length; ++i) {
     // estimate atlas size:
@@ -96,31 +99,6 @@ export function estimateLevelForAtlas(spatialDimsZYX: [number, number, number][]
     }
   }
   return levelToLoad;
-}
-
-/**
- * Picks the best scale level to load based on scale level dimensions, a max atlas size, and a `LoadSpec`.
- * This works like `estimateLevelForAtlas` but factors in `LoadSpec`'s `subregion` property (shrinks the size of the
- * data, maybe enough to allow loading a higher level) and its `multiscaleLevel` property (sets a max scale level).
- */
-export function pickLevelToLoad(
-  loadSpec: LoadSpec,
-  spatialDimsZYX: [number, number, number][],
-  maxAtlasEdge?: number
-): number {
-  if (spatialDimsZYX.length <= 1) {
-    return 0;
-  }
-
-  const size = loadSpec.subregion.getSize(new Vector3());
-  const dims = spatialDimsZYX.map(([z, y, x]): [number, number, number] => [
-    Math.max(z * size.z, 1),
-    Math.max(y * size.y, 1),
-    Math.max(x * size.x, 1),
-  ]);
-
-  const optimalLevel = estimateLevelForAtlas(dims, maxAtlasEdge);
-  return Math.max(optimalLevel, loadSpec.multiscaleLevel ?? 0);
 }
 
 /** Given the size of a volume in pixels, convert a `Box3` in the 0-1 range to pixels */

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -2,7 +2,6 @@ import "regenerator-runtime/runtime";
 import { Box3, Vector2, Vector3 } from "three";
 
 import { ImageInfo } from "../Volume";
-import { LoadSpec } from "./IVolumeLoader";
 
 const MAX_ATLAS_EDGE = 2048;
 

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -35,6 +35,9 @@ const testimgdata: ImageInfo = {
   timeScale: 1,
   timeUnit: "",
 
+  numMultiscaleLevels: 1,
+  multiscaleLevel: 0,
+
   transform: {
     translation: new Vector3(0, 0, 0),
     rotation: new Vector3(0, 0, 0),


### PR DESCRIPTION
Resolves #157: If a 3d volume is loaded, the user switches to z-slice mode, and a higher resolution level is available to load, reload at that higher resolution.

This is accomplished using the `loadDims` method on `IVolumeLoader` (unused until now), which loads the dimensions of a volume without loading any data. I made the following changes to make `loadDims` a good solution to this issue:
- `loadDims` returns an array of `VolumeDims` objects for each available scale level. I added the property `canLoad: boolean` to this type to indicate whether a level can be loaded given the specifications.
- Because `loadDims` is `async`, `updateRequiredData` must now be `async` too. This is a bummer, so to compensate, I tried to ensure that `loadDims` rarely or never is `async` in practice.

I also got rid of the `scene` property of `LoadSpec`, given that the only loader that supports scenes right now (`OmeZarrLoader`) must be bound to a single scene on construction.
