### PR TITLE
better single slice render

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,8 @@
         <button id="flipYBtn">FlipY</button>
         <button id="flipZBtn">FlipZ</button>
         <label for="zSlider">Z-Slice</label>
+        <button id="zbackBtn">Z Back</button>
+        <button id="zforwardBtn">Z Forward</button>
         <input id="zSlider" type="range" min="0" max="0" step="1" value="0"/><input type="number" id="zValue" min="0" max="0" value="0"/>
     </p>
     <p style="margin:2px;">

--- a/public/index.ts
+++ b/public/index.ts
@@ -586,6 +586,9 @@ function updateZSliceUI(volume: Volume) {
   const totalZSlices = volume.imageInfo.volumeSize.z;
   zSlider.max = `${totalZSlices}`;
   zInput.max = `${totalZSlices}`;
+
+  zInput.value = `${Math.floor(totalZSlices / 2)}`;
+  zSlider.value = `${Math.floor(totalZSlices / 2)}`;
 }
 
 function showChannelUI(volume: Volume) {
@@ -1186,8 +1189,20 @@ function main() {
   });
 
   // Set up Z-slice UI
+  const zforwardBtn = document.getElementById("zforwardBtn");
+  const zbackBtn = document.getElementById("zbackBtn");
   const zSlider = document.getElementById("zSlider") as HTMLInputElement;
   const zInput = document.getElementById("zValue") as HTMLInputElement;
