### PR TITLE
Only load enabled channels

### DIFF
--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -135,7 +135,7 @@ interface VolumeDataObserver {
  */
 export default class Volume {
   public imageInfo: ImageInfo;
-  public loadSpec: LoadSpec;
+  public loadSpec: Required<LoadSpec>;
   public loader?: IVolumeLoader;
   // `LoadSpec` representing the minimum data required to display what's in the viewer (subregion, channels, etc.).
   // Used to intelligently issue load requests whenever required by a state change. Modify with `updateRequiredData`.
@@ -169,13 +169,16 @@ export default class Volume {
     this.loaded = false;
     this.imageInfo = imageInfo;
     this.name = this.imageInfo.name;
-    this.loadSpec = loadSpec;
-    this.loadSpecRequired = {
+    this.loadSpec = {
       // Fill in defaults for optional properties
       multiscaleLevel: 0,
       channels: Array.from({ length: this.imageInfo.numChannels }, (_val, idx) => idx),
       ...loadSpec,
-      subregion: loadSpec.subregion.clone(),
+    };
+    this.loadSpecRequired = {
+      ...this.loadSpec,
+      channels: this.loadSpec.channels.slice(),
+      subregion: this.loadSpec.subregion.clone(),
     };
     this.loader = loader;
     // imageMetadata to be filled in by Volume Loaders
@@ -241,7 +244,8 @@ export default class Volume {
     this.loadSpecRequired = { ...this.loadSpecRequired, ...required };
     let noReload =
       this.loadSpec.time === this.loadSpecRequired.time &&
-      this.loadSpec.subregion.containsBox(this.loadSpecRequired.subregion);
+      this.loadSpec.subregion.containsBox(this.loadSpecRequired.subregion) &&
+      this.loadSpecRequired.channels.every((channel) => this.loadSpec.channels.includes(channel));
 
     // An update to `subregion` should trigger a reload when the new subregion is not contained in the old one
     // OR when the new subregion is smaller than the old one by enough that we can load a higher scale level.

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -139,7 +139,7 @@ export default class Volume {
   public loader?: IVolumeLoader;
   // `LoadSpec` representing the minimum data required to display what's in the viewer (subregion, channels, etc.).
   // Used to intelligently issue load requests whenever required by a state change. Modify with `updateRequiredData`.
-  private loadSpecRequired: Required<LoadSpec>;
+  public loadSpecRequired: Required<LoadSpec>;
   public channelLoadCallback?: PerChannelCallback;
   public imageMetadata: Record<string, unknown>;
   public name: string;

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -497,15 +497,11 @@ export default class VolumeDrawable {
     // flip the color to the "null" value
     this.fusion[channelIndex].rgbColor = enabled ? this.channelColors[channelIndex] : 0;
     // if all are nulled out, then hide the volume element from the scene.
-    if (this.fusion.every((elem) => elem.rgbColor === 0)) {
-      this.settings.visible = false;
-    } else {
-      this.settings.visible = true;
-    }
+    this.settings.visible = !this.fusion.every((elem) => elem.rgbColor === 0);
     this.volumeRendering.updateSettings(this.settings, SettingsFlags.VIEW);
 
     // add or remove this channel from the list of required channels to load
-    const { channels } = this.volume.loadSpec;
+    const { channels } = this.volume.loadSpecRequired;
     const channelRequired = channels.includes(channelIndex);
     if (enabled && !channelRequired) {
       this.volume.updateRequiredData({ channels: [...channels, channelIndex] });
@@ -522,6 +518,7 @@ export default class VolumeDrawable {
   // Set the color for a channel
   // @param {Array.<number>} colorrgb [r,g,b]
   updateChannelColor(channelIndex: number, colorrgb: [number, number, number]): void {
+    console.log("update color", channelIndex, colorrgb);
     if (!this.channelColors[channelIndex]) {
       return;
     }

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -503,6 +503,15 @@ export default class VolumeDrawable {
       this.settings.visible = true;
     }
     this.volumeRendering.updateSettings(this.settings, SettingsFlags.VIEW);
+
+    // add or remove this channel from the list of required channels to load
+    const { channels } = this.volume.loadSpec;
+    const channelRequired = channels.includes(channelIndex);
+    if (enabled && !channelRequired) {
+      this.volume.updateRequiredData({ channels: [...channels, channelIndex] });
+    } else if (!enabled && channelRequired) {
+      this.volume.updateRequiredData({ channels: channels.filter((i) => i !== channelIndex) });
+    }
   }
 
   isVolumeChannelEnabled(channelIndex: number): boolean {

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -518,7 +518,6 @@ export default class VolumeDrawable {
   // Set the color for a channel
   // @param {Array.<number>} colorrgb [r,g,b]
   updateChannelColor(channelIndex: number, colorrgb: [number, number, number]): void {
-    console.log("update color", channelIndex, colorrgb);
     if (!this.channelColors[channelIndex]) {
       return;
     }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -428,7 +428,7 @@ class OMEZarrLoader implements IVolumeLoader {
     // First, cancel any pending requests for this volume
     this.requestQueue.cancelAllRequests(CHUNK_REQUEST_CANCEL_REASON);
 
-    vol.loadSpec = explicitLoadSpec ?? vol.loadSpec;
+    vol.loadSpec = { ...explicitLoadSpec, ...vol.loadSpec };
     const maxExtent = this.maxExtent ?? new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1));
     const [z, y, x] = this.axesTCZYX.slice(2);
     const subregion = composeSubregion(vol.loadSpec.subregion, maxExtent);


### PR DESCRIPTION
Addresses #158: don't load disabled channels.

### To verify:
1. Open test app.
2. Switch volume to "OME Zarr (Nucmorph)"
3. Disable either channel.
4. Step through time. *Each time point should load faster than normal.*
5. Re-enable the disabled channel. *The channel should load into its current timepoint.*

### What this PR does NOT do:
This is a relatively small change to address the "letter" of the linked issue, which falls just a bit short of the "spirit" of the issue for the following reasons:

- Channels are initialized as enabled and only disabled after loading has begun, so this feature gives no benefit to the initial load of a volume. As a consequence, because the test viewer does not have a JSON volume that includes both multiple time points and enough channels to require more than one atlas image, I had trouble testing how the JSON atlas loader behaves when loading a subset of channels.
- Though I spent a long time trying to clean up how channel enabled/disabled state gets updated to fix a bug, which turned out to be caused by something unrelated and silly, I didn't manage to find a change that I could reasonably earmark onto this PR. Until channel state is a bit more reliable, this feature may be a bit fiddly, though the point above is the only behavior I've seen that I'd describe as a "bug."
- This PR doesn't include the optimization of only loading newly-enabled channels when possible. I'd rather address the subtleties that come with that optimization (described in the linked issue) when state updates are a bit more coherent. (Caching may make the benefits of this optimization minimal anyways.)