### PR TITLE
Subscribable request queue

### DIFF
--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -53,6 +53,19 @@ describe("SubscribableRequestQueue", () => {
       expect(result).to.equal("foo");
     });
 
+    it("does not queue a request if the subscriber id is invalid", () => {
+      const queue = new SubscribableRequestQueue();
+      expect(() => queue.addRequestToQueue("test", -1, () => delay(TIMEOUT, "foo"))).to.throw();
+      expect(() => queue.addRequestToQueue("test", 0, () => delay(TIMEOUT, "foo"))).to.throw();
+    });
+
+    it("does not queue a request if the subscriber has been deleted", () => {
+      const queue = new SubscribableRequestQueue();
+      const id = queue.addSubscriber();
+      queue.removeSubscriber(id);
+      expect(() => queue.addRequestToQueue("test", id, () => delay(TIMEOUT, "foo"))).to.throw();
+    });
+
     it("creates unique promises without duplicating work when two subscribers queue the same key", async () => {
       const queue = new SubscribableRequestQueue();
       const id1 = queue.addSubscriber();

--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -244,8 +244,8 @@ describe("SubscribableRequestQueue", () => {
       const id2 = queue.addSubscriber();
 
       const promise1 = queue.addRequestToQueue("test", id1, () => delay(TIMEOUT, "foo"));
-      const promise2 = queue.addRequestToQueue("test", id1, () => delay(TIMEOUT, "bar"));
-      const promise3 = queue.addRequestToQueue("test", id2, () => delay(TIMEOUT, "baz"));
+      const promise2 = queue.addRequestToQueue("test2", id1, () => delay(TIMEOUT, "bar"));
+      const promise3 = queue.addRequestToQueue("test", id2, () => delay(TIMEOUT, "foo"));
       expect(queue.hasRequest("test")).to.be.true;
       expect(queue.isSubscribed(id1, "test")).to.be.true;
       expect(queue.isSubscribed(id2, "test")).to.be.true;
@@ -253,6 +253,7 @@ describe("SubscribableRequestQueue", () => {
       queue.removeSubscriber(id1);
       expect(queue.hasRequest("test")).to.be.true;
       expect(queue.isSubscribed(id1, "test")).to.be.false;
+      expect(queue.isSubscribed(id1, "test2")).to.be.false;
       expect(await isRejected(promise1)).to.be.true;
       expect(await isRejected(promise2)).to.be.true;
       expect(await isRejected(promise3)).to.be.false;

--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -168,9 +168,11 @@ describe("SubscribableRequestQueue", () => {
       expect(queue.hasRequest("test")).to.be.true;
       expect(queue.isSubscribed(id, "test")).to.be.true;
 
-      queue.cancelRequest("test", id);
+      const cancelResult = queue.cancelRequest("test", id);
+      expect(cancelResult).to.be.true;
       expect(queue.isSubscribed(id, "test")).to.be.false;
       expect(await isRejected(promise)).to.be.true;
+      expect(queue.cancelRequest("test", id)).to.be.false;
     });
 
     it("does not cancel an underlying request if it is running", async () => {

--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -1,0 +1,248 @@
+import { expect } from "chai";
+
+import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
+
+const TIMEOUT = 10;
+const LONG_TIMEOUT = 20;
+
+/** Returns a promise that resolves after `timeoutMs` milliseconds with value `result`. */
+function delay<T>(timeoutMs: number, result: T): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(result), timeoutMs));
+}
+
+/** Returns a promise that rejects after `timeoutMs` milliseconds with reason `reason`. */
+function delayReject(timeoutMs: number, reason: unknown): Promise<unknown> {
+  return new Promise((_, reject) => setTimeout(() => reject(reason), timeoutMs));
+}
+
+/** Determines whether a promise has rejected. */
+// From https://gist.github.com/tyru/29360dfa475d2fefaf6c4655a93c2cb0
+function isRejected(promise: Promise<unknown>): Promise<boolean> {
+  return Promise.race([
+    delay(0, false),
+    promise.then(
+      () => false,
+      () => true
+    ),
+  ]);
+}
+
+describe("SubscribableRequestQueue", () => {
+  describe("addSubscriber", () => {
+    it("adds a subscriber", () => {
+      const queue = new SubscribableRequestQueue();
+      const id = queue.addSubscriber();
+      expect(queue.hasSubscriber(id)).to.be.true;
+    });
+
+    it("returns unique ids", () => {
+      const queue = new SubscribableRequestQueue();
+      const id1 = queue.addSubscriber();
+      const id2 = queue.addSubscriber();
+      expect(id1).to.not.equal(id2);
+    });
+  });
+
+  describe("addRequestToQueue", () => {
+    it("queues a request", async () => {
+      const queue = new SubscribableRequestQueue();
+      const id = queue.addSubscriber();
+      const promise = queue.addRequestToQueue("test", id, () => delay(TIMEOUT, "foo"));
+      expect(queue.hasRequest("test")).to.be.true;
+      const result = await promise;
+      expect(result).to.equal("foo");
+    });
+
+    it("creates unique promises without duplicating work when two subscribers queue the same key", async () => {
+      const queue = new SubscribableRequestQueue();
+      const id1 = queue.addSubscriber();
+      const id2 = queue.addSubscriber();
+
+      const promise1 = queue.addRequestToQueue("test", id1, () => delay(TIMEOUT, "foo"));
+      const promise2 = queue.addRequestToQueue("test", id2, () => delay(TIMEOUT, "bar"));
+      expect(queue.hasRequest("test")).to.be.true;
+      expect(promise1).to.not.equal(promise2);
+
+      const [result1, result2] = await Promise.all([promise1, promise2]);
+      expect(result1).to.equal("foo");
+      expect(result2).to.equal("foo");
+    });
+
+    it("creates different requests when one subscriber queues two keys", async () => {
+      const queue = new SubscribableRequestQueue();
+      const id = queue.addSubscriber();
+
+      const promise1 = queue.addRequestToQueue("test1", id, () => delay(TIMEOUT, "foo"));
+      const promise2 = queue.addRequestToQueue("test2", id, () => delay(TIMEOUT, "bar"));
+      expect(queue.hasRequest("test1")).to.be.true;
+      expect(queue.hasRequest("test2")).to.be.true;
+      expect(promise1).to.not.equal(promise2);
+
+      const [result1, result2] = await Promise.all([promise1, promise2]);
+      expect(result1).to.equal("foo");
+      expect(result2).to.equal("bar");
+    });
+
+    it("rejects and reissues a request when one subscriber queues the same key twice", async () => {
+      const queue = new SubscribableRequestQueue();
+      const id = queue.addSubscriber();
+
+      const promise1 = queue.addRequestToQueue("test", id, () => delay(TIMEOUT, "foo"));
+      const promise2 = queue.addRequestToQueue("test", id, () => delay(TIMEOUT, "bar"));
+      expect(queue.hasRequest("test")).to.be.true;
+      expect(await isRejected(promise1)).to.be.true;
+
+      const result2 = await promise2;
+      expect(result2).to.equal("foo");
+    });
+
+    it("passes request rejections to all subscribers", async () => {
+      const queue = new SubscribableRequestQueue();
+      const id1 = queue.addSubscriber();
+      const id2 = queue.addSubscriber();
+
+      const promise1 = queue.addRequestToQueue("test", id1, () => delayReject(TIMEOUT, "foo"));
+      const promise2 = queue.addRequestToQueue("test", id2, () => delay(TIMEOUT, "bar"));
+      expect(queue.hasRequest("test")).to.be.true;
+      let promise1RejectReason = "",
+        promise2RejectReason = "";
+      promise1.catch((reason) => (promise1RejectReason = reason));
+      promise2.catch((reason) => (promise2RejectReason = reason));
+
+      await Promise.allSettled([promise1, promise2]);
+      expect(promise1RejectReason).to.equal("foo");
+      expect(promise2RejectReason).to.equal("foo");
+    });
+
+    it("completes requests in order when max requests is set", async () => {
+      const queue = new SubscribableRequestQueue(1);
+      const id = queue.addSubscriber();
+
+      const promise1 = queue.addRequestToQueue("test1", id, () => delay(TIMEOUT, "foo"));
+      const promise2 = queue.addRequestToQueue("test2", id, () => delay(LONG_TIMEOUT, "bar"));
+      expect(queue.hasRequest("test1")).to.be.true;
+      expect(queue.hasRequest("test2")).to.be.true;
+      expect(queue.requestRunning("test1")).to.be.true;
+      expect(queue.requestRunning("test2")).to.be.false;
+
+      const result1 = await promise1;
+      expect(result1).to.equal("foo");
+      expect(queue.hasRequest("test1")).to.be.false;
+      expect(queue.hasRequest("test2")).to.be.true;
+      expect(queue.requestRunning("test2")).to.be.true;
+
+      const result2 = await promise2;
+      expect(result2).to.equal("bar");
+      expect(queue.hasRequest("test2")).to.be.false;
+    });
+  });
+
+  describe("cancelRequest", () => {
+    it("cancels a request subscription", async () => {
+      const queue = new SubscribableRequestQueue();
+      const id = queue.addSubscriber();
+      const promise = queue.addRequestToQueue("test", id, () => delay(TIMEOUT, "foo"));
+      expect(queue.hasRequest("test")).to.be.true;
+      expect(queue.isSubscribed(id, "test")).to.be.true;
+
+      queue.cancelRequest("test", id);
+      expect(queue.isSubscribed(id, "test")).to.be.false;
+      expect(await isRejected(promise)).to.be.true;
+    });
+
+    it("does not cancel an underlying request if it is running", async () => {
+      const queue = new SubscribableRequestQueue();
+      const id1 = queue.addSubscriber();
+      const id2 = queue.addSubscriber();
+
+      const promise1 = queue.addRequestToQueue("test", id1, () => delay(TIMEOUT, "foo"));
+      expect(queue.hasRequest("test")).to.be.true;
+      expect(queue.requestRunning("test")).to.be.true;
+      expect(queue.isSubscribed(id1, "test")).to.be.true;
+      expect(queue.isSubscribed(id2, "test")).to.be.false;
+
+      queue.cancelRequest("test", id1);
+      expect(queue.hasRequest("test")).to.be.true;
+      expect(queue.isSubscribed(id1, "test")).to.be.false;
+      expect(await isRejected(promise1)).to.be.true;
+
+      const promise2 = queue.addRequestToQueue("test", id2, () => delay(TIMEOUT, "bar"));
+      expect(queue.isSubscribed(id2, "test")).to.be.true;
+      const result = await promise2;
+      expect(result).to.equal("foo");
+    });
+
+    it("does not cancel an underlying request if it has another subscription", async () => {
+      const queue = new SubscribableRequestQueue(1);
+      const id1 = queue.addSubscriber();
+      const id2 = queue.addSubscriber();
+      // `block` keeps the queue full, to keep `test` from running
+      const block = queue.addRequestToQueue("block", id1, () => delay(TIMEOUT, undefined));
+
+      const promise1 = queue.addRequestToQueue("test", id1, () => delay(LONG_TIMEOUT, "foo"));
+      const promise2 = queue.addRequestToQueue("test", id2, () => delay(LONG_TIMEOUT, "bar"));
+      expect(queue.hasRequest("test")).to.be.true;
+      expect(queue.requestRunning("test")).to.be.false;
+      expect(queue.isSubscribed(id1, "test")).to.be.true;
+      expect(queue.isSubscribed(id2, "test")).to.be.true;
+
+      queue.cancelRequest("test", id1);
+      expect(queue.hasRequest("test")).to.be.true;
+      expect(queue.isSubscribed(id1, "test")).to.be.false;
+      expect(queue.isSubscribed(id2, "test")).to.be.true;
+      expect(await isRejected(promise1)).to.be.true;
+
+      await block;
+      expect(queue.requestRunning("test")).to.be.true;
+      const result = await promise2;
+      expect(result).to.equal("foo");
+    });
+
+    it("cancels an underlying request if it is waiting and has no other subscriptions", async () => {
+      const queue = new SubscribableRequestQueue(1);
+      const id = queue.addSubscriber();
+      // `block` keeps the queue full, to keep `test` from running
+      queue.addRequestToQueue("block", id, () => delay(TIMEOUT, undefined));
+
+      const promise = queue.addRequestToQueue("test", id, () => delay(LONG_TIMEOUT, "foo"));
+      expect(queue.hasRequest("test")).to.be.true;
+      expect(queue.requestRunning("test")).to.be.false;
+      expect(queue.isSubscribed(id, "test")).to.be.true;
+
+      queue.cancelRequest("test", id);
+      expect(await isRejected(promise)).to.be.true;
+      expect(queue.hasRequest("test")).to.be.false;
+      expect(queue.isSubscribed(id, "test")).to.be.false;
+    });
+  });
+
+  describe("removeSubscriber", () => {
+    it("removes a subscriber", async () => {
+      const queue = new SubscribableRequestQueue();
+      const id = queue.addSubscriber();
+      expect(queue.hasSubscriber(id)).to.be.true;
+      queue.removeSubscriber(id);
+      expect(queue.hasSubscriber(id)).to.be.false;
+    });
+
+    it("cancels all subscriptions from a removed subscriber", async () => {
+      const queue = new SubscribableRequestQueue();
+      const id1 = queue.addSubscriber();
+      const id2 = queue.addSubscriber();
+
+      const promise1 = queue.addRequestToQueue("test", id1, () => delay(TIMEOUT, "foo"));
+      const promise2 = queue.addRequestToQueue("test", id1, () => delay(TIMEOUT, "bar"));
+      const promise3 = queue.addRequestToQueue("test", id2, () => delay(TIMEOUT, "baz"));
+      expect(queue.hasRequest("test")).to.be.true;
+      expect(queue.isSubscribed(id1, "test")).to.be.true;
+      expect(queue.isSubscribed(id2, "test")).to.be.true;
+
+      queue.removeSubscriber(id1);
+      expect(queue.hasRequest("test")).to.be.true;
+      expect(queue.isSubscribed(id1, "test")).to.be.false;
+      expect(await isRejected(promise1)).to.be.true;
+      expect(await isRejected(promise2)).to.be.true;
+      expect(await isRejected(promise3)).to.be.false;
+    });
+  });
+});

--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -41,6 +41,16 @@ describe("SubscribableRequestQueue", () => {
       const id2 = queue.addSubscriber();
       expect(id1).to.not.equal(id2);
     });
+
+    it("never reuses ids of removed subscribers", () => {
+      const queue = new SubscribableRequestQueue();
+      const id1 = queue.addSubscriber();
+      const id2 = queue.addSubscriber();
+      queue.removeSubscriber(id1);
+      const id3 = queue.addSubscriber();
+      expect(id1).to.not.equal(id2);
+      expect(id3).to.not.equal(id2);
+    });
   });
 
   describe("addRequestToQueue", () => {

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -1,0 +1,127 @@
+import RequestQueue from "./RequestQueue";
+
+type Resolver = (value?: any) => void;
+type Rejecter = (reason?: unknown) => void;
+
+type RequestSubscription = {
+  subscriberId: number;
+  resolve: Resolver;
+  reject: Rejecter;
+};
+
+export default class SubscribableRequestQueue {
+  private queue: RequestQueue;
+
+  private subscriberIds: number;
+  /** "Reject" functions, keyed by subscriber ID *and* request key */
+  private subscribers: Map<number, Map<string, Rejecter>>;
+  /** "Resolve" functions, keyed by request key only */
+  private requests: Map<string, RequestSubscription[]>;
+
+  constructor(maxActiveRequests?: number) {
+    this.queue = new RequestQueue(maxActiveRequests);
+    this.subscriberIds = 0;
+    this.subscribers = new Map();
+    this.requests = new Map();
+  }
+
+  private resolveAll(key: string, value: any) {
+    const requests = this.requests.get(key);
+    if (requests) {
+      for (const { resolve, subscriberId } of requests) {
+        resolve(value);
+        this.subscribers.get(subscriberId)?.delete(key);
+      }
+      this.requests.delete(key);
+    }
+  }
+
+  private rejectAll(key: string, reason: unknown) {
+    const requests = this.requests.get(key);
+    if (requests) {
+      for (const { reject, subscriberId } of requests) {
+        reject(reason);
+        this.subscribers.get(subscriberId)?.delete(key);
+      }
+      this.requests.delete(key);
+    }
+  }
+
+  addSubscriber(): number {
+    const subscriberId = this.subscriberIds;
+    this.subscriberIds++;
+    this.subscribers.set(subscriberId, new Map());
+    return subscriberId;
+  }
+
+  addRequestToQueue<T>(
+    key: string,
+    subscriberId: number,
+    requestAction: () => Promise<T>,
+    delayMs?: number
+  ): Promise<T> {
+    // Create single underlying request if it does not yet exist
+    if (!this.queue.hasRequest(key)) {
+      this.queue
+        .addRequest(key, requestAction, delayMs)
+        .then((value) => this.resolveAll(key, value))
+        .catch((reason) => this.rejectAll(key, reason));
+    }
+    if (!this.requests.has(key)) {
+      this.requests.set(key, []);
+    }
+
+    // Validate subscriber
+    if (subscriberId >= this.subscriberIds || subscriberId < 0) {
+      throw new Error(`SubscribableRequestQueue: subscriber id ${subscriberId} has not been registered`);
+    }
+    if (!this.subscribers.has(subscriberId)) {
+      throw new Error(`SubscribableRequestQueue: subscriber id ${subscriberId} has been removed`);
+    }
+
+    // Create promise and add to list of requests
+    return new Promise<T>((resolve, reject) => {
+      this.requests.get(key)?.push({ resolve, reject, subscriberId });
+      this.subscribers.get(subscriberId)?.set(key, reject);
+    });
+  }
+
+  private rejectSubscription(key: string, reject: Rejecter, cancelReason?: unknown) {
+    // Reject the outer "subscription" promise
+    reject(cancelReason);
+
+    // Remove this request subscription by ref equality to `reject` (though we don't need to after rejecting it above)
+    const subscriptions = this.requests.get(key);
+    if (!subscriptions) {
+      // This should never happen
+      return;
+    }
+    const idx = subscriptions.findIndex((sub) => sub.reject === reject);
+    if (idx >= 0) {
+      subscriptions.splice(idx, 1);
+    }
+
+    // Remove the underlying request if there are no more subscribers and the request is not running
+    if (subscriptions.length < 1 && !this.queue.requestRunning(key)) {
+      this.queue.cancelRequest(key, cancelReason);
+      this.requests.delete(key);
+    }
+  }
+
+  cancelRequest(key: string, subscriberId: number, cancelReason?: unknown) {
+    const reject = this.subscribers.get(subscriberId)?.get(key);
+    if (reject) {
+      this.rejectSubscription(key, reject, cancelReason);
+    }
+  }
+
+  removeSubscriber(subscriberId: number, cancelReason?: unknown) {
+    const subscriptions = this.subscribers.get(subscriberId);
+    if (subscriptions) {
+      for (const [key, reject] of subscriptions.entries()) {
+        this.rejectSubscription(key, reject, cancelReason);
+      }
+    }
+    this.subscribers.delete(subscriberId);
+  }
+}

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -63,7 +63,11 @@ export default class SubscribableRequestQueue {
     return subscriberId;
   }
 
-  /** Queues a new request, or adds a subscription if the request is already queued/running. */
+  /**
+   * Queues a new request, or adds a subscription if the request is already queued/running.
+   *
+   * If `subscriberId` is already subscribed to the request, this rejects the existing promise and returns a new one.
+   */
   addRequestToQueue<T>(
     key: string,
     subscriberId: number,

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -31,7 +31,7 @@ export default class SubscribableRequestQueue {
     this.requests = new Map();
   }
 
-  /** Resolves all subscriptions to request `key` with `value */
+  /** Resolves all subscriptions to request `key` with `value` */
   private resolveAll<T>(key: string, value: T) {
     const requests = this.requests.get(key);
     if (requests) {

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -136,13 +136,20 @@ export default class SubscribableRequestQueue {
   }
 
   /** Cancels a request subscription, and cancels the underlying request if it is no longer subscribed or running. */
-  cancelRequest(key: string, subscriberId: number, cancelReason?: unknown): void {
+  cancelRequest(key: string, subscriberId: number, cancelReason?: unknown): boolean {
     const subscriber = this.subscribers.get(subscriberId);
-    const reject = subscriber?.get(key);
-    if (reject) {
-      this.rejectSubscription(key, reject, cancelReason);
+    if (!subscriber) {
+      return false;
     }
-    subscriber?.delete(key);
+
+    const reject = subscriber.get(key);
+    if (!reject) {
+      return false;
+    }
+
+    this.rejectSubscription(key, reject, cancelReason);
+    subscriber.delete(key);
+    return true;
   }
 
   /** Removes a subscriber and cancels its remaining subscriptions. */

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -1,5 +1,6 @@
 import RequestQueue from "./RequestQueue";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Resolver = (value?: any) => void;
 type Rejecter = (reason?: unknown) => void;
 
@@ -31,7 +32,7 @@ export default class SubscribableRequestQueue {
   }
 
   /** Resolves all subscriptions to request `key` with `value */
-  private resolveAll(key: string, value: any) {
+  private resolveAll<T>(key: string, value: T) {
     const requests = this.requests.get(key);
     if (requests) {
       for (const { resolve, subscriberId } of requests) {

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -32,7 +32,7 @@ export default class SubscribableRequestQueue {
   }
 
   /** Resolves all subscriptions to request `key` with `value` */
-  private resolveAll<T>(key: string, value: T) {
+  private resolveAll<T>(key: string, value: T): void {
     const requests = this.requests.get(key);
     if (requests) {
       for (const { resolve, subscriberId } of requests) {
@@ -44,7 +44,7 @@ export default class SubscribableRequestQueue {
   }
 
   /** Rejects all subscriptions to request `key` with `reason` */
-  private rejectAll(key: string, reason: unknown) {
+  private rejectAll(key: string, reason: unknown): void {
     const requests = this.requests.get(key);
     if (requests) {
       for (const { reject, subscriberId } of requests) {
@@ -105,7 +105,7 @@ export default class SubscribableRequestQueue {
    * Rejects a subscription and removes it from the list of subscriptions for a request, then cancels the underlying
    * request if it is no longer subscribed and is not running already.
    */
-  private rejectSubscription(key: string, reject: Rejecter, cancelReason?: unknown) {
+  private rejectSubscription(key: string, reject: Rejecter, cancelReason?: unknown): void {
     // Reject the outer "subscription" promise
     reject(cancelReason);
 
@@ -129,7 +129,7 @@ export default class SubscribableRequestQueue {
   }
 
   /** Cancels a request subscription, and cancels the underlying request if it is no longer subscribed or running. */
-  cancelRequest(key: string, subscriberId: number, cancelReason?: unknown) {
+  cancelRequest(key: string, subscriberId: number, cancelReason?: unknown): void {
     const subscriber = this.subscribers.get(subscriberId);
     const reject = subscriber?.get(key);
     if (reject) {
@@ -139,7 +139,7 @@ export default class SubscribableRequestQueue {
   }
 
   /** Removes a subscriber and cancels its remaining subscriptions. */
-  removeSubscriber(subscriberId: number, cancelReason?: unknown) {
+  removeSubscriber(subscriberId: number, cancelReason?: unknown): void {
     const subscriptions = this.subscribers.get(subscriberId);
     if (subscriptions) {
       for (const [key, reject] of subscriptions.entries()) {

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -18,7 +18,7 @@ export default class SubscribableRequestQueue {
   private queue: RequestQueue;
 
   /** Number of subscribers, used for generating unique subscriber IDs. */
-  private subscriberIds: number;
+  private numSubscribers: number;
   /** Map keyed by subscriber ID. Subscribers are only useful for cancelling early, so we only store rejecters here. */
   private subscribers: Map<number, Map<string, Rejecter>>;
   /** Map from "inner" request (managed by `queue`) to "outer" promises generated per-subscriber. */
@@ -26,7 +26,7 @@ export default class SubscribableRequestQueue {
 
   constructor(maxActiveRequests?: number) {
     this.queue = new RequestQueue(maxActiveRequests);
-    this.subscriberIds = 0;
+    this.numSubscribers = 0;
     this.subscribers = new Map();
     this.requests = new Map();
   }
@@ -57,8 +57,8 @@ export default class SubscribableRequestQueue {
 
   /** Adds a new request subscriber. Returns a unique ID to identify this subscriber. */
   addSubscriber(): number {
-    const subscriberId = this.subscriberIds;
-    this.subscriberIds++;
+    const subscriberId = this.numSubscribers;
+    this.numSubscribers++;
     this.subscribers.set(subscriberId, new Map());
     return subscriberId;
   }
@@ -82,7 +82,7 @@ export default class SubscribableRequestQueue {
     }
 
     // Validate subscriber
-    if (subscriberId >= this.subscriberIds || subscriberId < 0) {
+    if (subscriberId >= this.numSubscribers || subscriberId < 0) {
       throw new Error(`SubscribableRequestQueue: subscriber id ${subscriberId} has not been registered`);
     }
     const subscriber = this.subscribers.get(subscriberId);


### PR DESCRIPTION
Progress on #154: adds `SubscribableRequestQueue`, which wraps `RequestQueue` and adds the concept of "subscribers." Subscribers can cancel their subscriptions to a request without cancelling the underlying request.

Does NOT add `SubscribableRequestQueue` to `OMEZarrLoader` yet.