+  zforwardBtn?.addEventListener("click", () => {
+    if (goToZSlice(zSlider?.valueAsNumber + 1)) {
+      //
+    }
+  });
+  zbackBtn?.addEventListener("click", () => {
+    if (goToZSlice(zSlider?.valueAsNumber - 1)) {
+      //
+    }
+  });
   zSlider?.addEventListener("change", () => {
     goToZSlice(zSlider?.valueAsNumber);
   });

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -44,7 +44,7 @@ export class View3d {
   private backgroundColor: Color;
   private pixelSamplingRate: number;
   private exposure: number;
-  private volumeRenderMode: RenderMode;
+  private volumeRenderMode: RenderMode.PATHTRACE | RenderMode.RAYMARCH;
   private renderUpdateListener?: (iteration: number) => void;
   private image?: VolumeDrawable;
 
@@ -480,7 +480,7 @@ export class View3d {
    */
   setCameraMode(mode: string): void {
     this.canvas3d.switchViewMode(mode);
-    this.image?.setViewMode(mode);
+    this.image?.setViewMode(mode, this.volumeRenderMode);
     this.image?.setIsOrtho(mode !== "3D");
     this.canvas3d.redraw();
   }
@@ -831,19 +831,24 @@ export class View3d {
    * Switch between single pass ray-marched volume rendering and progressive path traced rendering.
    * @param {number} mode 0 for single pass ray march, 1 for progressive path trace
    */
-  setVolumeRenderMode(mode: number): void {
+  setVolumeRenderMode(mode: RenderMode.PATHTRACE | RenderMode.RAYMARCH): void {
     if (mode === this.volumeRenderMode) {
       return;
     }
 
     this.volumeRenderMode = mode;
     if (this.image) {
-      if (mode === RenderMode.PATHTRACE && this.canvas3d.hasWebGL2) {
+      const viewMode = this.image.getViewMode();
+      if (viewMode === Axis.Z) {
+        // if the camera view is in single-slice view, then we don't want to change
+        // anything but still remember the mode for when we switch back to a volumetric view
+        return;
+      } else if (mode === RenderMode.PATHTRACE && this.canvas3d.hasWebGL2) {
         this.image.setVolumeRendering(RenderMode.PATHTRACE);
         this.image.updateLights(this.lights);
         // pathtrace is a continuous rendering mode
         this.canvas3d.startRenderLoop();
-      } else {
+      } else if (mode === RenderMode.RAYMARCH) {
         this.image.setVolumeRendering(RenderMode.RAYMARCH);
         this.canvas3d.redraw();
       }

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -281,19 +281,19 @@ export default class VolumeDrawable {
    * Sets the camera mode of the VolumeDrawable.
    * @param mode Mode can be "3D", or "XY" or "Z", or "YZ" or "X", or "XZ" or "Y".
    */
-  setViewMode(mode: string): void {
+  setViewMode(mode: string, volumeRenderModeHint: RenderMode.PATHTRACE | RenderMode.RAYMARCH): void {
     const axis = this.modeStringToAxis(mode);
     this.viewMode = axis;
     // Force a volume render reset if we have switched to or from Z mode while raymarching is enabled.
     if (axis === Axis.Z) {
       // If currently in 3D raymarch mode, hotswap the 2D slice
-      if (this.renderMode === RenderMode.RAYMARCH) {
+      if (this.renderMode === RenderMode.RAYMARCH || this.renderMode === RenderMode.PATHTRACE) {
         this.setVolumeRendering(RenderMode.SLICE);
       }
     } else {
       // If in 2D slice mode, switch back to 3D raymarch mode
       if (this.renderMode === RenderMode.SLICE) {
-        this.setVolumeRendering(RenderMode.RAYMARCH);
+        this.setVolumeRendering(volumeRenderModeHint);
       }
     }
     if (this.settings.viewAxis !== axis) {
@@ -371,6 +371,10 @@ export default class VolumeDrawable {
     if (this.renderMode !== RenderMode.PATHTRACE) {
       this.meshVolume.doRender(canvas);
     }
+  }
+
+  getViewMode(): Axis {
+    return this.viewMode;
   }
 
   // If an isosurface exists, update its isovalue and regenerate the surface. Otherwise do nothing.

--- a/src/constants/shaders/slice.frag
+++ b/src/constants/shaders/slice.frag
@@ -24,16 +24,7 @@ uniform vec3 flipVolume;
 
 varying vec2 vUv;
 
-vec4 luma2Alpha(vec4 color, float vmin, float vmax, float C) {
-  float x = dot(color.rgb, vec3(0.2125, 0.7154, 0.0721));
-  float xi = (x - vmin) / (vmax - vmin);
-  xi = clamp(xi, 0.0, 1.0);
-  float y = pow(xi, C);
-  y = clamp(y, 0.0, 1.0);
-  color[3] = y;
-  return color;
-}
-
+// for atlased texture, we need to find the uv offset for the slice at t
 vec2 offsetFrontBack(float t) {
   int a = int(t);
   int ax = int(ATLAS_DIMS.x);
@@ -41,7 +32,7 @@ vec2 offsetFrontBack(float t) {
   return clamp(os, vec2(0.0), vec2(1.0) - vec2(1.0) / ATLAS_DIMS);
 }
 
-vec4 sampleAtlasLinear(sampler2D tex, vec4 pos) {
+vec4 sampleAtlas(sampler2D tex, vec4 pos) {
   float bounds = float(pos[0] >= 0.0 && pos[0] <= 1.0 &&
     pos[1] >= 0.0 && pos[1] <= 1.0 &&
     pos[2] >= 0.0 && pos[2] <= 1.0);
@@ -49,57 +40,18 @@ vec4 sampleAtlasLinear(sampler2D tex, vec4 pos) {
 
   vec2 loc0 = ((pos.xy - 0.5) * flipVolume.xy + 0.5) / ATLAS_DIMS;
 
-  // loc ranges from 0 to 1/ATLAS_DIMS
-  // shrink loc0 to within one half edge texel - so as not to sample across edges of tiles.
-  loc0 = vec2(0.5) / textureRes + loc0 * (vec2(1.0) - ATLAS_DIMS / textureRes);
 
-  // interpolate between two slices
-  float z = (pos.z) * (nSlices - 1.0);
-  float z0 = floor(z);
-  float t = z - z0; //mod(z, 1.0);
-  float z1 = min(z0 + 1.0, nSlices - 1.0);
-
-  // flipped:
-  if(flipVolume.z == -1.0) {
-    z0 = nSlices - z0 - 1.0;
-    z1 = nSlices - z1 - 1.0;
-    t = 1.0 - t;
+  if (interpolationEnabled) {
+    // loc ranges from 0 to 1/ATLAS_DIMS
+    // shrink loc0 to within one half edge texel - so as not to sample across edges of tiles.
+    loc0 = loc0 * (vec2(1.0) - ATLAS_DIMS / textureRes);
   }
-
-  // get slice offsets in texture atlas
-  vec2 o0 = offsetFrontBack(z0) + loc0;
-  vec2 o1 = offsetFrontBack(z1) + loc0;
-
-  vec4 slice0Color = texture2D(tex, o0);
-  vec4 slice1Color = texture2D(tex, o1);
-  // NOTE we could premultiply the mask in the fuse function,
-  // but that is slower to update the maskAlpha value than here in the shader.
-  // it is a memory vs perf tradeoff.  Do users really need to update the maskAlpha at realtime speed?
-  float slice0Mask = texture2D(textureAtlasMask, o0).x;
-  float slice1Mask = texture2D(textureAtlasMask, o1).x;
-  // or use max for conservative 0 or 1 masking?
-  float maskVal = mix(slice0Mask, slice1Mask, t);
-  // take mask from 0..1 to alpha..1
-  maskVal = mix(maskVal, 1.0, maskAlpha);
-  vec4 retval = mix(slice0Color, slice1Color, t);
-  // only mask the rgb, not the alpha(?)
-  retval.rgb *= maskVal;
-  return bounds * retval;
-}
-
-vec4 sampleAtlasNearest(sampler2D tex, vec4 pos) {
-  float bounds = float(pos[0] >= 0.0 && pos[0] <= 1.0 &&
-    pos[1] >= 0.0 && pos[1] <= 1.0 &&
-    pos[2] >= 0.0 && pos[2] <= 1.0);
-  float nSlices = float(SLICES);
-
-  vec2 loc0 = ((pos.xy - 0.5) * flipVolume.xy + 0.5) / ATLAS_DIMS;
-
-  // No interpolation - sample just one slice at a pixel center.
-  // Ideally this would be accomplished in part by switching this texture to linear
-  //   filtering, but three makes this difficult to do through a WebGLRenderTarget.
-  loc0 = floor(loc0 * textureRes) / textureRes;
+  else {
+    // No interpolation - sample just one slice at a pixel center.
+    loc0 = floor(loc0 * textureRes) / textureRes;
+  }
   loc0 += vec2(0.5) / textureRes;
+
 
   float z = min(floor(pos.z * nSlices), nSlices - 1.0);
 
@@ -137,14 +89,8 @@ void main() {
   pos.xyz = (pos.xyz - SUBSET_OFFSET) / SUBSET_SCALE;
 
   vec4 C;
-  if(interpolationEnabled) {
-    C = sampleAtlasLinear(textureAtlas, pos);
-  } else {
-    C = sampleAtlasNearest(textureAtlas, pos);
-  }
-  C = luma2Alpha(C, GAMMA_MIN, GAMMA_MAX, GAMMA_SCALE);
+  C = sampleAtlas(textureAtlas, pos);
   C.xyz *= BRIGHTNESS;
-  // C.w *= DENSITY;  // Density disabled because it causes XY mode to render very dark on default settings
 
   C = clamp(C, 0.0, 1.0);
   gl_FragColor = C;

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -147,6 +147,7 @@ class SmartStoreWrapper implements AsyncStore<ArrayBuffer, RequestInit> {
     if (this.requestQueue) {
       return this.requestQueue.addRequest(key, () => this.getAndCacheItem(item, key, opts));
     } else {
+      // Should we ever hit this code?  We should always have a request queue.
       return this.getAndCacheItem(item, key, opts);
     }
   }


### PR DESCRIPTION
Some small improvements in this PR:

1. Single-slice rendering was a bit too dim. When you switch modes, the colors were really muted.  This was because of remnants of the volumetric shader still in the single-slice shader altering the alpha value.  I simplified the single slice shader considerably.
2. The z slider was initialized to 0 even though the volume is initialized to the middle slice.  Slider now inits to middle value.
3. Add z+1 and z-1 buttons to test caching when chunks consist of more than one slice
4. Remember pathtrace vs raymarch when switching between z and 3d mode.

