### PR TITLE
fix how pathtracer receives updates to colors and lut

### DIFF
--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -370,6 +370,7 @@ export default class PathTracedVolume implements VolumeRenderImpl {
 
     if (dirtyFlags & SettingsFlags.MATERIAL) {
       this.pathTracingUniforms.gDensityScale.value = this.settings.density * 150.0;
+      this.updateMaterial();
     }
 
     // update bounds
@@ -574,7 +575,7 @@ export default class PathTracedVolume implements VolumeRenderImpl {
     this.updateVolumeData4();
     this.resetProgress();
     this.updateLuts(channelColors, channelData);
-    this.updateMaterial(channelColors, channelData);
+    this.updateMaterial();
   }
 
   updateVolumeData4(): void {
@@ -644,12 +645,13 @@ export default class PathTracedVolume implements VolumeRenderImpl {
 
   // image is a material interface that supports per-channel color, spec,
   // emissive, glossiness
-  updateMaterial(channelColors: FuseChannel[], channelData: Channel[]): void {
+  updateMaterial(): void {
     for (let c = 0; c < this.viewChannels.length; ++c) {
       const i = this.viewChannels[c];
       if (i > -1) {
         // diffuse color is actually blended into the LUT now.
-        const combinedLut = channelData[i].combineLuts(channelColors[i].rgbColor);
+        const channelData = this.volume.getChannel(i);
+        const combinedLut = channelData.combineLuts(this.settings.diffuse[i]);
         this.pathTracingUniforms.gLutTexture.value.image.data.set(combinedLut, c * LUT_ARRAY_LENGTH);
         this.pathTracingUniforms.gLutTexture.value.needsUpdate = true;
         this.pathTracingUniforms.gDiffuse.value[c] = new Vector3(1.0, 1.0, 1.0);

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -427,10 +427,12 @@ export default class VolumeDrawable {
 
   updateMaterial(): void {
     this.volumeRendering.updateActiveChannels(this.fusion, this.volume.channels);
+    this.volumeRendering.updateSettings(this.settings, SettingsFlags.MATERIAL);
   }
 
   updateLuts(): void {
     this.volumeRendering.updateActiveChannels(this.fusion, this.volume.channels);
+    this.volumeRendering.updateSettings(this.settings, SettingsFlags.MATERIAL);
   }
 
   setVoxelSize(values: Vector3): void {
@@ -545,6 +547,7 @@ export default class VolumeDrawable {
       return;
     }
     this.updateChannelColor(channelIndex, colorrgb);
+    this.settings.diffuse[channelIndex] = colorrgb;
     this.settings.specular[channelIndex] = specularrgb;
     this.settings.emissive[channelIndex] = emissivergb;
     this.settings.glossiness[channelIndex] = glossiness;

--- a/src/VolumeRenderSettings.ts
+++ b/src/VolumeRenderSettings.ts
@@ -16,7 +16,7 @@ export enum SettingsFlags {
   ROI = 0b000001000,
   /** parameters: maskAlpha */
   MASK_ALPHA = 0b000010000,
-  /** parameters: density, specular, emissive, glossiness */
+  /** parameters: density, diffuse, specular, emissive, glossiness */
   MATERIAL = 0b000100000,
   /** parameters: resolution, useInterpolation, pixelSamplingRate, primaryRayStepSize, secondaryRayStepSize*/
   SAMPLING = 0b001000000,
@@ -64,6 +64,7 @@ export class VolumeRenderSettings {
 
   // MATERIAL
   public density: number;
+  public diffuse: [number, number, number][];
   public specular: [number, number, number][];
   public emissive: [number, number, number][];
   public glossiness: number[];
@@ -115,11 +116,13 @@ export class VolumeRenderSettings {
     // volume-dependent properties
     if (volume) {
       this.zSlice = Math.floor(volume.imageInfo.subregionSize.z / 2);
+      this.diffuse = new Array(volume.imageInfo.numChannels).fill([255, 255, 255]);
       this.specular = new Array(volume.imageInfo.numChannels).fill([0, 0, 0]);
       this.emissive = new Array(volume.imageInfo.numChannels).fill([0, 0, 0]);
       this.glossiness = new Array(volume.imageInfo.numChannels).fill(0);
     } else {
       this.zSlice = 0;
+      this.diffuse = [[255, 255, 255]];
       this.specular = [[0, 0, 0]];
       this.emissive = [[0, 0, 0]];
       this.glossiness = [0];
@@ -130,6 +133,7 @@ export class VolumeRenderSettings {
 
   public resizeWithVolume(volume: Volume): void {
     this.zSlice = Math.floor(volume.imageInfo.subregionSize.z / 2);
+    this.diffuse = new Array(volume.imageInfo.numChannels).fill([255, 255, 255]);
     this.specular = new Array(volume.imageInfo.numChannels).fill([0, 0, 0]);
     this.emissive = new Array(volume.imageInfo.numChannels).fill([0, 0, 0]);
     this.glossiness = new Array(volume.imageInfo.numChannels).fill(0);


### PR DESCRIPTION
Pathtracer's main updating function for color and LUT updates was updateActiveChannels.  This function short-circuits based only on changes to the set of enabled channels, so if you didn't enable/disable a channel, then nothing else would update.

I am fixing this by using our settings MATERIAL flag to let the path tracer receive these updates.  Part of the fix is to add the per-channel color to our volume render settings.  Over time, we should add more and more per-channel settings to this structure and more and more will be able to use our updateSettings code path.