### PR TITLE
Zarr prefetching

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -28,7 +28,7 @@ import { getDefaultImageInfo } from "../src/Volume";
 const CACHE_MAX_SIZE = 1_000_000_000;
 const CONCURRENCY_LIMIT = 8;
 const PREFETCH_CONCURRENCY_LIMIT = 3;
-const PREFETCH_DISTANCE = new Vector4(5, 5, 5, 5);
+const PREFETCH_DISTANCE: [number, number, number, number] = [5, 5, 5, 5];
 const MAX_PREFETCH_CHUNKS = 25;
 const PLAYBACK_INTERVAL = 80;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import Volume from "./Volume";
 import Channel from "./Channel";
 import VolumeMaker from "./VolumeMaker";
 import VolumeCache from "./VolumeCache";
+import RequestQueue from "./utils/RequestQueue";
+import SubscribableRequestQueue from "./utils/SubscribableRequestQueue";
 import Histogram from "./Histogram";
 import { ViewportCorner } from "./types";
 import { VolumeFileFormat, createVolumeLoader } from "./loaders";
@@ -17,6 +19,7 @@ export type { ImageInfo } from "./Volume";
 export type { ControlPoint, Lut } from "./Histogram";
 export type { CreateLoaderOptions } from "./loaders";
 export type { IVolumeLoader, PerChannelCallback } from "./loaders/IVolumeLoader";
