### PR TITLE
Use zarrita

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "geotiff": "^2.0.5",
         "three": "^0.144.0",
         "tweakpane": "^3.1.9",
-        "zarr": "^0.5.2"
+        "zarrita": "^0.3.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.14.8",
@@ -3128,6 +3128,40 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "node_modules/@zarrita/core": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@zarrita/core/-/core-0.0.3.tgz",
+      "integrity": "sha512-fWv51b+xbYnws1pkNDPwJQoDa76aojxplHyMup82u11UAiet3gURMsrrkhM6YbeTgSY1A8oGxDOrvar3SiZpLA==",
+      "dependencies": {
+        "@zarrita/storage": "^0.0.2",
+        "@zarrita/typedarray": "^0.0.1",
+        "numcodecs": "^0.2.2"
+      }
+    },
+    "node_modules/@zarrita/indexing": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@zarrita/indexing/-/indexing-0.0.3.tgz",
+      "integrity": "sha512-Q61d9MYX6dsK1DLltEpwx4mJWCZHj0TXiaEN4QpxNDtToa/EoyytP/pYHPypO4GXBscZooJ6eZkKT5FMx9PVfg==",
+      "dependencies": {
+        "@zarrita/core": "^0.0.3",
+        "@zarrita/storage": "^0.0.2",
+        "@zarrita/typedarray": "^0.0.1"
+      }
+    },
+    "node_modules/@zarrita/storage": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.0.2.tgz",
+      "integrity": "sha512-uFt4abAoiOYLroalNDAnVaQxA17zGKrQ0waYKmTVm+bNonz8ggKZP+0FqMhgUZITGChqoANHuYTazbuU5AFXWA==",
+      "dependencies": {
+        "reference-spec-reader": "^0.2.0",
+        "unzipit": "^1.3.6"
+      }
+    },
+    "node_modules/@zarrita/typedarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@zarrita/typedarray/-/typedarray-0.0.1.tgz",
+      "integrity": "sha512-ZdvNjYP1bEuQXoSTVkemV99w42jHYrJ3nh9golCLd4MVBlrVbfZo4wWgBslU4JZUaDikhFSH+GWMDgAq/rI32g=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -5551,7 +5585,8 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -9795,21 +9830,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/p-queue": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
-      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
-      "dependencies": {
-        "eventemitter3": "^4.0.7",
-        "p-timeout": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -9821,17 +9841,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -10667,6 +10676,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/reference-spec-reader": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+      "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ=="
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -12257,6 +12271,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unzipit": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+      "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+      "dependencies": {
+        "uzip-module": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -12388,6 +12413,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/uzip-module": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
+      "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -13246,16 +13276,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/zarr": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.5.2.tgz",
-      "integrity": "sha512-XiAZTlkCTALZyXCAXY2rgfRY45sIaGZd/rKKuQa84+bjpxoyNYXbAU5uaIDTR+CvIuTFABqq8Gc4PfzZHYOvkw==",
+    "node_modules/zarrita": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.3.2.tgz",
+      "integrity": "sha512-Zx9nS28C2tXZhF1BmQkgQGi0M/Z5JiM/KCMa+fEYtr/MnIzyizR4sKRA/sXjDP1iuylILWTJAWWBJD//0ONXCA==",
       "dependencies": {
-        "numcodecs": "^0.2.2",
-        "p-queue": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=12"
+        "@zarrita/core": "^0.0.3",
+        "@zarrita/indexing": "^0.0.3",
+        "@zarrita/storage": "^0.0.2"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "geotiff": "^2.0.5",
     "three": "^0.144.0",
     "tweakpane": "^3.1.9",
-    "zarr": "^0.5.2"
+    "zarrita": "^0.3.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.8",

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -186,7 +186,7 @@ function pickLevelToLoad(loadSpec: LoadSpec, spatialDimsZYX: [number, number, nu
   return Math.max(optimalLevel, loadSpec.multiscaleLevel ?? 0);
 }
 
-function convertChannel(channelData: zarr.TypedArray<"uint8" | "uint16">): Uint8Array {
+function convertChannel(channelData: zarr.TypedArray<zarr.NumberDataType>): Uint8Array {
   if (channelData instanceof Uint8Array) {
     return channelData as Uint8Array;
   }
@@ -215,8 +215,10 @@ function convertChannel(channelData: zarr.TypedArray<"uint8" | "uint16">): Uint8
   return u8;
 }
 
+type NumericZarrArray = zarr.Array<zarr.NumberDataType>;
+
 class OMEZarrLoader implements IVolumeLoader {
-  scaleLevels: zarr.Array<"uint8" | "uint16">[];
+  scaleLevels: NumericZarrArray[];
   multiscaleMetadata: OMEMultiscale;
   omeroMetadata: OmeroTransitionalMetadata;
   axesTCZYX: [number, number, number, number, number];
@@ -230,7 +232,7 @@ class OMEZarrLoader implements IVolumeLoader {
   maxExtent?: Box3;
 
   private constructor(
-    scaleLevels: zarr.Array<"uint8" | "uint16">[],
+    scaleLevels: NumericZarrArray[],
     multiscaleMetadata: OMEMultiscale,
     omeroMetadata: OmeroTransitionalMetadata,
     axisTCZYX: [number, number, number, number, number],
@@ -268,13 +270,7 @@ class OMEZarrLoader implements IVolumeLoader {
     const scaleLevels = await Promise.all(scaleLevelPromises);
     const axisTCZYX = remapAxesToTCZYX(multiscale.axes);
 
-    return new OMEZarrLoader(
-      scaleLevels as zarr.Array<"uint8" | "uint16", WrappedStore<RequestInit>>[],
-      multiscale,
-      metadata.omero,
-      axisTCZYX,
-      queue
-    );
+    return new OMEZarrLoader(scaleLevels as NumericZarrArray[], multiscale, metadata.omero, axisTCZYX, queue);
   }
 
   private getUnitSymbols(): [string, string] {

--- a/src/test/RequestQueue.test.ts
+++ b/src/test/RequestQueue.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { Vector3 } from "three";
-import { TypedArray } from "zarr";
+import { TypedArray } from "@zarrita/core";
 
 import RequestQueue, { Request } from "../utils/RequestQueue";
 import { LoadSpec, loadSpecToString } from "../loaders/IVolumeLoader";
@@ -335,7 +335,7 @@ describe("test RequestQueue", () => {
       expect(count).to.equal(0);
     });
 
-    async function mockLoader(loadSpec: Required<LoadSpec>, maxDelayMs = 10.0): Promise<TypedArray> {
+    async function mockLoader(loadSpec: Required<LoadSpec>, maxDelayMs = 10.0): Promise<TypedArray<"uint8">> {
       const { x, y, z } = loadSpec.subregion.getSize(new Vector3());
       const data = new Uint8Array(x * y * z);
       const delayMs = Math.random() * maxDelayMs;


### PR DESCRIPTION
Zarrita.js is a slightly more modular zarr library which works in a similar way to zarr.js, but fixes a number of problems we've been facing with the current library:

- Most immediately relevant: errors caused by cancelled requests are properly caught (this seems to have been caused by zarr.js's use of p-queue for limiting concurrent requests; zarrita uses a dummy queue by default). This should remove the need for the hacky fix in #167
- It allows us to pass down arbitrary options to its version of `Store` (called `Readable`), which solves a huge problem we've been facing with tracking prefetch requests

This PR switches us from zarr to zarrita. Remarkably little actually changes about how we interact with the library. The biggest change is converting the store wrapper from an instance of `Store`, which requires lots of methods that look like interacting with a filesystem, to an instance of `Readable`, which requires only one method: `get`.