+export type { ZarrLoaderFetchOptions } from "./loaders/OmeZarrLoader";
 export {
   Histogram,
   View3d,
@@ -24,6 +27,8 @@ export {
   LoadSpec,
   VolumeMaker,
   VolumeCache,
+  RequestQueue,
+  SubscribableRequestQueue,
   OMEZarrLoader,
   JsonImageInfoLoader,
   TiffLoader,

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -127,12 +127,28 @@ class OMEZarrLoader implements IVolumeLoader {
 
   static async createLoader(
     url: string,
+    scene?: number,
+    cache?: VolumeCache,
+    queue?: SubscribableRequestQueue
+  ): Promise<OMEZarrLoader>;
+  static async createLoader(
+    url: string,
+    scene?: number,
+    cache?: VolumeCache,
+    concurrencyLimit?: number,
+    prefetchConcurrencyLimit?: number
+  ): Promise<OMEZarrLoader>;
+  static async createLoader(
+    url: string,
     scene = 0,
     cache?: VolumeCache,
-    concurrencyLimit = 10
+    queue?: SubscribableRequestQueue | number,
+    prefetchConcurrencyLimit?: number
   ): Promise<OMEZarrLoader> {
-    // Setup: create queue and store, get basic metadata
-    const queue = new SubscribableRequestQueue(concurrencyLimit, 5);
+    // Setup queue and store, get basic metadata
+    if (typeof queue === "number" || queue === undefined) {
+      queue = new SubscribableRequestQueue(queue, prefetchConcurrencyLimit);
+    }
     const store = new WrappedStore<RequestInit>(new FetchStore(url), cache, queue);
     const root = zarr.root(store);
     const group = await zarr.open(root, { kind: "group" });

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -33,8 +33,6 @@ import {
 
 const CHUNK_REQUEST_CANCEL_REASON = "chunk request cancelled";
 
-const PREFETCH_TIME_MARGIN = 8;
-
 /** Turns `axisTCZYX` into the number of dimensions in the array */
 const getDimensionCount = ([t, c, z]: TCZYX<number>) => 2 + Number(t > -1) + Number(c > -1) + Number(z > -1);
 
@@ -108,10 +106,10 @@ function convertChannel(channelData: zarr.TypedArray<zarr.NumberDataType>): Uint
 type NumericZarrArray = zarr.Array<zarr.NumberDataType, WrappedStore<RequestInit>>;
 
 class OMEZarrLoader implements IVolumeLoader {
-  /** Hold one optional subscriber ID per timestep, each defined iff a batch of prefetches is waiting for that frame */
-  private prefetchSubscribers: (SubscriberId | undefined)[];
   /** The ID of the subscriber responsible for "actual loads" (non-prefetch requests) */
   private loadSubscriber: SubscriberId | undefined;
+  /** The ID of the subscriber responsible for prefetches, so that requests can be cancelled and reissued */
+  private prefetchSubscriber: SubscriberId | undefined;
 
   // TODO: this property should definitely be owned by `Volume` if this loader is ever used by multiple volumes.
   //   This may cause errors or incorrect results otherwise!
@@ -125,11 +123,7 @@ class OMEZarrLoader implements IVolumeLoader {
     private axesTCZYX: TCZYX<number>,
     // TODO: should we be able to share `RequestQueue`s between loaders?
     private requestQueue: SubscribableRequestQueue
-  ) {
-    const ti = this.axesTCZYX[0];
-    const times = ti < 0 ? 1 : this.scaleLevels[0].shape[this.axesTCZYX[0]];
-    this.prefetchSubscribers = new Array(times).fill(undefined);
-  }
+  ) {}
 
   static async createLoader(
     url: string,
@@ -366,58 +360,23 @@ class OMEZarrLoader implements IVolumeLoader {
     const chunkDimsUnordered = scaleLevel.shape.map((dim, idx) => Math.ceil(dim / scaleLevel.chunks[idx]));
     const chunkDims = this.orderByTCZYX(chunkDimsUnordered, 1);
 
-    const experimentalIndexer = new ChunkPrefetchIterator(
+    const subscriber = this.requestQueue.addSubscriber();
+    // `ChunkPrefetchIterator` yields chunk coordinates in order of roughly how likely they are to be loaded next
+    const prefetchIterator = new ChunkPrefetchIterator(
       chunkCoords,
       new Vector4(2, 2, 2, 2),
       new Vector4(chunkDims[4], chunkDims[3], chunkDims[2], chunkDims[0])
     );
-    for (const chunk of experimentalIndexer) {
-      console.log(chunk);
+
+    for (const chunk of prefetchIterator) {
+      this.prefetchChunk(scaleLevel.path, chunk, subscriber);
     }
 
-    // Get all channels involved in this request
-    const channels = new Set<number>();
-    for (const coord of chunkCoords) {
-      channels.add(coord[1]);
+    // Clear out old prefetch requests (requests which also cover this new prefetch will be preserved)
+    if (this.prefetchSubscriber !== undefined) {
+      this.requestQueue.removeSubscriber(this.prefetchSubscriber, CHUNK_REQUEST_CANCEL_REASON);
     }
-
-    // Clear out any existing prefetches (requests already in flight will be picked up by new prefetches if useful)
-    for (const subscriber of this.prefetchSubscribers) {
-      if (subscriber !== undefined) {
-        this.requestQueue.removeSubscriber(subscriber, CHUNK_REQUEST_CANCEL_REASON);
-      }
-    }
-
-    // Now let's get to prefetching!
-    // TODO: consider cache size and something like average chunk size when deciding how much to prefetch
-    const activeTimestep = chunkCoords[0][0];
-    const tmin = Math.max(0, activeTimestep - PREFETCH_TIME_MARGIN);
-    const tmax = Math.min(chunkDims[0], activeTimestep + PREFETCH_TIME_MARGIN);
-    for (let t = tmin; t < tmax; t++) {
-      const subscriber = this.requestQueue.addSubscriber();
-      this.prefetchSubscribers[t] = subscriber;
-
-      if (t === activeTimestep) {
-        // For the current timestep: get all chunks in ZYX for all channels involved in this request
-        // TODO: it is dangerous to assume that we can reasonably prefetch the entire volume at the current timestep.
-        //   This behavior shouldn't be allowed into production if we expect anyone to deal with large enough datasets.
-        for (const c of channels) {
-          for (let z = 0; z < chunkDims[2]; z++) {
-            for (let y = 0; y < chunkDims[3]; y++) {
-              for (let x = 0; x < chunkDims[4]; x++) {
-                this.prefetchChunk(scaleLevel.path, [t, c, z, y, x], subscriber);
-              }
-            }
-          }
-        }
-      } else {
-        // For nearby timesteps: duplicate only the load requests made on the current timestep on this one too
-        for (const coord of chunkCoords) {
-          const [c, z, y, x] = coord.slice(1);
-          this.prefetchChunk(scaleLevel.path, [t, c, z, y, x], subscriber);
-        }
-      }
-    }
+    this.prefetchSubscriber = subscriber;
   }
 
   async loadVolumeData(vol: Volume, explicitLoadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<void> {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -1,4 +1,4 @@
-import { Box3, Vector3, Vector4 } from "three";
+import { Box3, Vector3 } from "three";
 
 import * as zarr from "@zarrita/core";
 import { get as zarrGet, slice, Slice } from "@zarrita/indexing";
@@ -115,16 +115,16 @@ export type ZarrLoaderFetchOptions = {
   prefetchConcurrencyLimit?: number;
   /**
    * The max. number of chunks to prefetch outward in either direction. E.g. if a load requests chunks with z coords 3
-   * and 4 and `maxPrefetchDistance.z` is 2, the loader will prefetch similar chunks with z coords 1, 2, 5, and 6 (or
-   * until it hits `maxPrefetchChunks`). The `w` component is time.
+   * and 4 and `maxPrefetchDistance` in z is 2, the loader will prefetch similar chunks with z coords 1, 2, 5, and 6
+   * (or until it hits `maxPrefetchChunks`). Ordered TZYX.
    */
-  maxPrefetchDistance: Vector4;
+  maxPrefetchDistance: [number, number, number, number];
   /** The max. number of total chunks that can be prefetched after any load. */
   maxPrefetchChunks: number;
 };
 
 const DEFAULT_FETCH_OPTIONS = {
-  maxPrefetchDistance: new Vector4(5, 5, 5, 5),
+  maxPrefetchDistance: [5, 5, 5, 5] as [number, number, number, number],
   maxPrefetchChunks: 30,
 };
 
@@ -388,10 +388,11 @@ class OMEZarrLoader implements IVolumeLoader {
 
     const subscriber = this.requestQueue.addSubscriber();
     // `ChunkPrefetchIterator` yields chunk coordinates in order of roughly how likely they are to be loaded next
+    const chunkDimsTZYX: [number, number, number, number] = [chunkDims[0], chunkDims[2], chunkDims[3], chunkDims[4]];
     const prefetchIterator = new ChunkPrefetchIterator(
       chunkCoords,
       this.fetchOptions.maxPrefetchDistance,
-      new Vector4(chunkDims[4], chunkDims[3], chunkDims[2], chunkDims[0])
+      chunkDimsTZYX
     );
 
     let prefetchCount = 0;

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -1,7 +1,7 @@
 import { Box3, Vector3 } from "three";
 
 import * as zarr from "@zarrita/core";
-import { get as zarrGet, slice, Slice } from "@zarrita/indexing";
+import { get as zarrGet, slice } from "@zarrita/indexing";
 import { AbsolutePath, AsyncReadable, Readable } from "@zarrita/storage";
 // Importing `FetchStore` from its home subpackage (@zarrita/storage) causes errors.
 // Getting it from the top-level package means we don't get its type. This is also a bug, but it's more acceptable.
@@ -9,7 +9,6 @@ import { FetchStore } from "zarrita";
 
 import Volume, { ImageInfo } from "../Volume";
 import VolumeCache from "../VolumeCache";
-import RequestQueue from "../utils/RequestQueue";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
 import { IVolumeLoader, LoadSpec, PerChannelCallback, VolumeDims } from "./IVolumeLoader";
 import {

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -1,9 +1,10 @@
 import { IVolumeLoader } from "./IVolumeLoader";
 
-import { OMEZarrLoader } from "./OmeZarrLoader";
+import { OMEZarrLoader, ZarrLoaderFetchOptions } from "./OmeZarrLoader";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader";
 import { TiffLoader } from "./TiffLoader";
 import VolumeCache from "../VolumeCache";
+import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
 
 export const enum VolumeFileFormat {
   ZARR = "zarr",
@@ -14,8 +15,9 @@ export const enum VolumeFileFormat {
 export type CreateLoaderOptions = {
   fileType?: VolumeFileFormat;
   cache?: VolumeCache;
+  queue?: SubscribableRequestQueue;
   scene?: number;
-  concurrencyLimit?: number;
+  fetchOptions?: ZarrLoaderFetchOptions;
 };
 
 export async function createVolumeLoader(
@@ -26,7 +28,13 @@ export async function createVolumeLoader(
 
   switch (options?.fileType) {
     case VolumeFileFormat.ZARR:
-      return await OMEZarrLoader.createLoader(pathString, options.scene, options.cache, options.concurrencyLimit);
+      return await OMEZarrLoader.createLoader(
+        pathString,
+        options.scene,
+        options.cache,
+        options.queue,
+        options.fetchOptions
+      );
     case VolumeFileFormat.JSON:
       return new JsonImageInfoLoader(path, options.cache);
     case VolumeFileFormat.TIFF:
@@ -37,7 +45,13 @@ export async function createVolumeLoader(
       } else if (pathString.endsWith(".tif") || pathString.endsWith(".tiff")) {
         return new TiffLoader(pathString);
       } else {
-        return await OMEZarrLoader.createLoader(pathString, options?.scene, options?.cache, options?.concurrencyLimit);
+        return await OMEZarrLoader.createLoader(
+          pathString,
+          options?.scene,
+          options?.cache,
+          options?.queue,
+          options?.fetchOptions
+        );
       }
   }
 }

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -37,13 +37,13 @@ const directionToIndex = (dir: PrefetchDirection): number => {
   return absDir + Number(absDir !== 0); // convert TZYX -> TCZYX by skipping c (index 1)
 };
 
-function updateMinMax(val: number, minmax: number[], offset: number): void {
-  if (val < minmax[offset]) {
-    minmax[offset] = val;
+function updateMinMax(val: number, minmax: [number, number]): void {
+  if (val < minmax[0]) {
+    minmax[0] = val;
   }
 
-  if (val > minmax[offset + 1]) {
-    minmax[offset + 1] = val;
+  if (val > minmax[1]) {
+    minmax[1] = val;
   }
 }
 
@@ -57,18 +57,23 @@ export default class ChunkPrefetchIterator {
   directions: PrefetchDirectionState[];
 
   constructor(chunks: TCZYX<number>[], tzyxMaxPrefetchOffset: TZYX, tzyxNumChunks: TZYX) {
-    // Get max and min chunk coordinates for T/Z/Y/X
-    const extrema = [Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity];
+    // Get min and max chunk coordinates for T/Z/Y/X
+    const extrema: [number, number][] = [
+      [Infinity, -Infinity],
+      [Infinity, -Infinity],
+      [Infinity, -Infinity],
+      [Infinity, -Infinity],
+    ];
 
     for (const chunk of chunks) {
-      updateMinMax(chunk[0], extrema, 0);
-      updateMinMax(chunk[2], extrema, 2);
-      updateMinMax(chunk[3], extrema, 4);
-      updateMinMax(chunk[4], extrema, 6);
+      updateMinMax(chunk[0], extrema[0]);
+      updateMinMax(chunk[2], extrema[1]);
+      updateMinMax(chunk[3], extrema[2]);
+      updateMinMax(chunk[4], extrema[3]);
     }
 
     // Create `PrefetchDirectionState`s for each direction
-    const directions: PrefetchDirectionState[] = extrema.map((start, direction) => {
+    const directions: PrefetchDirectionState[] = extrema.flat().map((start, direction) => {
       const dimension = direction >> 1;
       if (direction & 1) {
         // Positive direction - end is either the max coordinate in the fetched set plus the max offset in this

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -1,0 +1,104 @@
+import { Vector4 } from "three";
+
+import { TCZYX } from "./types";
+
+const enum PrefetchDirection {
+  T_MINUS = 0,
+  T_PLUS = 1,
+
+  Z_MINUS = 2,
+  Z_PLUS = 3,
+
+  Y_MINUS = 4,
+  Y_PLUS = 5,
+
+  X_MINUS = 6,
+  X_PLUS = 7,
+}
+
+type PrefetchDirectionState = {
+  direction: PrefetchDirection;
+  chunks: TCZYX<number>[];
+  start: number;
+  end: number;
+};
+
+const skipC = (idx: number): number => idx + Number(idx !== 0);
+const directionToIndex = (dir: PrefetchDirection): number => skipC(dir >> 1);
+
+/**
+ * Since the user is most likely to want nearby data (in space or time) first, we should prefetch those chunks first.
+ *
+ * Given a list of just-loaded chunks and some bounds, `ChunkPrefetchIterator` iterates evenly outwards in T/Z/Y/X.
+ */
+// NOTE: Assumes `chunks` form a rectangular prism! Will create gaps otherwise! (in practice they always should)
+export default class ChunkPrefetchIterator {
+  directions: PrefetchDirectionState[];
+
+  constructor(chunks: TCZYX<number>[], xyztMaxOffset: Vector4, xyztChunkSize: Vector4) {
+    const maxOffsetArr = [xyztMaxOffset.w, xyztMaxOffset.z, xyztMaxOffset.y, xyztMaxOffset.x];
+    const chunkSizeArr = [xyztChunkSize.w, xyztChunkSize.z, xyztChunkSize.y, xyztChunkSize.x];
+    // Get max and min chunk coordinates for T/Z/Y/X
+    const extrema = [Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity];
+
+    for (const chunk of chunks) {
+      for (let j = 0; j < 4; j++) {
+        const val = chunk[skipC(j)];
+        const extremaIdx = j << 1;
+
+        if (val < extrema[extremaIdx]) {
+          extrema[extremaIdx] = val;
+        }
+
+        if (val > extrema[extremaIdx + 1]) {
+          extrema[extremaIdx + 1] = val;
+        }
+      }
+    }
+
+    // Create `PrefetchDirectionState`s for each direction and fill them with chunks at the borders of the fetched set
+    const directions: PrefetchDirectionState[] = extrema.map((start, direction) => {
+      const end =
+        direction & 1
+          ? Math.min(start + maxOffsetArr[direction >> 1], chunkSizeArr[direction >> 1] - 1)
+          : Math.max(start - maxOffsetArr[direction >> 1], 0);
+      return { direction, start, end, chunks: [] };
+    });
+
+    for (const chunk of chunks) {
+      for (const dir of directions) {
+        if (chunk[directionToIndex(dir.direction)] === dir.start) {
+          dir.chunks.push(chunk);
+        }
+      }
+    }
+
+    this.directions = directions;
+  }
+
+  *[Symbol.iterator](): Iterator<TCZYX<number>> {
+    let offset = 1;
+
+    while (this.directions.length > 0) {
+      // Remove directions in which we have hit a boundary
+      this.directions = this.directions.filter((dir) => {
+        if (dir.direction & 1) {
+          return dir.start + offset <= dir.end;
+        } else {
+          return dir.start - offset >= dir.end;
+        }
+      });
+
+      // Yield chunks one chunk farther out in every remaining direction
+      for (const dir of this.directions) {
+        for (const chunk of dir.chunks) {
+          const newChunk = chunk.slice() as TCZYX<number>;
+          newChunk[directionToIndex(dir.direction)] += offset * (dir.direction & 1 ? 1 : -1);
+          yield newChunk;
+        }
+      }
+
+      offset += 1;
+    }
+  }
+}

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -35,6 +35,16 @@ type PrefetchDirectionState = {
 const skipC = (idx: number): number => idx + Number(idx !== 0);
 const directionToIndex = (dir: PrefetchDirection): number => skipC(dir >> 1);
 
+function updateMinMax(val: number, minmax: number[], offset: number): void {
+  if (val < minmax[offset]) {
+    minmax[offset] = val;
+  }
+
+  if (val > minmax[offset + 1]) {
+    minmax[offset + 1] = val;
+  }
+}
+
 /**
  * Since the user is most likely to want nearby data (in space or time) first, we should prefetch those chunks first.
  *
@@ -49,18 +59,10 @@ export default class ChunkPrefetchIterator {
     const extrema = [Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity];
 
     for (const chunk of chunks) {
-      for (let j = 0; j < 4; j++) {
-        const val = chunk[skipC(j)];
-        const extremaIdx = j << 1;
-
-        if (val < extrema[extremaIdx]) {
-          extrema[extremaIdx] = val;
-        }
-
-        if (val > extrema[extremaIdx + 1]) {
-          extrema[extremaIdx + 1] = val;
-        }
-      }
+      updateMinMax(chunk[0], extrema, 0);
+      updateMinMax(chunk[2], extrema, 2);
+      updateMinMax(chunk[3], extrema, 4);
+      updateMinMax(chunk[4], extrema, 6);
     }
 
     // Create `PrefetchDirectionState`s for each direction

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -1,6 +1,6 @@
-import { Vector4 } from "three";
-
 import { TCZYX } from "./types";
+
+type TZYX = [number, number, number, number];
 
 /**
  * Directions in which to move outward from the loaded set of chunks while prefetching.
@@ -44,9 +44,7 @@ const directionToIndex = (dir: PrefetchDirection): number => skipC(dir >> 1);
 export default class ChunkPrefetchIterator {
   directions: PrefetchDirectionState[];
 
-  constructor(chunks: TCZYX<number>[], xyztMaxOffset: Vector4, xyztChunkSize: Vector4) {
-    const maxOffsetArr = [xyztMaxOffset.w, xyztMaxOffset.z, xyztMaxOffset.y, xyztMaxOffset.x];
-    const chunkSizeArr = [xyztChunkSize.w, xyztChunkSize.z, xyztChunkSize.y, xyztChunkSize.x];
+  constructor(chunks: TCZYX<number>[], tzyxMaxOffset: TZYX, tzyxChunkSize: TZYX) {
     // Get max and min chunk coordinates for T/Z/Y/X
     const extrema = [Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity];
 
@@ -71,12 +69,12 @@ export default class ChunkPrefetchIterator {
       if (direction & 1) {
         // Positive direction - end is either the max coordinate in the fetched set plus the max offset in this
         // dimension, or the max chunk coordinate in this dimension, whichever comes first
-        const end = Math.min(start + maxOffsetArr[dimension], chunkSizeArr[dimension] - 1);
+        const end = Math.min(start + tzyxMaxOffset[dimension], tzyxChunkSize[dimension] - 1);
         return { direction, start, end, chunks: [] };
       } else {
         // Negative direction - end is either the min coordinate in the fetched set minus the max offset in this
         // dimension, or 0, whichever comes first
-        const end = Math.max(start - maxOffsetArr[dimension], 0);
+        const end = Math.max(start - tzyxMaxOffset[dimension], 0);
         return { direction, start, end, chunks: [] };
       }
     });

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -32,8 +32,10 @@ type PrefetchDirectionState = {
   end: number;
 };
 
-const skipC = (idx: number): number => idx + Number(idx !== 0);
-const directionToIndex = (dir: PrefetchDirection): number => skipC(dir >> 1);
+const directionToIndex = (dir: PrefetchDirection): number => {
+  const absDir = dir >> 1; // shave off sign bit to get index in TZYX
+  return absDir + Number(absDir !== 0); // convert TZYX -> TCZYX by skipping c (index 1)
+};
 
 function updateMinMax(val: number, minmax: number[], offset: number): void {
   if (val < minmax[offset]) {

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -54,7 +54,7 @@ function updateMinMax(val: number, minmax: number[], offset: number): void {
 export default class ChunkPrefetchIterator {
   directions: PrefetchDirectionState[];
 
-  constructor(chunks: TCZYX<number>[], tzyxMaxOffset: TZYX, tzyxChunkSize: TZYX) {
+  constructor(chunks: TCZYX<number>[], tzyxMaxPrefetchOffset: TZYX, tzyxNumChunks: TZYX) {
     // Get max and min chunk coordinates for T/Z/Y/X
     const extrema = [Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity];
 
@@ -71,12 +71,12 @@ export default class ChunkPrefetchIterator {
       if (direction & 1) {
         // Positive direction - end is either the max coordinate in the fetched set plus the max offset in this
         // dimension, or the max chunk coordinate in this dimension, whichever comes first
-        const end = Math.min(start + tzyxMaxOffset[dimension], tzyxChunkSize[dimension] - 1);
+        const end = Math.min(start + tzyxMaxPrefetchOffset[dimension], tzyxNumChunks[dimension] - 1);
         return { direction, start, end, chunks: [] };
       } else {
         // Negative direction - end is either the min coordinate in the fetched set minus the max offset in this
         // dimension, or 0, whichever comes first
-        const end = Math.max(start - tzyxMaxOffset[dimension], 0);
+        const end = Math.max(start - tzyxMaxPrefetchOffset[dimension], 0);
         return { direction, start, end, chunks: [] };
       }
     });

--- a/src/loaders/zarr_utils/WrappedStore.ts
+++ b/src/loaders/zarr_utils/WrappedStore.ts
@@ -1,0 +1,68 @@
+import { FetchStore } from "zarrita";
+import { AbsolutePath, AsyncReadable, Readable } from "@zarrita/storage";
+
+import SubscribableRequestQueue from "../../utils/SubscribableRequestQueue";
+import VolumeCache from "../../VolumeCache";
+
+import { SubscriberId } from "./types";
+
+type WrappedStoreOpts<Opts> = {
+  options?: Opts;
+  subscriber: SubscriberId;
+  reportKey?: (key: string, subscriber: SubscriberId) => void;
+  isPrefetch?: boolean;
+};
+
+/**
+ * `Readable` is zarrita's minimal abstraction for any source of data.
+ * `WrappedStore` wraps another `Readable` and adds (optional) connections to `VolumeCache` and `RequestQueue`.
+ */
+class WrappedStore<Opts, S extends Readable<Opts> = Readable<Opts>> implements AsyncReadable<WrappedStoreOpts<Opts>> {
+  constructor(private baseStore: S, private cache?: VolumeCache, private queue?: SubscribableRequestQueue) {}
+
+  private async getAndCache(key: AbsolutePath, cacheKey: string, opts?: Opts): Promise<Uint8Array | undefined> {
+    const result = await this.baseStore.get(key, opts);
+    if (this.cache && result) {
+      this.cache.insert(cacheKey, result);
+    }
+    return result;
+  }
+
+  async get(key: AbsolutePath, opts?: WrappedStoreOpts<Opts> | undefined): Promise<Uint8Array | undefined> {
+    const ZARR_EXTS = [".zarray", ".zgroup", ".zattrs", "zarr.json"];
+    if (!this.cache || ZARR_EXTS.some((s) => key.endsWith(s))) {
+      return this.baseStore.get(key, opts?.options);
+    }
+    if (opts?.reportKey) {
+      opts.reportKey(key, opts.subscriber);
+    }
+
+    let keyPrefix = (this.baseStore as FetchStore).url ?? "";
+    if (keyPrefix !== "" && !(keyPrefix instanceof URL) && !keyPrefix.endsWith("/")) {
+      keyPrefix += "/";
+    }
+
+    const fullKey = keyPrefix + key.slice(1);
+
+    // Check the cache
+    const cacheResult = this.cache.get(fullKey);
+    if (cacheResult) {
+      return new Uint8Array(cacheResult);
+    }
+
+    // Not in cache; load the chunk and cache it
+    if (this.queue && opts) {
+      return this.queue.addRequest(
+        fullKey,
+        opts.subscriber,
+        () => this.getAndCache(key, fullKey, opts?.options),
+        opts.isPrefetch
+      );
+    } else {
+      // Should we ever hit this code?  We should always have a request queue.
+      return this.getAndCache(key, fullKey, opts?.options);
+    }
+  }
+}
+
+export default WrappedStore;

--- a/src/loaders/zarr_utils/types.ts
+++ b/src/loaders/zarr_utils/types.ts
@@ -1,0 +1,69 @@
+import SubscribableRequestQueue from "../../utils/SubscribableRequestQueue";
+
+export type TCZYX<T> = [T, T, T, T, T];
+export type SubscriberId = ReturnType<SubscribableRequestQueue["addSubscriber"]>;
+
+export type OMECoordinateTransformation =
+  | {
+      type: "identity";
+    }
+  | {
+      type: "translation";
+      translation: number[];
+    }
+  | {
+      type: "scale";
+      scale: number[];
+    }
+  | {
+      type: "translation" | "scale";
+      path: string;
+    };
+
+export type OMEAxis = {
+  name: string;
+  type?: string;
+  unit?: string;
+};
+
+export type OMEDataset = {
+  path: string;
+  coordinateTransformations?: OMECoordinateTransformation[];
+};
+
+// https://ngff.openmicroscopy.org/latest/#multiscale-md
+export type OMEMultiscale = {
+  version?: string;
+  name?: string;
+  axes: OMEAxis[];
+  datasets: OMEDataset[];
+  coordinateTransformations?: OMECoordinateTransformation[];
+  type?: string;
+  metadata?: Record<string, unknown>;
+};
+
+// https://ngff.openmicroscopy.org/latest/#omero-md
+export type OmeroTransitionalMetadata = {
+  id: number;
+  name: string;
+  version: string;
+  channels: {
+    active: boolean;
+    coefficient: number;
+    color: string;
+    family: string;
+    inverted: boolean;
+    label: string;
+    window: {
+      end: number;
+      max: number;
+      min: number;
+      start: number;
+    };
+  }[];
+};
+
+export type OMEZarrMetadata = {
+  multiscales: OMEMultiscale[];
+  omero: OmeroTransitionalMetadata;
+};

--- a/src/test/ChunkPrefetchIterator.test.ts
+++ b/src/test/ChunkPrefetchIterator.test.ts
@@ -1,0 +1,172 @@
+import { expect } from "chai";
+
+import { TCZYX } from "../loaders/zarr_utils/types";
+import ChunkPrefetchIterator from "../loaders/zarr_utils/ChunkPrefetchIterator";
+
+const EXPECTED_3X3X3X3 = [
+  [0, 0, 1, 1, 1], // T-
+  [2, 0, 1, 1, 1], // T+
+  [1, 0, 0, 1, 1], // Z-
+  [1, 0, 2, 1, 1], // Z+
+  [1, 0, 1, 0, 1], // Y-
+  [1, 0, 1, 2, 1], // Y+
+  [1, 0, 1, 1, 0], // X-
+  [1, 0, 1, 1, 2], // X+
+];
+
+const EXPECTED_5X5X5X5 = [
+  [1, 0, 2, 2, 2], // T-
+  [3, 0, 2, 2, 2], // T+
+  [2, 0, 1, 2, 2], // Z-
+  [2, 0, 3, 2, 2], // Z+
+  [2, 0, 2, 1, 2], // Y-
+  [2, 0, 2, 3, 2], // Y+
+  [2, 0, 2, 2, 1], // X-
+  [2, 0, 2, 2, 3], // X+
+];
+
+function validate(iter: ChunkPrefetchIterator, expected: number[][]) {
+  expect([...iter]).to.deep.equal(expected);
+}
+
+describe("ChunkPrefetchIterator", () => {
+  it("iterates outward in TZYX order, negative then positive", () => {
+    // 3x3x3x3, with one chunk in the center
+    const iterator = new ChunkPrefetchIterator([[1, 0, 1, 1, 1]], [1, 1, 1, 1], [3, 3, 3, 3]);
+    validate(iterator, EXPECTED_3X3X3X3);
+  });
+
+  it("finds the borders of a set of multiple chunks and iterates outward from them", () => {
+    // 4x4x4, with a 2x2x2 set of chunks in the center
+    const fetchedChunks: TCZYX<number>[] = [
+      [1, 0, 1, 1, 1],
+      [1, 0, 1, 1, 2],
+      [1, 0, 1, 2, 1],
+      [1, 0, 1, 2, 2],
+      [1, 0, 2, 1, 1],
+      [1, 0, 2, 1, 2],
+      [1, 0, 2, 2, 1],
+      [1, 0, 2, 2, 2],
+    ];
+    const iterator = new ChunkPrefetchIterator(fetchedChunks, [1, 1, 1, 1], [3, 4, 4, 4]);
+
+    const expected = [
+      ...fetchedChunks.map(([_t, c, z, y, x]) => [0, c, z, y, x]), // T-
+      ...fetchedChunks.map(([_t, c, z, y, x]) => [2, c, z, y, x]), // T+
+      ...fetchedChunks.filter(([_t, _c, z, _y, _x]) => z === 1).map(([t, c, _z, y, x]) => [t, c, 0, y, x]), // Z-
+      ...fetchedChunks.filter(([_t, _c, z, _y, _x]) => z === 2).map(([t, c, _z, y, x]) => [t, c, 3, y, x]), // Z+
+      ...fetchedChunks.filter(([_t, _c, _z, y, _x]) => y === 1).map(([t, c, z, _y, x]) => [t, c, z, 0, x]), // Y-
+      ...fetchedChunks.filter(([_t, _c, _z, y, _x]) => y === 2).map(([t, c, z, _y, x]) => [t, c, z, 3, x]), // Y+
+      ...fetchedChunks.filter(([_t, _c, _z, _y, x]) => x === 1).map(([t, c, z, y, _x]) => [t, c, z, y, 0]), // X-
+      ...fetchedChunks.filter(([_t, _c, _z, _y, x]) => x === 2).map(([t, c, z, y, _x]) => [t, c, z, y, 3]), // X+
+    ];
+    validate(iterator, expected);
+  });
+
+  it("iterates through the same offset in all dimensions before increasing the offset", () => {
+    // 5x5x5, with one chunk in the center
+    const iterator = new ChunkPrefetchIterator([[2, 0, 2, 2, 2]], [2, 2, 2, 2], [5, 5, 5, 5]);
+
+    const expected = [
+      // offset = 1
+      ...EXPECTED_5X5X5X5,
+      // offset = 2!
+      [0, 0, 2, 2, 2], // T--
+      [4, 0, 2, 2, 2], // T++
+      [2, 0, 0, 2, 2], // Z--
+      [2, 0, 4, 2, 2], // Z++
+      [2, 0, 2, 0, 2], // Y--
+      [2, 0, 2, 4, 2], // Y++
+      [2, 0, 2, 2, 0], // X--
+      [2, 0, 2, 2, 4], // X++
+    ];
+    validate(iterator, expected);
+  });
+
+  it("stops at the max offset in each dimension", () => {
+    // 5x5x5, with one chunk in the center
+    const iterator = new ChunkPrefetchIterator([[2, 0, 2, 2, 2]], [1, 1, 1, 1], [5, 5, 5, 5]);
+    validate(iterator, EXPECTED_5X5X5X5);
+  });
+
+  it("stops at the borders of the zarr", () => {
+    // 3x3x3x3, with one chunk in the center
+    const iterator = new ChunkPrefetchIterator([[1, 0, 1, 1, 1]], [2, 2, 2, 2], [3, 3, 3, 3]);
+    validate(iterator, EXPECTED_3X3X3X3);
+  });
+
+  it("does not iterate in dimensions which are entirely covered by the fetched set", () => {
+    // 3x3x3x3, with a 1x1x3x3 slice covering all of x and y
+    const fetchedChunks: TCZYX<number>[] = [
+      [1, 0, 1, 0, 0], // 0, 0
+      [1, 0, 1, 0, 1], // 0, 1
+      [1, 0, 1, 0, 2], // 0, 2
+      [1, 0, 1, 1, 0], // 1, 0
+      [1, 0, 1, 1, 1], // 1, 1
+      [1, 0, 1, 1, 2], // 1, 2
+      [1, 0, 1, 2, 0], // 2, 0
+      [1, 0, 1, 2, 1], // 2, 1
+      [1, 0, 1, 2, 2], // 2, 2
+    ];
+    const iterator = new ChunkPrefetchIterator(fetchedChunks, [1, 1, 1, 1], [3, 3, 3, 3]);
+
+    const expected = [
+      ...fetchedChunks.map(([_t, c, z, y, x]) => [0, c, z, y, x]), // T-
+      ...fetchedChunks.map(([_t, c, z, y, x]) => [2, c, z, y, x]), // T+
+      ...fetchedChunks.map(([t, c, _z, y, x]) => [t, c, 0, y, x]), // Z-
+      ...fetchedChunks.map(([t, c, _z, y, x]) => [t, c, 2, y, x]), // Z+
+      // skips x and y
+    ];
+    validate(iterator, expected);
+  });
+
+  it("does not iterate in dimensions where the max offset is 0", () => {
+    // 3x3x3x3, with one chunk in the center
+    const iterator = new ChunkPrefetchIterator([[1, 0, 1, 1, 1]], [1, 0, 1, 0], [3, 3, 3, 3]);
+
+    const expected = [
+      [0, 0, 1, 1, 1], // T-
+      [2, 0, 1, 1, 1], // T+
+      // skips z
+      [1, 0, 1, 0, 1], // Y-
+      [1, 0, 1, 2, 1], // Y+
+      // skips x
+    ];
+    validate(iterator, expected);
+  });
+
+  it("continues iterating in other dimensions when some reach their limits", () => {
+    // final boss: 4x4x6 volume with off-center fetched set
+    // t has a max offset of 2, but is already at its maximum of 2 and never iterates in positive direction
+    // z has a max offset of 2, but stops early in negative direction at 0
+    // y has a max offset of 2, but is already covered in the negative direction by chunks in the fetched set
+    // x has a max offset of 1, which stops iteration before it gets to either edge
+    const fetchedChunks: TCZYX<number>[] = [
+      [2, 0, 1, 0, 2],
+      [2, 0, 1, 0, 3],
+      [2, 0, 1, 1, 2],
+      [2, 0, 1, 1, 3],
+    ];
+    const iterator = new ChunkPrefetchIterator(fetchedChunks, [2, 2, 2, 1], [3, 4, 4, 6]);
+
+    // prettier-ignore
+    const expected = [
+      ...fetchedChunks.map(([_t, c, z, y, x]) => [1, c, z, y, x]), // T-
+      // skip t+: already at max t
+      ...fetchedChunks.map(([t, c, _z, y, x]) => [t, c, 0, y, x]), // Z-
+      ...fetchedChunks.map(([t, c, _z, y, x]) => [t, c, 2, y, x]), // Z+
+      // skip y-: already covered by fetched chunks
+      [2, 0, 1, 2, 2], [2, 0, 1, 2, 3], // Y+
+      [2, 0, 1, 0, 1], [2, 0, 1, 1, 1], // X-
+      [2, 0, 1, 0, 4], [2, 0, 1, 1, 4], // X+
+      ...fetchedChunks.map(([_t, c, z, y, x]) => [0, c, z, y, x]), // T--
+      // skip t++: still at max t
+      // skip z--: already reached z = 0 above
+      ...fetchedChunks.map(([t, c, _z, y, x]) => [t, c, 3, y, x]), // Z++
+      // skip y-: still already covered by fetched chunks
+      [2, 0, 1, 3, 2], [2, 0, 1, 3, 3], // Y+
+      // skip x: already at max offset in x
+    ];
+    validate(iterator, expected);
+  });
+});

--- a/src/test/ChunkPrefetchIterator.test.ts
+++ b/src/test/ChunkPrefetchIterator.test.ts
@@ -14,16 +14,8 @@ const EXPECTED_3X3X3X3 = [
   [1, 0, 1, 1, 2], // X+
 ];
 
-const EXPECTED_5X5X5X5 = [
-  [1, 0, 2, 2, 2], // T-
-  [3, 0, 2, 2, 2], // T+
-  [2, 0, 1, 2, 2], // Z-
-  [2, 0, 3, 2, 2], // Z+
-  [2, 0, 2, 1, 2], // Y-
-  [2, 0, 2, 3, 2], // Y+
-  [2, 0, 2, 2, 1], // X-
-  [2, 0, 2, 2, 3], // X+
-];
+// move from the middle of a 3x3x3x3 cube to the middle of a 5x5x5x5 cube
+const EXPECTED_5X5X5X5 = EXPECTED_3X3X3X3.map(([t, c, z, y, x]) => [t + 1, c, z + 1, y + 1, x + 1]);
 
 function validate(iter: ChunkPrefetchIterator, expected: number[][]) {
   expect([...iter]).to.deep.equal(expected);

--- a/src/test/ChunkPrefetchIterator.test.ts
+++ b/src/test/ChunkPrefetchIterator.test.ts
@@ -86,7 +86,7 @@ describe("ChunkPrefetchIterator", () => {
   it("stops at the max offset in each dimension", () => {
     // 5x5x5, with one chunk in the center
     const iterator = new ChunkPrefetchIterator([[2, 0, 2, 2, 2]], [1, 1, 1, 1], [5, 5, 5, 5]);
-    validate(iterator, EXPECTED_5X5X5X5);
+    validate(iterator, EXPECTED_5X5X5X5); // never reaches offset = 2, as it does above
   });
 
   it("stops at the borders of the zarr", () => {

--- a/src/test/RequestQueue.test.ts
+++ b/src/test/RequestQueue.test.ts
@@ -50,7 +50,7 @@ describe("test RequestQueue", () => {
       const startTime = Date.now();
       const delayMs = 15;
       const immediatePromise = rq.addRequest("a", () => Promise.resolve());
-      const delayedPromise = rq.addRequest("b", () => Promise.resolve(), delayMs);
+      const delayedPromise = rq.addRequest("b", () => Promise.resolve(), false, delayMs);
 
       const promises: Promise<unknown>[] = [];
       promises.push(
@@ -218,7 +218,7 @@ describe("test RequestQueue", () => {
         { key: "b", requestAction: work },
       ];
       const start = Date.now();
-      const promises = rq.addRequests(requests, delayMs);
+      const promises = rq.addRequests(requests, false, delayMs);
       rq.addRequest("b", work); // requesting this again should remove the delay
       await Promise.allSettled(promises);
       expect(Date.now() - start).to.be.lessThan(delayMs);
@@ -284,7 +284,7 @@ describe("test RequestQueue", () => {
         workCount++;
         return;
       };
-      const promise = rq.addRequest("a", work, delayMs);
+      const promise = rq.addRequest("a", work, false, delayMs);
       rq.cancelRequest("a");
       await Promise.allSettled([promise]);
       await sleep(delayMs);
@@ -299,7 +299,7 @@ describe("test RequestQueue", () => {
       };
       const promises: Promise<unknown>[] = [];
       for (let i = 0; i < 10; i++) {
-        promises.push(rq.addRequest(`${i}`, work, 0));
+        promises.push(rq.addRequest(`${i}`, work, false, 0));
         rq.cancelRequest(`${i}`);
       }
       await Promise.allSettled(promises);

--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -47,7 +47,7 @@ describe("SubscribableRequestQueue", () => {
     it("queues a request", async () => {
       const queue = new SubscribableRequestQueue();
       const id = queue.addSubscriber();
-      const promise = queue.addRequestToQueue("test", id, () => delay(TIMEOUT, "foo"));
+      const promise = queue.addRequest("test", id, () => delay(TIMEOUT, "foo"));
       expect(queue.hasRequest("test")).to.be.true;
       const result = await promise;
       expect(result).to.equal("foo");
@@ -55,15 +55,15 @@ describe("SubscribableRequestQueue", () => {
 
     it("does not queue a request if the subscriber id is invalid", () => {
       const queue = new SubscribableRequestQueue();
-      expect(() => queue.addRequestToQueue("test", -1, () => delay(TIMEOUT, "foo"))).to.throw();
-      expect(() => queue.addRequestToQueue("test", 0, () => delay(TIMEOUT, "foo"))).to.throw();
+      expect(() => queue.addRequest("test", -1, () => delay(TIMEOUT, "foo"))).to.throw();
+      expect(() => queue.addRequest("test", 0, () => delay(TIMEOUT, "foo"))).to.throw();
     });
 
     it("does not queue a request if the subscriber has been deleted", () => {
       const queue = new SubscribableRequestQueue();
       const id = queue.addSubscriber();
       queue.removeSubscriber(id);
-      expect(() => queue.addRequestToQueue("test", id, () => delay(TIMEOUT, "foo"))).to.throw();
+      expect(() => queue.addRequest("test", id, () => delay(TIMEOUT, "foo"))).to.throw();
     });
 
     it("creates unique promises without duplicating work when two subscribers queue the same key", async () => {
@@ -71,8 +71,8 @@ describe("SubscribableRequestQueue", () => {
       const id1 = queue.addSubscriber();
       const id2 = queue.addSubscriber();
 
-      const promise1 = queue.addRequestToQueue("test", id1, () => delay(TIMEOUT, "foo"));
-      const promise2 = queue.addRequestToQueue("test", id2, () => delay(TIMEOUT, "bar"));
+      const promise1 = queue.addRequest("test", id1, () => delay(TIMEOUT, "foo"));
+      const promise2 = queue.addRequest("test", id2, () => delay(TIMEOUT, "bar"));
       expect(queue.hasRequest("test")).to.be.true;
       expect(promise1).to.not.equal(promise2);
 
@@ -85,8 +85,8 @@ describe("SubscribableRequestQueue", () => {
       const queue = new SubscribableRequestQueue();
       const id = queue.addSubscriber();
 
-      const promise1 = queue.addRequestToQueue("test1", id, () => delay(TIMEOUT, "foo"));
-      const promise2 = queue.addRequestToQueue("test2", id, () => delay(TIMEOUT, "bar"));
+      const promise1 = queue.addRequest("test1", id, () => delay(TIMEOUT, "foo"));
+      const promise2 = queue.addRequest("test2", id, () => delay(TIMEOUT, "bar"));
       expect(queue.hasRequest("test1")).to.be.true;
       expect(queue.hasRequest("test2")).to.be.true;
       expect(promise1).to.not.equal(promise2);
@@ -100,8 +100,8 @@ describe("SubscribableRequestQueue", () => {
       const queue = new SubscribableRequestQueue();
       const id = queue.addSubscriber();
 
-      const promise1 = queue.addRequestToQueue("test", id, () => delay(TIMEOUT, "foo"));
-      const promise2 = queue.addRequestToQueue("test", id, () => delay(TIMEOUT, "bar"));
+      const promise1 = queue.addRequest("test", id, () => delay(TIMEOUT, "foo"));
+      const promise2 = queue.addRequest("test", id, () => delay(TIMEOUT, "bar"));
       expect(queue.hasRequest("test")).to.be.true;
       expect(await isRejected(promise1)).to.be.true;
 
@@ -114,8 +114,8 @@ describe("SubscribableRequestQueue", () => {
       const id1 = queue.addSubscriber();
       const id2 = queue.addSubscriber();
 
-      const promise1 = queue.addRequestToQueue("test", id1, () => delayReject(TIMEOUT, "foo"));
-      const promise2 = queue.addRequestToQueue("test", id2, () => delay(TIMEOUT, "bar"));
+      const promise1 = queue.addRequest("test", id1, () => delayReject(TIMEOUT, "foo"));
+      const promise2 = queue.addRequest("test", id2, () => delay(TIMEOUT, "bar"));
       expect(queue.hasRequest("test")).to.be.true;
       let promise1RejectReason = "",
         promise2RejectReason = "";
@@ -131,8 +131,8 @@ describe("SubscribableRequestQueue", () => {
       const queue = new SubscribableRequestQueue(1);
       const id = queue.addSubscriber();
 
-      const promise1 = queue.addRequestToQueue("test1", id, () => delay(TIMEOUT, "foo"));
-      const promise2 = queue.addRequestToQueue("test2", id, () => delay(LONG_TIMEOUT, "bar"));
+      const promise1 = queue.addRequest("test1", id, () => delay(TIMEOUT, "foo"));
+      const promise2 = queue.addRequest("test2", id, () => delay(LONG_TIMEOUT, "bar"));
       expect(queue.hasRequest("test1")).to.be.true;
       expect(queue.hasRequest("test2")).to.be.true;
       expect(queue.requestRunning("test1")).to.be.true;
@@ -154,7 +154,7 @@ describe("SubscribableRequestQueue", () => {
     it("cancels a request subscription", async () => {
       const queue = new SubscribableRequestQueue();
       const id = queue.addSubscriber();
-      const promise = queue.addRequestToQueue("test", id, () => delay(TIMEOUT, "foo"));
+      const promise = queue.addRequest("test", id, () => delay(TIMEOUT, "foo"));
       expect(queue.hasRequest("test")).to.be.true;
       expect(queue.isSubscribed(id, "test")).to.be.true;
 
@@ -168,7 +168,7 @@ describe("SubscribableRequestQueue", () => {
       const id1 = queue.addSubscriber();
       const id2 = queue.addSubscriber();
 
-      const promise1 = queue.addRequestToQueue("test", id1, () => delay(TIMEOUT, "foo"));
+      const promise1 = queue.addRequest("test", id1, () => delay(TIMEOUT, "foo"));
       expect(queue.hasRequest("test")).to.be.true;
       expect(queue.requestRunning("test")).to.be.true;
       expect(queue.isSubscribed(id1, "test")).to.be.true;
@@ -179,7 +179,7 @@ describe("SubscribableRequestQueue", () => {
       expect(queue.isSubscribed(id1, "test")).to.be.false;
       expect(await isRejected(promise1)).to.be.true;
 
-      const promise2 = queue.addRequestToQueue("test", id2, () => delay(TIMEOUT, "bar"));
+      const promise2 = queue.addRequest("test", id2, () => delay(TIMEOUT, "bar"));
       expect(queue.isSubscribed(id2, "test")).to.be.true;
       const result = await promise2;
       expect(result).to.equal("foo");
@@ -190,10 +190,10 @@ describe("SubscribableRequestQueue", () => {
       const id1 = queue.addSubscriber();
       const id2 = queue.addSubscriber();
       // `block` keeps the queue full, to keep `test` from running
-      const block = queue.addRequestToQueue("block", id1, () => delay(TIMEOUT, undefined));
+      const block = queue.addRequest("block", id1, () => delay(TIMEOUT, undefined));
 
-      const promise1 = queue.addRequestToQueue("test", id1, () => delay(LONG_TIMEOUT, "foo"));
-      const promise2 = queue.addRequestToQueue("test", id2, () => delay(LONG_TIMEOUT, "bar"));
+      const promise1 = queue.addRequest("test", id1, () => delay(LONG_TIMEOUT, "foo"));
+      const promise2 = queue.addRequest("test", id2, () => delay(LONG_TIMEOUT, "bar"));
       expect(queue.hasRequest("test")).to.be.true;
       expect(queue.requestRunning("test")).to.be.false;
       expect(queue.isSubscribed(id1, "test")).to.be.true;
@@ -215,9 +215,9 @@ describe("SubscribableRequestQueue", () => {
       const queue = new SubscribableRequestQueue(1);
       const id = queue.addSubscriber();
       // `block` keeps the queue full, to keep `test` from running
-      queue.addRequestToQueue("block", id, () => delay(TIMEOUT, undefined));
+      queue.addRequest("block", id, () => delay(TIMEOUT, undefined));
 
-      const promise = queue.addRequestToQueue("test", id, () => delay(LONG_TIMEOUT, "foo"));
+      const promise = queue.addRequest("test", id, () => delay(LONG_TIMEOUT, "foo"));
       expect(queue.hasRequest("test")).to.be.true;
       expect(queue.requestRunning("test")).to.be.false;
       expect(queue.isSubscribed(id, "test")).to.be.true;
@@ -243,9 +243,9 @@ describe("SubscribableRequestQueue", () => {
       const id1 = queue.addSubscriber();
       const id2 = queue.addSubscriber();
 
-      const promise1 = queue.addRequestToQueue("test", id1, () => delay(TIMEOUT, "foo"));
-      const promise2 = queue.addRequestToQueue("test2", id1, () => delay(TIMEOUT, "bar"));
-      const promise3 = queue.addRequestToQueue("test", id2, () => delay(TIMEOUT, "foo"));
+      const promise1 = queue.addRequest("test", id1, () => delay(TIMEOUT, "foo"));
+      const promise2 = queue.addRequest("test2", id1, () => delay(TIMEOUT, "bar"));
+      const promise3 = queue.addRequest("test", id2, () => delay(TIMEOUT, "foo"));
       expect(queue.hasRequest("test")).to.be.true;
       expect(queue.isSubscribed(id1, "test")).to.be.true;
       expect(queue.isSubscribed(id2, "test")).to.be.true;

--- a/src/utils/RequestQueue.ts
+++ b/src/utils/RequestQueue.ts
@@ -37,8 +37,9 @@ export default class RequestQueue {
   private maxActiveRequests: number;
 
   /**
-   * The maximum number of requests that can be handled concurrently for low-priority requests to be queued. Equal to
-   * `maxActiveRequests` by default, but may be set lower to ensure the queue leaves space for high-priority requests.
+   * The maximum number of requests that can be handled concurrently if only low-priority requests are waiting. Set
+   * lower than `concurrencyLimit` to always leave space for high-priority requests. Cannot be set higher than
+   * `concurrencyLimit`.
    */
   private maxLowPriorityRequests: number;
 
@@ -60,7 +61,7 @@ export default class RequestQueue {
    * @param maxLowPriorityRequests The maximum number of low-priority requests that will be handled concurrently. Equal
    *    to `maxActiveRequests` by default, but may be set lower to always leave space for new high-priority requests.
    */
-  constructor(maxActiveRequests = 10, maxLowPriorityRequests = maxActiveRequests) {
+  constructor(maxActiveRequests = 10, maxLowPriorityRequests = 5) {
     this.allRequests = new Map();
     this.activeRequests = new Set();
     this.queue = [];

--- a/src/utils/RequestQueue.ts
+++ b/src/utils/RequestQueue.ts
@@ -30,12 +30,23 @@ interface RequestItem<V> {
  * while the original request is still in the queue.
  */
 export default class RequestQueue {
-  /** The maximum number of requests that can be handled concurently.
-    Once reached, additional requests will be queued up to run once a running request completes.*/
+  /**
+   * The maximum number of requests that can be handled concurently.
+   * Once reached, additional requests will be queued up to run once a running request completes.
+   */
   private maxActiveRequests: number;
+
+  /**
+   * The maximum number of requests that can be handled concurrently for low-priority requests to be queued. Equal to
+   * `maxActiveRequests` by default, but may be set lower to ensure the queue leaves space for high-priority requests.
+   */
+  private maxLowPriorityRequests: number;
 
   /** A queue of requests that are ready to be executed, in order of request time. */
   private queue: string[];
+
+  /** A queue of low-priority tasks that are ready to be executed. `queue` must be empty before any of these tasks run. */
+  private queueLowPriority: string[];
 
   /** Stores all requests, even those that are currently active. */
   private allRequests: Map<string, RequestItem<unknown>>;
@@ -46,12 +57,16 @@ export default class RequestQueue {
   /**
    * Creates a new RequestQueue.
    * @param maxActiveRequests The maximum number of requests that will be handled concurrently. This is 10 by default.
+   * @param maxLowPriorityRequests The maximum number of low-priority requests that will be handled concurrently. Equal
+   *    to `maxActiveRequests` by default, but may be set lower to always leave space for new high-priority requests.
    */
-  constructor(maxActiveRequests = 10) {
+  constructor(maxActiveRequests = 10, maxLowPriorityRequests = maxActiveRequests) {
     this.allRequests = new Map();
     this.activeRequests = new Set();
     this.queue = [];
+    this.queueLowPriority = [];
     this.maxActiveRequests = maxActiveRequests;
+    this.maxLowPriorityRequests = Math.min(maxActiveRequests, maxLowPriorityRequests);
   }
 
   /**
@@ -84,8 +99,9 @@ export default class RequestQueue {
   /**
    * Moves a registered request into the processing queue, clearing any timeouts on the request.
    * @param key string identifier of the request.
+   * @param lowPriority Whether this request should be added with low priority. False by default.
    */
-  private addRequestToQueue(key: string): void {
+  private addRequestToQueue(key: string, lowPriority?: boolean): void {
     // Check that this request is not cancelled.
     if (this.allRequests.has(key)) {
       // Clear the request timeout, if it has one, since it is being added to the queue.
@@ -94,9 +110,13 @@ export default class RequestQueue {
         clearTimeout(requestItem.timeoutId);
         requestItem.timeoutId = undefined;
       }
-      if (!this.queue.includes(key)) {
+      if (!this.queue.includes(key) && !this.queueLowPriority.includes(key)) {
         // Add to queue and check if the request can be processed right away.
-        this.queue.push(key);
+        if (lowPriority) {
+          this.queueLowPriority.push(key);
+        } else {
+          this.queue.push(key);
+        }
         this.dequeue();
       }
     }
@@ -108,6 +128,7 @@ export default class RequestQueue {
    * @param requestAction Function that will be called to complete the request. The function
    *  will be run only once per unique key while the request exists, and may be deferred by the
    *  queue at any time.
+   * @param lowPriority Whether this request should be added with low priority. False by default.
    * @param delayMs Minimum delay, in milliseconds, before this request should be executed.
    *
    * NOTE: Cancelling a request while the action is running WILL NOT stop the action. If this behavior is desired,
@@ -119,23 +140,31 @@ export default class RequestQueue {
    *  until the request is resolved or cancelled.
    *  Note that the return type of the promise will match that of the first request's instance.
    */
-  public addRequest<T>(key: string, requestAction: () => Promise<T>, delayMs = 0): Promise<T> {
+  public addRequest<T>(key: string, requestAction: () => Promise<T>, lowPriority = false, delayMs = 0): Promise<T> {
     if (!this.allRequests.has(key)) {
       // New request!
       const requestItem = this.registerRequest(key, requestAction);
       // If a delay is set, wait to add this to the queue.
       if (delayMs > 0) {
-        const timeoutId = setTimeout(() => this.addRequestToQueue(key), delayMs);
+        const timeoutId = setTimeout(() => this.addRequestToQueue(key, lowPriority), delayMs);
         // Save timeout information to request metadata
         requestItem.timeoutId = timeoutId;
       } else {
         // No delay, add immediately
-        this.addRequestToQueue(key);
+        this.addRequestToQueue(key, lowPriority);
       }
-    } else if (delayMs <= 0) {
-      // This request is registered, but is now being requested without a delay.
-      // Move into queue immediately if it's not already added, and clear any timeouts it may have.
-      this.addRequestToQueue(key);
+    } else {
+      const lowPriorityIndex = this.queueLowPriority.indexOf(key);
+      if (lowPriorityIndex > -1 && !lowPriority) {
+        // This request is registered and queued, but is now being requested with high priority.
+        // Promote it to high priority.
+        this.queueLowPriority.splice(lowPriorityIndex, 1);
+        this.addRequestToQueue(key);
+      } else if (delayMs <= 0) {
+        // This request is registered, but is now being requested without a delay.
+        // Move into queue immediately if it's not already added, and clear any timeouts it may have.
+        this.addRequestToQueue(key, lowPriority);
+      }
     }
 
     const promise = this.allRequests.get(key)?.promise;
@@ -148,6 +177,7 @@ export default class RequestQueue {
   /**
    * Adds multiple requests to the queue, with an optional delay between each.
    * @param requests An array of RequestItems, which include a key and a request action.
+   * @param lowPriority Whether these requests should be added with low priority. False by default.
    * @param delayMs An optional minimum delay in milliseconds to be added between each request.
    *  For example, a delay of 10 ms will cause the second request to be added to the processing queue
    *  after 10 ms, the third to added after 20 ms, and so on. Set to 10 ms by default.
@@ -155,11 +185,11 @@ export default class RequestQueue {
    * of the returned array will be a Promise for the resolution of `requests[i]`). If a request
    *  with a matching key is already pending, returns the promise for the initial request.
    */
-  public addRequests<T>(requests: Request<T>[], delayMs = 10): Promise<unknown>[] {
+  public addRequests<T>(requests: Request<T>[], lowPriority = false, delayMs = 10): Promise<unknown>[] {
     const promises: Promise<unknown>[] = [];
     for (let i = 0; i < requests.length; i++) {
       const item = requests[i];
-      const promise = this.addRequest(item.key, item.requestAction, delayMs * i);
+      const promise = this.addRequest(item.key, item.requestAction, lowPriority, delayMs * i);
       promises.push(promise);
     }
     return promises;
@@ -171,10 +201,15 @@ export default class RequestQueue {
    * requests already active.
    */
   private async dequeue(): Promise<void> {
-    if (this.activeRequests.size >= this.maxActiveRequests || this.queue.length === 0) {
+    const numRequests = this.activeRequests.size;
+    if (
+      numRequests >= this.maxActiveRequests ||
+      (this.queue.length === 0 && (numRequests >= this.maxLowPriorityRequests || this.queueLowPriority.length === 0))
+    ) {
       return;
     }
-    const requestKey = this.queue.shift();
+
+    const requestKey = this.queue.shift() ?? this.queueLowPriority.shift();
     if (!requestKey) {
       return;
     }
@@ -217,7 +252,15 @@ export default class RequestQueue {
       // Reject the request, then clear from the queue and known requests.
       requestItem.reject(cancelReason);
     }
-    this.queue = this.queue.filter((k) => key !== k);
+    const queueIndex = this.queue.indexOf(key);
+    if (queueIndex > -1) {
+      this.queue.splice(queueIndex, 1);
+    } else {
+      const lowPriorityIndex = this.queueLowPriority.indexOf(key);
+      if (lowPriorityIndex > -1) {
+        this.queueLowPriority.splice(lowPriorityIndex, 1);
+      }
+    }
     this.allRequests.delete(key);
     this.activeRequests.delete(key);
   }
@@ -227,7 +270,9 @@ export default class RequestQueue {
    * @param cancelReason A message or object that will be used as the promise rejection.
    */
   public cancelAllRequests(cancelReason: unknown = DEFAULT_REQUEST_CANCEL_REASON): void {
-    this.queue = []; // Clear the queue so we don't do extra work while filtering it
+    // Clear the queue so we don't do extra work while filtering it
+    this.queue = [];
+    this.queueLowPriority = [];
     for (const key of this.allRequests.keys()) {
       this.cancelRequest(key, cancelReason);
     }

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -30,10 +30,10 @@ export default class SubscribableRequestQueue {
   constructor(maxActiveRequests?: number, maxLowPriorityRequests?: number);
   constructor(inner: RequestQueue);
   constructor(maxActiveRequests?: number | RequestQueue, maxLowPriorityRequests?: number) {
-    if (typeof maxActiveRequests === "object" && maxActiveRequests !== undefined) {
-      this.queue = maxActiveRequests;
-    } else {
+    if (typeof maxActiveRequests === "number" || maxActiveRequests === undefined) {
       this.queue = new RequestQueue(maxActiveRequests, maxLowPriorityRequests);
+    } else {
+      this.queue = maxActiveRequests;
     }
     this.nextSubscriberId = 0;
     this.subscribers = new Map();

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -144,8 +144,8 @@ export default class SubscribableRequestQueue {
       for (const [key, reject] of subscriptions.entries()) {
         this.rejectSubscription(key, reject, cancelReason);
       }
+      this.subscribers.delete(subscriberId);
     }
-    this.subscribers.delete(subscriberId);
   }
 
   /** Returns whether a request with the given `key` is running or waiting in the queue */

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -63,7 +63,11 @@ export default class SubscribableRequestQueue {
     return subscriberId;
   }
 
-  /** Queues a new request, or adds a subscription if the request is already queued/running. */
+  /**
+   * Queues a new request, or adds a subscription if the request is already queued/running.
+   *
+   * If `subscriberId` is already subscribed to the request, this rejects the existing promise and returns a new one.
+   */
   addRequestToQueue<T>(
     key: string,
     subscriberId: number,

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -68,12 +68,7 @@ export default class SubscribableRequestQueue {
    *
    * If `subscriberId` is already subscribed to the request, this rejects the existing promise and returns a new one.
    */
-  addRequestToQueue<T>(
-    key: string,
-    subscriberId: number,
-    requestAction: () => Promise<T>,
-    delayMs?: number
-  ): Promise<T> {
+  addRequest<T>(key: string, subscriberId: number, requestAction: () => Promise<T>, delayMs?: number): Promise<T> {
     // Create single underlying request if it does not yet exist
     if (!this.queue.hasRequest(key)) {
       this.queue

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -27,6 +27,10 @@ export default class SubscribableRequestQueue {
   /** Map from "inner" request (managed by `queue`) to "outer" promises generated per-subscriber. */
   private requests: Map<string, RequestSubscription[]>;
 
+  /**
+   * Since `SubscribableRequestQueue` wraps `RequestQueue`, its constructor may either take the same arguments as the
+   * `RequestQueue` constructor and create a new `RequestQueue`, or it may take an existing `RequestQueue` to wrap.
+   */
   constructor(maxActiveRequests?: number, maxLowPriorityRequests?: number);
   constructor(inner: RequestQueue);
   constructor(maxActiveRequests?: number | RequestQueue, maxLowPriorityRequests?: number) {

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -27,8 +27,14 @@ export default class SubscribableRequestQueue {
   /** Map from "inner" request (managed by `queue`) to "outer" promises generated per-subscriber. */
   private requests: Map<string, RequestSubscription[]>;
 
-  constructor(maxActiveRequests?: number, maxLowPriorityRequests?: number) {
-    this.queue = new RequestQueue(maxActiveRequests, maxLowPriorityRequests);
+  constructor(maxActiveRequests?: number, maxLowPriorityRequests?: number);
+  constructor(inner: RequestQueue);
+  constructor(maxActiveRequests?: number | RequestQueue, maxLowPriorityRequests?: number) {
+    if (typeof maxActiveRequests === "object" && maxActiveRequests !== undefined) {
+      this.queue = maxActiveRequests;
+    } else {
+      this.queue = new RequestQueue(maxActiveRequests, maxLowPriorityRequests);
+    }
     this.nextSubscriberId = 0;
     this.subscribers = new Map();
     this.requests = new Map();


### PR DESCRIPTION
Adds configurable prefetching behavior to `OmeZarrLoader`. Should (at last!) resolve #126. I think I have this feature working pretty well now, but please pull it and try for yourself!

### How it works for users:

- When any zarr volume with a time series loads, the loader begins prefetching adjacent time steps. Moving to adjacent time steps gets faster because those steps may already have been requested and received.
- When the user switches to z-slice mode and the chunking of the volume affords loading a subset of the volume at higher resolution, the loader begins prefetching adjacent chunks in z. Moving to adjacent z-slices gets faster too.
- If both of the above are true, it does both at the same time!

### How it works for developers:

- `RequestQueue` now has two "lanes:" regular and low-priority.
  - The zarr loader uses the regular lane for normal loads and the low-priority lane for prefetches.
  - All regular requests must be started before any low-priority requests get to go.
  - The low-priority lane has its own concurrency limit, which may be set lower (but cannot be set higher!) than the limit for the regular lane. This allows the user to ensure that the queue always leaves some space open for new regular requests to begin immediately.
- `OmeZarrLoader` now properly uses `SubscribableRequestQueue`, which has new method arguments to use `RequestQueue`'s new priority features.
- `OmeZarrLoader` has two new options to configure prefetching behavior:
  - `maxPrefetchDistance` is a `Vector4` representing the maximum number of chunks to prefetch outwards in both directions of a given dimension. (X and Y are of course not currently used in practice, but they're still in there for just in case.) For instance, if a load requests chunks with z coords 3 and 4 and `maxPrefetchDistance.z` is 2, the loader will prefetch similar chunks with z coords 1, 2, 5, and 6. The `w` component is time.
  - `maxPrefetchChunks` is the max number of total prefetch requests that can be made after any load. The loader will always stop issuing prefetch requests at this number even if `maxPrefetchDistance` would allow loading more.

### Other changes:

- OmeZarrLoader.ts was getting long and cumbersome, and began with a growing string of items that made the actual beginning of the `OmeZarrLoader` class declaration hard to find. I moved some of these items into their own files in a new /zarr_utils subdirectory:
  - WrappedStore.ts for the object that lets us link into zarrita's low-level chunk request behavior.
  - types.ts for stray shared types and the big declaration of the OME-Zarr JSON metadata format.
- /zarr_utils also has one brand new item: `ChunkPrefetchIterator` encapsulates the somewhat complicated process of identifying which chunks can and should be prefetched and in what order.
- Did a bit of refactoring in `OmeZarrLoader` to make all of the above easier, notably adding a couple methods for convenient reshuffling of dimension-ordered arrays.