### PR TITLE
Feature/loader worker

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -9,7 +9,6 @@ import {
   JsonImageInfoLoader,
   View3d,
   Volume,
-  VolumeCache,
   VolumeMaker,
   Light,
   AREA_LIGHT,
@@ -17,7 +16,6 @@ import {
   RENDERMODE_RAYMARCH,
   SKY_LIGHT,
   VolumeFileFormat,
-  createVolumeLoader,
 } from "../src";
 // special loader really just for this demo app but lives with the other loaders
 import { OpenCellLoader } from "../src/loaders/OpenCellLoader";

--- a/public/index.ts
+++ b/public/index.ts
@@ -21,7 +21,7 @@ import {
 import { OpenCellLoader } from "../src/loaders/OpenCellLoader";
 import { State, TestDataSpec } from "./types";
 import { getDefaultImageInfo } from "../src/Volume";
-import LoadWorker from "../src/workers/LoadWorkerHandle";
+import VolumeLoaderContext from "../src/workers/LoadWorkerHandle";
 
 const CACHE_MAX_SIZE = 1_000_000_000;
 const CONCURRENCY_LIMIT = 8;
@@ -86,7 +86,7 @@ const TEST_DATA: Record<string, TestDataSpec> = {
 
 let view3D: View3d;
 
-const loadWorker = new LoadWorker(CACHE_MAX_SIZE, CONCURRENCY_LIMIT, PREFETCH_CONCURRENCY_LIMIT);
+const loadWorker = new VolumeLoaderContext(CACHE_MAX_SIZE, CONCURRENCY_LIMIT, PREFETCH_CONCURRENCY_LIMIT);
 
 const myState: State = {
   file: "",

--- a/public/index.ts
+++ b/public/index.ts
@@ -1,5 +1,5 @@
 import "regenerator-runtime/runtime";
-import { Vector2, Vector3, Vector4 } from "three";
+import { Vector2, Vector3 } from "three";
 import * as dat from "dat.gui";
 
 import {

--- a/public/index.ts
+++ b/public/index.ts
@@ -23,6 +23,7 @@ import {
 import { OpenCellLoader } from "../src/loaders/OpenCellLoader";
 import { State, TestDataSpec } from "./types";
 import { getDefaultImageInfo } from "../src/Volume";
+import LoadWorker from "../src/workers/LoadWorkerHandle";
 
 const CACHE_MAX_SIZE = 1_000_000_000;
 const PLAYBACK_INTERVAL = 80;
@@ -83,7 +84,8 @@ const TEST_DATA: Record<string, TestDataSpec> = {
 
 let view3D: View3d;
 
-const volumeCache = new VolumeCache(CACHE_MAX_SIZE);
+// const volumeCache = new VolumeCache(CACHE_MAX_SIZE);
+const loadWorker = new LoadWorker(CACHE_MAX_SIZE);
 
 const myState: State = {
   file: "",
@@ -1005,6 +1007,8 @@ function createTestVolume() {
 }
 
 async function createLoader(data: TestDataSpec): Promise<IVolumeLoader> {
+  await loadWorker.onOpen();
+  console.log(new Vector2(0, 1));
   if (data.type === "opencell") {
     return new OpenCellLoader();
   }
@@ -1018,7 +1022,7 @@ async function createLoader(data: TestDataSpec): Promise<IVolumeLoader> {
     }
   }
 
-  return await createVolumeLoader(path, { cache: volumeCache });
+  return await loadWorker.createLoader(path);
 }
 
 async function loadVolume(loadSpec: LoadSpec, loader: IVolumeLoader): Promise<void> {

--- a/public/index.ts
+++ b/public/index.ts
@@ -86,7 +86,7 @@ const TEST_DATA: Record<string, TestDataSpec> = {
 
 let view3D: View3d;
 
-const loadWorker = new VolumeLoaderContext(CACHE_MAX_SIZE, CONCURRENCY_LIMIT, PREFETCH_CONCURRENCY_LIMIT);
+const loaderContext = new VolumeLoaderContext(CACHE_MAX_SIZE, CONCURRENCY_LIMIT, PREFETCH_CONCURRENCY_LIMIT);
 
 const myState: State = {
   file: "",
@@ -1012,7 +1012,7 @@ async function createLoader(data: TestDataSpec): Promise<IVolumeLoader> {
     return new OpenCellLoader();
   }
 
-  await loadWorker.onOpen();
+  await loaderContext.onOpen();
 
   let path: string | string[] = data.url;
   if (data.type === VolumeFileFormat.JSON) {
@@ -1023,7 +1023,7 @@ async function createLoader(data: TestDataSpec): Promise<IVolumeLoader> {
     }
   }
 
-  return await loadWorker.createLoader(path, {
+  return await loaderContext.createLoader(path, {
     fetchOptions: { maxPrefetchDistance: PREFETCH_DISTANCE, maxPrefetchChunks: MAX_PREFETCH_CHUNKS },
   });
 }

--- a/public/index.ts
+++ b/public/index.ts
@@ -86,8 +86,7 @@ const TEST_DATA: Record<string, TestDataSpec> = {
 
 let view3D: View3d;
 
-// const volumeCache = new VolumeCache(CACHE_MAX_SIZE);
-const loadWorker = new LoadWorker(CACHE_MAX_SIZE);
+const loadWorker = new LoadWorker(CACHE_MAX_SIZE, CONCURRENCY_LIMIT, PREFETCH_CONCURRENCY_LIMIT);
 
 const myState: State = {
   file: "",
@@ -1010,7 +1009,6 @@ function createTestVolume() {
 
 async function createLoader(data: TestDataSpec): Promise<IVolumeLoader> {
   await loadWorker.onOpen();
-  console.log(new Vector2(0, 1));
   if (data.type === "opencell") {
     return new OpenCellLoader();
   }
@@ -1024,7 +1022,9 @@ async function createLoader(data: TestDataSpec): Promise<IVolumeLoader> {
     }
   }
 
-  return await loadWorker.createLoader(path);
+  return await loadWorker.createLoader(path, {
+    fetchOptions: { maxPrefetchDistance: PREFETCH_DISTANCE, maxPrefetchChunks: MAX_PREFETCH_CHUNKS },
+  });
 }
 
 async function loadVolume(loadSpec: LoadSpec, loader: IVolumeLoader): Promise<void> {

--- a/public/index.ts
+++ b/public/index.ts
@@ -1008,10 +1008,11 @@ function createTestVolume() {
 }
 
 async function createLoader(data: TestDataSpec): Promise<IVolumeLoader> {
-  await loadWorker.onOpen();
   if (data.type === "opencell") {
     return new OpenCellLoader();
   }
+
+  await loadWorker.onOpen();
 
   let path: string | string[] = data.url;
   if (data.type === VolumeFileFormat.JSON) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { LoadSpec } from "./loaders/IVolumeLoader";
 import { OMEZarrLoader } from "./loaders/OmeZarrLoader";
 import { JsonImageInfoLoader } from "./loaders/JsonImageInfoLoader";
 import { TiffLoader } from "./loaders/TiffLoader";
-import LoadWorker from "./workers/LoadWorkerHandle";
+import VolumeLoaderContext from "./workers/LoadWorkerHandle";
 
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light";
 
@@ -34,7 +34,7 @@ export {
   OMEZarrLoader,
   JsonImageInfoLoader,
   TiffLoader,
-  LoadWorker,
+  VolumeLoaderContext,
   VolumeFileFormat,
   createVolumeLoader,
   Channel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { LoadSpec } from "./loaders/IVolumeLoader";
 import { OMEZarrLoader } from "./loaders/OmeZarrLoader";
 import { JsonImageInfoLoader } from "./loaders/JsonImageInfoLoader";
 import { TiffLoader } from "./loaders/TiffLoader";
+import LoadWorker from "./workers/LoadWorkerHandle";
 
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light";
 
@@ -20,6 +21,7 @@ export type { ControlPoint, Lut } from "./Histogram";
 export type { CreateLoaderOptions } from "./loaders";
 export type { IVolumeLoader, PerChannelCallback } from "./loaders/IVolumeLoader";
 export type { ZarrLoaderFetchOptions } from "./loaders/OmeZarrLoader";
+export type { WorkerLoader } from "./workers/LoadWorkerHandle";
 export {
   Histogram,
   View3d,
@@ -32,6 +34,7 @@ export {
   OMEZarrLoader,
   JsonImageInfoLoader,
   TiffLoader,
+  LoadWorker,
   VolumeFileFormat,
   createVolumeLoader,
   Channel,

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -1,7 +1,7 @@
 import { Box3, Vector2, Vector3 } from "three";
 
 import { IVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
-import Volume, { ImageInfo } from "../Volume";
+import { ImageInfo } from "../Volume";
 import VolumeCache from "../VolumeCache";
 
 interface PackedChannelsImage {

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -199,12 +199,12 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
    *     "channels": [6, 7, 8]
    * }], mycallback);
    */
-  static async loadVolumeAtlasData(
+  static loadVolumeAtlasData(
     imageArray: PackedChannelsImage[],
     onData: RawChannelDataCallback,
     cache?: VolumeCache
-  ): Promise<void> {
-    const loadPromises = imageArray.map(async (image) => {
+  ): void {
+    imageArray.forEach(async (image) => {
       // Because the data is fetched such that one fetch returns a whole batch,
       // if any in batch is cached then they all should be. So if any in batch is NOT cached,
       // then we will have to do a batch request. This logic works both ways because it's all or nothing.
@@ -266,8 +266,6 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
         onData(chindex, channelsBits[ch], [bitmap.width, bitmap.height]);
       }
     });
-
-    await Promise.all(loadPromises);
   }
 }
 

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -232,7 +232,7 @@ class JsonImageInfoLoader extends IVolumeLoader {
       const bitmap = await createImageBitmap(blob);
 
       const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
-      const ctx = canvas.getContext("2d");
+      const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D | null;
       if (!ctx) {
         console.log("Error creating canvas 2d context for " + image.name);
         return;

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -1,6 +1,6 @@
 import { Box3, Vector2, Vector3 } from "three";
 
-import { IVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
+import { ThreadableVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
 import { ImageInfo } from "../Volume";
 import VolumeCache from "../VolumeCache";
 
@@ -91,7 +91,7 @@ const convertImageInfo = (json: JsonImageInfo): ImageInfo => ({
   userData: json.userData,
 });
 
-class JsonImageInfoLoader extends IVolumeLoader {
+class JsonImageInfoLoader extends ThreadableVolumeLoader {
   urls: string[];
   jsonInfo: (JsonImageInfo | undefined)[];
 

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -10,7 +10,7 @@ import { FetchStore } from "zarrita";
 import { ImageInfo } from "../Volume";
 import VolumeCache from "../VolumeCache";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
-import { IVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
+import { ThreadableVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
 import {
   composeSubregion,
   computePackedAtlasDims,
@@ -217,7 +217,7 @@ function convertChannel(channelData: zarr.TypedArray<zarr.NumberDataType>): Uint
 
 type NumericZarrArray = zarr.Array<zarr.NumberDataType, WrappedStore<RequestInit>>;
 
-class OMEZarrLoader extends IVolumeLoader {
+class OMEZarrLoader extends ThreadableVolumeLoader {
   /** Hold one optional subscriber ID per timestep, each defined iff a batch of prefetches is waiting for that frame */
   private prefetchSubscribers: (SubscriberId | undefined)[];
   /** The ID of the subscriber responsible for "actual loads" (non-prefetch requests) */

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -1,7 +1,7 @@
 import { Box3, Vector3 } from "three";
 
 import * as zarr from "@zarrita/core";
-import { get as zarrGet, slice, Slice } from "@zarrita/indexing";
+import { get as zarrGet, slice } from "@zarrita/indexing";
 import { AbsolutePath, AsyncReadable, Readable } from "@zarrita/storage";
 // Importing `FetchStore` from its home subpackage (@zarrita/storage) causes errors.
 // Getting it from the top-level package means we don't get its type. This is also a bug, but it's more acceptable.
@@ -9,7 +9,6 @@ import { FetchStore } from "zarrita";
 
 import Volume, { ImageInfo } from "../Volume";
 import VolumeCache from "../VolumeCache";
-import RequestQueue from "../utils/RequestQueue";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
 import { IVolumeLoader, LoadSpec, PerChannelCallback, VolumeDims } from "./IVolumeLoader";
 import {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -121,9 +121,6 @@ class WrappedStore<Opts, S extends Readable<Opts> = Readable<Opts>> implements A
     if (!this.cache || ZARR_EXTS.some((s) => key.endsWith(s))) {
       return this.baseStore.get(key, opts?.options);
     }
-    if (opts?.isPrefetch) {
-      console.log("prefetch: ", key);
-    }
     if (opts?.reportKey) {
       opts.reportKey(key, opts.subscriber);
     }

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -1,10 +1,10 @@
 import { Vector2, Vector3 } from "three";
 
-import { IVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
+import { ThreadableVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
 import { ImageInfo } from "../Volume";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader";
 
-class OpenCellLoader extends IVolumeLoader {
+class OpenCellLoader extends ThreadableVolumeLoader {
   async loadDims(_: LoadSpec): Promise<VolumeDims[]> {
     const d = new VolumeDims();
     d.shape = [1, 2, 27, 600, 600];

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -1,6 +1,12 @@
 import { Vector2, Vector3 } from "three";
 
-import { ThreadableVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
+import {
+  ThreadableVolumeLoader,
+  LoadSpec,
+  RawChannelDataCallback,
+  VolumeDims,
+  LoadedVolumeInfo,
+} from "./IVolumeLoader";
 import { ImageInfo } from "../Volume";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader";
 
@@ -14,7 +20,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     return [d];
   }
 
-  async createImageInfo(_loadSpec: LoadSpec): Promise<[ImageInfo, LoadSpec]> {
+  async createImageInfo(_loadSpec: LoadSpec): Promise<LoadedVolumeInfo> {
     const numChannels = 2;
 
     // we know these are standardized to 600x600, two channels, one channel per jpg.
@@ -48,14 +54,14 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     };
 
     // This loader uses no fields from `LoadSpec`. Initialize volume with defaults.
-    return [imgdata, new LoadSpec()];
+    return { imageInfo: imgdata, loadSpec: new LoadSpec() };
   }
 
   loadRawChannelData(
     imageInfo: ImageInfo,
     _loadSpec: LoadSpec,
     onData: RawChannelDataCallback
-  ): Promise<[undefined, undefined]> {
+  ): Promise<Record<string, never>> {
     // HQTILE or LQTILE
     // make a json metadata dict for the two channels:
     const urls = [
@@ -72,7 +78,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     const w = imageInfo.atlasTileDims.x * imageInfo.volumeSize.x;
     const h = imageInfo.atlasTileDims.y * imageInfo.volumeSize.y;
     JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, data) => onData(ch, data, [w, h]));
-    return Promise.resolve([undefined, undefined]);
+    return Promise.resolve({});
   }
 }
 

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -1,7 +1,7 @@
 import { fromUrl } from "geotiff";
 import { Vector3 } from "three";
 
-import { IVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
+import { ThreadableVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
 import { computePackedAtlasDims } from "./VolumeLoaderUtils";
 import { ImageInfo } from "../Volume";
 
@@ -61,7 +61,7 @@ function getOMEDims(imageEl: Element): OMEDims {
 
 const getBytesPerSample = (type: string): number => (type === "uint8" ? 1 : type === "uint16" ? 2 : 4);
 
-class TiffLoader extends IVolumeLoader {
+class TiffLoader extends ThreadableVolumeLoader {
   url: string;
   dims?: OMEDims;
 

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -1,7 +1,13 @@
 import { fromUrl } from "geotiff";
 import { Vector3 } from "three";
 
-import { ThreadableVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "./IVolumeLoader";
+import {
+  ThreadableVolumeLoader,
+  LoadSpec,
+  RawChannelDataCallback,
+  VolumeDims,
+  LoadedVolumeInfo,
+} from "./IVolumeLoader";
 import { computePackedAtlasDims } from "./VolumeLoaderUtils";
 import { ImageInfo } from "../Volume";
 
@@ -100,7 +106,7 @@ class TiffLoader extends ThreadableVolumeLoader {
     return [d];
   }
 
-  async createImageInfo(_loadSpec: LoadSpec): Promise<[ImageInfo, LoadSpec]> {
+  async createImageInfo(_loadSpec: LoadSpec): Promise<LoadedVolumeInfo> {
     const dims = await this.loadOmeDims();
     // compare with sizex, sizey
     //const width = image.getWidth();
@@ -144,14 +150,14 @@ class TiffLoader extends ThreadableVolumeLoader {
     };
 
     // This loader uses no fields from `LoadSpec`. Initialize volume with defaults.
-    return [imgdata, new LoadSpec()];
+    return { imageInfo: imgdata, loadSpec: new LoadSpec() };
   }
 
   async loadRawChannelData(
     imageInfo: ImageInfo,
     _loadSpec: LoadSpec,
     onData: RawChannelDataCallback
-  ): Promise<[undefined, undefined]> {
+  ): Promise<Record<string, never>> {
     const dims = await this.loadOmeDims();
 
     // do each channel on a worker?
@@ -181,7 +187,7 @@ class TiffLoader extends ThreadableVolumeLoader {
       worker.postMessage(params);
     }
 
-    return [undefined, undefined];
+    return {};
   }
 }
 

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -32,7 +32,7 @@ export async function createVolumeLoader(
   path: string | string[],
   options?: CreateLoaderOptions
 ): Promise<IVolumeLoader> {
-  const pathString = typeof path === "object" ? path[0] : path;
+  const pathString = Array.isArray(path) ? path[0] : path;
   const fileType = options?.fileType || pathToFileType(pathString);
 
   switch (fileType) {

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -1,4 +1,4 @@
-import { IVolumeLoader } from "./IVolumeLoader";
+import { ThreadableVolumeLoader } from "./IVolumeLoader";
 
 import { OMEZarrLoader } from "./OmeZarrLoader";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader";
@@ -31,7 +31,7 @@ export function pathToFileType(path: string): VolumeFileFormat {
 export async function createVolumeLoader(
   path: string | string[],
   options?: CreateLoaderOptions
-): Promise<IVolumeLoader> {
+): Promise<ThreadableVolumeLoader> {
   const pathString = Array.isArray(path) ? path[0] : path;
   const fileType = options?.fileType || pathToFileType(pathString);
 

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -37,8 +37,7 @@ export async function createVolumeLoader(
 
   switch (fileType) {
     case VolumeFileFormat.ZARR:
-      const { scene, cache, concurrencyLimit } = options || {};
-      return await OMEZarrLoader.createLoader(pathString, scene, cache, concurrencyLimit);
+      return await OMEZarrLoader.createLoader(pathString, options?.scene, options?.cache, options?.concurrencyLimit);
     case VolumeFileFormat.JSON:
       return new JsonImageInfoLoader(path, options?.cache);
     case VolumeFileFormat.TIFF:

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -23,9 +23,8 @@ export function pathToFileType(path: string): VolumeFileFormat {
     return VolumeFileFormat.JSON;
   } else if (path.endsWith(".tif") || path.endsWith(".tiff")) {
     return VolumeFileFormat.TIFF;
-  } else {
-    return VolumeFileFormat.ZARR;
   }
+  return VolumeFileFormat.ZARR;
 }
 
 export async function createVolumeLoader(

--- a/src/workers/LoadWorkerHandle.ts
+++ b/src/workers/LoadWorkerHandle.ts
@@ -9,7 +9,7 @@ import {
   WorkerResponse,
   WorkerResponsePayload,
   ChannelLoadEvent,
-  WorkerResponseKind,
+  WorkerResponseResult,
 } from "./types";
 import { rebuildImageInfo, rebuildLoadSpec } from "./util";
 
@@ -70,7 +70,7 @@ class SharedLoadWorkerHandle {
   }
 
   private receiveMessage<T extends WorkerMsgType>({ data }: MessageEvent<WorkerResponse<T>>): void {
-    if (data.responseKind === WorkerResponseKind.EVENT) {
+    if (data.responseKind === WorkerResponseResult.EVENT) {
       this.onChannelData?.(data);
     } else {
       const prom = this.pendingRequests[data.msgId];
@@ -82,7 +82,7 @@ class SharedLoadWorkerHandle {
         throw new Error(`Received response of type ${data.type} for message of type ${prom.type}`);
       }
 
-      if (data.responseKind === WorkerResponseKind.ERROR) {
+      if (data.responseKind === WorkerResponseResult.ERROR) {
         prom.reject(data.payload);
       } else {
         prom.resolve(data.payload);

--- a/src/workers/LoadWorkerHandle.ts
+++ b/src/workers/LoadWorkerHandle.ts
@@ -1,0 +1,166 @@
+import { ImageInfo } from "../Volume";
+import { CreateLoaderOptions } from "../loaders";
+import { IVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "../loaders/IVolumeLoader";
+import {
+  WorkerMsgType,
+  WorkerRequest,
+  WorkerRequestPayload,
+  WorkerResponse,
+  WorkerResponsePayload,
+  ChannelLoadEvent,
+} from "./types";
+
+type StoredPromise = {
+  resolve: (value: WorkerResponsePayload<WorkerMsgType>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+/**
+ * A handle that holds the worker and lets us interact with it through async calls and events rather than messages.
+ * This is separate from `LoadWorker` so that `sendMessage` and `onChannelData` can be shared with `WorkerLoader`s
+ * without leaking the API outside this file.
+ */
+class InternalLoadWorkerHandle {
+  private worker: Worker;
+  private pendingRequests: (StoredPromise | undefined)[] = [];
+
+  public onChannelData: ((e: ChannelLoadEvent) => void) | undefined = undefined;
+
+  constructor() {
+    this.worker = new Worker(new URL("./VolumeLoadWorker", import.meta.url));
+    this.worker.onmessage = this.receiveMessage.bind(this);
+    this.worker.onerror = this.receiveError.bind(this);
+  }
+
+  /** Given a handle for settling a promise when a response is received from the worker, store it and return its ID */
+  private registerMessagePromise(prom: StoredPromise): number {
+    for (const [i, pendingPromise] of this.pendingRequests.entries()) {
+      if (pendingPromise === undefined) {
+        this.pendingRequests[i] = prom;
+        return i;
+      }
+    }
+
+    return this.pendingRequests.push(prom) - 1;
+  }
+
+  sendMessage<T extends WorkerMsgType>(type: T, payload: WorkerRequestPayload<T>): Promise<WorkerResponsePayload<T>> {
+    let msgId = -1;
+    const promise = new Promise<WorkerResponsePayload<T>>((resolve, reject) => {
+      msgId = this.registerMessagePromise({ resolve, reject } as StoredPromise);
+    });
+
+    const msg: WorkerRequest<T> = { msgId, type, payload, isEvent: false };
+    this.worker.postMessage(msg);
+
+    return promise;
+  }
+
+  private receiveMessage({ data }: MessageEvent<WorkerResponse<WorkerMsgType> | ChannelLoadEvent>): void {
+    if (data.isEvent) {
+      this.onChannelData?.(data);
+    } else {
+      const prom = this.pendingRequests[data.msgId];
+      if (prom === undefined) {
+        throw new Error(`Received response for unknown message ID ${data.msgId}`);
+      }
+      prom.resolve(data.payload);
+      this.pendingRequests[data.msgId] = undefined;
+    }
+  }
+
+  private receiveError(e: ErrorEvent): void {
+    // TODO propagate errors through promises
+    // if (!e.error)
+    console.log(e);
+  }
+}
+
+class LoadWorker {
+  private workerHandle: InternalLoadWorkerHandle;
+  private openPromise: Promise<void>;
+
+  private activeLoader: WorkerLoader | undefined = undefined;
+  private activeLoaderId = -1;
+
+  constructor(maxCacheSize?: number) {
+    this.workerHandle = new InternalLoadWorkerHandle();
+    this.openPromise = this.workerHandle.sendMessage(WorkerMsgType.INIT, { maxCacheSize });
+  }
+
+  onOpen(): Promise<void> {
+    return this.openPromise;
+  }
+
+  async createLoader(path: string | string[], options?: CreateLoaderOptions): Promise<WorkerLoader> {
+    const success = await this.workerHandle.sendMessage(WorkerMsgType.CREATE_LOADER, { path, options });
+    if (!success) {
+      throw new Error("Failed to create loader");
+    }
+
+    this.activeLoader?.close();
+    this.activeLoaderId += 1;
+    this.activeLoader = new WorkerLoader(this.activeLoaderId, this.workerHandle);
+    return this.activeLoader;
+  }
+}
+
+class WorkerLoader extends IVolumeLoader {
+  private isActive = true;
+
+  private currentLoadId = -1;
+  private currentLoadCallback: RawChannelDataCallback | undefined = undefined;
+
+  constructor(private loaderId: number, private workerHandle: InternalLoadWorkerHandle) {
+    super();
+    workerHandle.onChannelData = this.onChannelData.bind(this);
+  }
+
+  private checkIsActive(): void {
+    if (!this.isActive) {
+      throw new Error("Tried to use a closed loader");
+    }
+  }
+
+  close(): void {
+    this.isActive = false;
+  }
+
+  loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]> {
+    this.checkIsActive();
+    return this.workerHandle.sendMessage(WorkerMsgType.LOAD_DIMS, loadSpec);
+  }
+
+  createImageInfo(loadSpec: LoadSpec): Promise<[ImageInfo, LoadSpec]> {
+    this.checkIsActive();
+    return this.workerHandle.sendMessage(WorkerMsgType.CREATE_VOLUME, loadSpec);
+  }
+
+  loadRawChannelData(
+    imageInfo: ImageInfo,
+    loadSpec: LoadSpec,
+    onData: RawChannelDataCallback
+  ): Promise<[ImageInfo | undefined, LoadSpec | undefined]> {
+    this.checkIsActive();
+
+    this.currentLoadCallback = onData;
+    this.currentLoadId += 1;
+    return this.workerHandle.sendMessage(WorkerMsgType.LOAD_VOLUME_DATA, {
+      imageInfo,
+      loadSpec,
+      loaderId: this.loaderId,
+      loadId: this.currentLoadId,
+    });
+  }
+
+  onChannelData(e: ChannelLoadEvent): void {
+    if (e.loaderId !== this.loaderId || e.loadId !== this.currentLoadId) {
+      return;
+    }
+
+    this.currentLoadCallback?.(e.channelIndex, e.data, e.atlasDims);
+  }
+}
+
+export default LoadWorker;
+export type { WorkerLoader };

--- a/src/workers/LoadWorkerHandle.ts
+++ b/src/workers/LoadWorkerHandle.ts
@@ -92,7 +92,7 @@ class SharedLoadWorkerHandle {
   }
 }
 
-class LoadWorker {
+class VolumeLoaderContext {
   private workerHandle: SharedLoadWorkerHandle;
   private openPromise: Promise<void>;
 
@@ -203,5 +203,5 @@ class WorkerLoader extends ThreadableVolumeLoader {
   }
 }
 
-export default LoadWorker;
+export default VolumeLoaderContext;
 export type { WorkerLoader };

--- a/src/workers/LoadWorkerHandle.ts
+++ b/src/workers/LoadWorkerHandle.ts
@@ -118,7 +118,7 @@ class LoadWorker {
 
   async createLoader(path: string | string[], options?: CreateLoaderOptions): Promise<WorkerLoader | TiffLoader> {
     // Special case: TIFF loader doesn't work on a worker, has its own workers anyways, and doesn't use cache or queue.
-    const pathString = typeof path === "object" ? path[0] : path;
+    const pathString = Array.isArray(path) ? path[0] : path;
     const fileType = options?.fileType || pathToFileType(pathString);
     if (fileType === VolumeFileFormat.TIFF) {
       return new TiffLoader(pathString);

--- a/src/workers/LoadWorkerHandle.ts
+++ b/src/workers/LoadWorkerHandle.ts
@@ -99,9 +99,13 @@ class LoadWorker {
   private activeLoader: WorkerLoader | undefined = undefined;
   private activeLoaderId = -1;
 
-  constructor(maxCacheSize?: number) {
+  constructor(maxCacheSize?: number, maxActiveRequests?: number, maxLowPriorityRequests?: number) {
     this.workerHandle = new SharedLoadWorkerHandle();
-    this.openPromise = this.workerHandle.sendMessage(WorkerMsgType.INIT, { maxCacheSize });
+    this.openPromise = this.workerHandle.sendMessage(WorkerMsgType.INIT, {
+      maxCacheSize,
+      maxActiveRequests,
+      maxLowPriorityRequests,
+    });
   }
 
   onOpen(): Promise<void> {
@@ -116,7 +120,10 @@ class LoadWorker {
     this.activeLoader?.close();
   }
 
-  async createLoader(path: string | string[], options?: CreateLoaderOptions): Promise<WorkerLoader | TiffLoader> {
+  async createLoader(
+    path: string | string[],
+    options?: Omit<CreateLoaderOptions, "cache" | "queue">
+  ): Promise<WorkerLoader | TiffLoader> {
     // Special case: TIFF loader doesn't work on a worker, has its own workers anyways, and doesn't use cache or queue.
     const pathString = Array.isArray(path) ? path[0] : path;
     const fileType = options?.fileType || pathToFileType(pathString);

--- a/src/workers/LoadWorkerHandle.ts
+++ b/src/workers/LoadWorkerHandle.ts
@@ -1,6 +1,6 @@
 import { ImageInfo } from "../Volume";
 import { CreateLoaderOptions, VolumeFileFormat, pathToFileType } from "../loaders";
-import { IVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "../loaders/IVolumeLoader";
+import { ThreadableVolumeLoader, LoadSpec, RawChannelDataCallback, VolumeDims } from "../loaders/IVolumeLoader";
 import { TiffLoader } from "../loaders/TiffLoader";
 import {
   WorkerMsgType,
@@ -136,7 +136,7 @@ class LoadWorker {
   }
 }
 
-class WorkerLoader extends IVolumeLoader {
+class WorkerLoader extends ThreadableVolumeLoader {
   private isOpen = true;
   private currentLoadId = -1;
   private currentLoadCallback: RawChannelDataCallback | undefined = undefined;

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -67,7 +67,7 @@ const messageHandlers: { [T in WorkerMsgType]: MessageHandler<T> } = {
           data,
           atlasDims,
         };
-        self.postMessage(message, copyOnLoad ? [] : [data.buffer]);
+        (self as unknown as Worker).postMessage(message, copyOnLoad ? [] : [data.buffer]);
       }
     );
   },

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -1,0 +1,64 @@
+import VolumeCache from "../VolumeCache";
+import { createVolumeLoader } from "../loaders";
+import { IVolumeLoader } from "../loaders/IVolumeLoader";
+import { WorkerMsgType, WorkerRequest, WorkerRequestPayload, WorkerResponsePayload } from "./types";
+
+let cache: VolumeCache | undefined = undefined;
+let loader: IVolumeLoader | undefined = undefined;
+
+type MessageHandlersType = {
+  [T in WorkerMsgType]: (payload: WorkerRequestPayload<T>) => Promise<WorkerResponsePayload<T>>;
+};
+
+const messageHandlers: MessageHandlersType = {
+  [WorkerMsgType.INIT]: ({ maxCacheSize }) => {
+    cache = new VolumeCache(maxCacheSize);
+    return Promise.resolve();
+  },
+
+  [WorkerMsgType.CREATE_LOADER]: async ({ path, options }) => {
+    loader = await createVolumeLoader(path, { ...options, cache });
+    return loader !== undefined;
+  },
+
+  [WorkerMsgType.CREATE_VOLUME]: async (loadSpec) => {
+    if (loader === undefined) {
+      throw new Error("No loader created");
+    }
+    const volume = await loader.createVolume(loadSpec);
+    return [volume.imageInfo, volume.loadSpec];
+  },
+
+  [WorkerMsgType.LOAD_DIMS]: async (loadSpec) => {
+    if (loader === undefined) {
+      throw new Error("No loader created");
+    }
+    return await loader.loadDims(loadSpec);
+  },
+
+  [WorkerMsgType.LOAD_VOLUME_DATA]: async ({ imageInfo, loadSpec, loaderId, loadId }) => {
+    if (loader === undefined) {
+      throw new Error("No loader created");
+    }
+    if (loaderId !== 0) {
+      throw new Error("Only one loader is supported");
+    }
+    const [updatedImageInfo, updatedLoadSpec] = await loader.loadRawChannelData(
+      imageInfo,
+      loadSpec,
+      (data, channelIndex, atlasDims) => {
+        self.postMessage({
+          isEvent: true,
+          loaderId,
+          loadId,
+          channelIndex,
+          data,
+          atlasDims,
+        });
+      }
+    );
+    return [updatedImageInfo, updatedLoadSpec];
+  },
+};
+
+self.onmessage = ({ data }: MessageEvent<WorkerRequest<WorkerMsgType>>) => {};

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -1,6 +1,6 @@
 import VolumeCache from "../VolumeCache";
 import { VolumeFileFormat, createVolumeLoader, pathToFileType } from "../loaders";
-import { IVolumeLoader } from "../loaders/IVolumeLoader";
+import { ThreadableVolumeLoader } from "../loaders/IVolumeLoader";
 import {
   WorkerMsgType,
   WorkerRequest,
@@ -12,7 +12,7 @@ import {
 import { rebuildImageInfo, rebuildLoadSpec } from "./util";
 
 let cache: VolumeCache | undefined = undefined;
-let loader: IVolumeLoader | undefined = undefined;
+let loader: ThreadableVolumeLoader | undefined = undefined;
 let initialized = false;
 let copyOnLoad = false;
 

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -66,7 +66,7 @@ const messageHandlers: { [T in WorkerMsgType]: MessageHandler<T> } = {
       rebuildLoadSpec(loadSpec),
       (channelIndex, data, atlasDims) => {
         const message: WorkerResponse<WorkerMsgType> = {
-          responseKind: WorkerResponseResult.EVENT,
+          responseResult: WorkerResponseResult.EVENT,
           loaderId,
           loadId,
           channelIndex,
@@ -85,9 +85,9 @@ self.onmessage = async <T extends WorkerMsgType>({ data }: MessageEvent<WorkerRe
 
   try {
     const response = await messageHandlers[type](payload);
-    message = { responseKind: WorkerResponseResult.SUCCESS, msgId, type, payload: response };
+    message = { responseResult: WorkerResponseResult.SUCCESS, msgId, type, payload: response };
   } catch (e) {
-    message = { responseKind: WorkerResponseResult.ERROR, msgId, type, payload: (e as Error).message };
+    message = { responseResult: WorkerResponseResult.ERROR, msgId, type, payload: (e as Error).message };
   }
   self.postMessage(message);
 };

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -8,7 +8,7 @@ import {
   WorkerRequest,
   WorkerRequestPayload,
   WorkerResponse,
-  WorkerResponseKind,
+  WorkerResponseResult,
   WorkerResponsePayload,
 } from "./types";
 import { rebuildImageInfo, rebuildLoadSpec } from "./util";
@@ -66,7 +66,7 @@ const messageHandlers: { [T in WorkerMsgType]: MessageHandler<T> } = {
       rebuildLoadSpec(loadSpec),
       (channelIndex, data, atlasDims) => {
         const message: WorkerResponse<WorkerMsgType> = {
-          responseKind: WorkerResponseKind.EVENT,
+          responseKind: WorkerResponseResult.EVENT,
           loaderId,
           loadId,
           channelIndex,
@@ -85,9 +85,9 @@ self.onmessage = async <T extends WorkerMsgType>({ data }: MessageEvent<WorkerRe
 
   try {
     const response = await messageHandlers[type](payload);
-    message = { responseKind: WorkerResponseKind.SUCCESS, msgId, type, payload: response };
+    message = { responseKind: WorkerResponseResult.SUCCESS, msgId, type, payload: response };
   } catch (e) {
-    message = { responseKind: WorkerResponseKind.ERROR, msgId, type, payload: (e as Error).message };
+    message = { responseKind: WorkerResponseResult.ERROR, msgId, type, payload: (e as Error).message };
   }
   self.postMessage(message);
 };

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -1,6 +1,6 @@
 import { ImageInfo } from "../Volume";
 import { CreateLoaderOptions } from "../loaders";
-import { LoadSpec, VolumeDims } from "../loaders/IVolumeLoader";
+import { LoadSpec, LoadedVolumeInfo, VolumeDims } from "../loaders/IVolumeLoader";
 
 /** The types of requests that can be made to the worker. Mostly corresponds to methods on `IVolumeLoader`. */
 export const enum WorkerMsgType {
@@ -50,9 +50,9 @@ export type WorkerRequestPayload<T extends WorkerMsgType> = {
 export type WorkerResponsePayload<T extends WorkerMsgType> = {
   [WorkerMsgType.INIT]: void;
   [WorkerMsgType.CREATE_LOADER]: boolean;
-  [WorkerMsgType.CREATE_VOLUME]: [ImageInfo, LoadSpec];
+  [WorkerMsgType.CREATE_VOLUME]: LoadedVolumeInfo;
   [WorkerMsgType.LOAD_DIMS]: VolumeDims[];
-  [WorkerMsgType.LOAD_VOLUME_DATA]: [ImageInfo | undefined, LoadSpec | undefined];
+  [WorkerMsgType.LOAD_VOLUME_DATA]: Partial<LoadedVolumeInfo>;
 }[T];
 
 /** Currently the only event a loader can produce is a `ChannelLoadEvent` when a single channel loads. */

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -2,6 +2,7 @@ import { ImageInfo } from "../Volume";
 import { CreateLoaderOptions } from "../loaders";
 import { LoadSpec, VolumeDims } from "../loaders/IVolumeLoader";
 
+/** The types of requests that can be made to the worker. Mostly corresponds to methods on `IVolumeLoader`. */
 export const enum WorkerMsgType {
   INIT,
   CREATE_LOADER,
@@ -10,18 +11,21 @@ export const enum WorkerMsgType {
   LOAD_VOLUME_DATA,
 }
 
+/** The kind of response a worker can return - `SUCCESS`, `ERROR`, or `EVENT`. */
 export const enum WorkerResponseResult {
   SUCCESS,
   ERROR,
   EVENT,
 }
 
+/** All messages to/from a worker carry a `msgId`, a `type`, and a `payload` (whose type is determined by `type`). */
 type WorkerMsgBase<T extends WorkerMsgType, P> = {
   msgId: number;
   type: T;
   payload: P;
 };
 
+/** Maps each `WorkerMsgType` to the type of the payload of requests of that type. */
 export type WorkerRequestPayload<T extends WorkerMsgType> = {
   [WorkerMsgType.INIT]: {
     maxCacheSize?: number;
@@ -42,6 +46,7 @@ export type WorkerRequestPayload<T extends WorkerMsgType> = {
   };
 }[T];
 
+/** Maps each `WorkerMsgType` to the type of the payload of responses of that type. */
 export type WorkerResponsePayload<T extends WorkerMsgType> = {
   [WorkerMsgType.INIT]: void;
   [WorkerMsgType.CREATE_LOADER]: boolean;
@@ -50,6 +55,7 @@ export type WorkerResponsePayload<T extends WorkerMsgType> = {
   [WorkerMsgType.LOAD_VOLUME_DATA]: [ImageInfo | undefined, LoadSpec | undefined];
 }[T];
 
+/** Currently the only event a loader can produce is a `ChannelLoadEvent` when a single channel loads. */
 export type ChannelLoadEvent = {
   loaderId: number;
   loadId: number;
@@ -58,7 +64,9 @@ export type ChannelLoadEvent = {
   atlasDims?: [number, number];
 };
 
+/** All valid types of worker requests, with some `WorkerMsgType` and a matching payload type. */
 export type WorkerRequest<T extends WorkerMsgType> = WorkerMsgBase<T, WorkerRequestPayload<T>>;
+/** All valid types of worker responses: `SUCCESS` with a matching payload, `ERROR` with a message, or an `EVENT`. */
 export type WorkerResponse<T extends WorkerMsgType> =
   | ({ responseKind: WorkerResponseResult.SUCCESS } & WorkerMsgBase<T, WorkerResponsePayload<T>>)
   | ({ responseKind: WorkerResponseResult.ERROR } & WorkerMsgBase<T, string>)

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -2,7 +2,7 @@ import { ImageInfo } from "../Volume";
 import { CreateLoaderOptions } from "../loaders";
 import { LoadSpec, VolumeDims } from "../loaders/IVolumeLoader";
 
-export enum WorkerMsgType {
+export const enum WorkerMsgType {
   INIT,
   CREATE_LOADER,
   CREATE_VOLUME,
@@ -10,8 +10,13 @@ export enum WorkerMsgType {
   LOAD_VOLUME_DATA,
 }
 
+export const enum WorkerResponseKind {
+  SUCCESS,
+  ERROR,
+  EVENT,
+}
+
 type WorkerMsgBase<T extends WorkerMsgType, P> = {
-  isEvent: false;
   msgId: number;
   type: T;
   payload: P;
@@ -43,14 +48,16 @@ export type WorkerResponsePayload<T extends WorkerMsgType> = {
   [WorkerMsgType.LOAD_VOLUME_DATA]: [ImageInfo | undefined, LoadSpec | undefined];
 }[T];
 
-export type WorkerRequest<T extends WorkerMsgType> = WorkerMsgBase<T, WorkerRequestPayload<T>>;
-export type WorkerResponse<T extends WorkerMsgType> = WorkerMsgBase<T, WorkerResponsePayload<T>>;
-
 export type ChannelLoadEvent = {
-  isEvent: true;
   loaderId: number;
   loadId: number;
   channelIndex: number;
   data: Uint8Array;
   atlasDims?: [number, number];
 };
+
+export type WorkerRequest<T extends WorkerMsgType> = WorkerMsgBase<T, WorkerRequestPayload<T>>;
+export type WorkerResponse<T extends WorkerMsgType> =
+  | ({ responseKind: WorkerResponseKind.SUCCESS } & WorkerMsgBase<T, WorkerResponsePayload<T>>)
+  | ({ responseKind: WorkerResponseKind.ERROR } & WorkerMsgBase<T, string>)
+  | ({ responseKind: WorkerResponseKind.EVENT } & ChannelLoadEvent);

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -10,7 +10,7 @@ export const enum WorkerMsgType {
   LOAD_VOLUME_DATA,
 }
 
-export const enum WorkerResponseKind {
+export const enum WorkerResponseResult {
   SUCCESS,
   ERROR,
   EVENT,
@@ -60,6 +60,6 @@ export type ChannelLoadEvent = {
 
 export type WorkerRequest<T extends WorkerMsgType> = WorkerMsgBase<T, WorkerRequestPayload<T>>;
 export type WorkerResponse<T extends WorkerMsgType> =
-  | ({ responseKind: WorkerResponseKind.SUCCESS } & WorkerMsgBase<T, WorkerResponsePayload<T>>)
-  | ({ responseKind: WorkerResponseKind.ERROR } & WorkerMsgBase<T, string>)
-  | ({ responseKind: WorkerResponseKind.EVENT } & ChannelLoadEvent);
+  | ({ responseKind: WorkerResponseResult.SUCCESS } & WorkerMsgBase<T, WorkerResponsePayload<T>>)
+  | ({ responseKind: WorkerResponseResult.ERROR } & WorkerMsgBase<T, string>)
+  | ({ responseKind: WorkerResponseResult.EVENT } & ChannelLoadEvent);

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -68,6 +68,6 @@ export type ChannelLoadEvent = {
 export type WorkerRequest<T extends WorkerMsgType> = WorkerMsgBase<T, WorkerRequestPayload<T>>;
 /** All valid types of worker responses: `SUCCESS` with a matching payload, `ERROR` with a message, or an `EVENT`. */
 export type WorkerResponse<T extends WorkerMsgType> =
-  | ({ responseKind: WorkerResponseResult.SUCCESS } & WorkerMsgBase<T, WorkerResponsePayload<T>>)
-  | ({ responseKind: WorkerResponseResult.ERROR } & WorkerMsgBase<T, string>)
-  | ({ responseKind: WorkerResponseResult.EVENT } & ChannelLoadEvent);
+  | ({ responseResult: WorkerResponseResult.SUCCESS } & WorkerMsgBase<T, WorkerResponsePayload<T>>)
+  | ({ responseResult: WorkerResponseResult.ERROR } & WorkerMsgBase<T, string>)
+  | ({ responseResult: WorkerResponseResult.EVENT } & ChannelLoadEvent);

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -25,6 +25,8 @@ type WorkerMsgBase<T extends WorkerMsgType, P> = {
 export type WorkerRequestPayload<T extends WorkerMsgType> = {
   [WorkerMsgType.INIT]: {
     maxCacheSize?: number;
+    maxActiveRequests?: number;
+    maxLowPriorityRequests?: number;
   };
   [WorkerMsgType.CREATE_LOADER]: {
     path: string | string[];

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -1,0 +1,56 @@
+import { ImageInfo } from "../Volume";
+import { CreateLoaderOptions } from "../loaders";
+import { LoadSpec, VolumeDims } from "../loaders/IVolumeLoader";
+
+export enum WorkerMsgType {
+  INIT,
+  CREATE_LOADER,
+  CREATE_VOLUME,
+  LOAD_DIMS,
+  LOAD_VOLUME_DATA,
+}
+
+type WorkerMsgBase<T extends WorkerMsgType, P> = {
+  isEvent: false;
+  msgId: number;
+  type: T;
+  payload: P;
+};
+
+export type WorkerRequestPayload<T extends WorkerMsgType> = {
+  [WorkerMsgType.INIT]: {
+    maxCacheSize?: number;
+  };
+  [WorkerMsgType.CREATE_LOADER]: {
+    path: string | string[];
+    options?: CreateLoaderOptions;
+  };
+  [WorkerMsgType.CREATE_VOLUME]: LoadSpec;
+  [WorkerMsgType.LOAD_DIMS]: LoadSpec;
+  [WorkerMsgType.LOAD_VOLUME_DATA]: {
+    imageInfo: ImageInfo;
+    loadSpec: LoadSpec;
+    loaderId: number;
+    loadId: number;
+  };
+}[T];
+
+export type WorkerResponsePayload<T extends WorkerMsgType> = {
+  [WorkerMsgType.INIT]: void;
+  [WorkerMsgType.CREATE_LOADER]: boolean;
+  [WorkerMsgType.CREATE_VOLUME]: [ImageInfo, LoadSpec];
+  [WorkerMsgType.LOAD_DIMS]: VolumeDims[];
+  [WorkerMsgType.LOAD_VOLUME_DATA]: [ImageInfo | undefined, LoadSpec | undefined];
+}[T];
+
+export type WorkerRequest<T extends WorkerMsgType> = WorkerMsgBase<T, WorkerRequestPayload<T>>;
+export type WorkerResponse<T extends WorkerMsgType> = WorkerMsgBase<T, WorkerResponsePayload<T>>;
+
+export type ChannelLoadEvent = {
+  isEvent: true;
+  loaderId: number;
+  loadId: number;
+  channelIndex: number;
+  data: Uint8Array;
+  atlasDims?: [number, number];
+};

--- a/src/workers/util.ts
+++ b/src/workers/util.ts
@@ -1,0 +1,26 @@
+import { Box3, Vector2, Vector3 } from "three";
+import { LoadSpec } from "../loaders/IVolumeLoader";
+import { ImageInfo } from "../Volume";
+
+export function rebuildLoadSpec(spec: LoadSpec): LoadSpec {
+  return {
+    ...spec,
+    subregion: new Box3(new Vector3().copy(spec.subregion.min), new Vector3().copy(spec.subregion.max)),
+  };
+}
+
+export function rebuildImageInfo(imageInfo: ImageInfo): ImageInfo {
+  return {
+    ...imageInfo,
+    originalSize: new Vector3().copy(imageInfo.originalSize),
+    atlasTileDims: new Vector2().copy(imageInfo.atlasTileDims),
+    volumeSize: new Vector3().copy(imageInfo.volumeSize),
+    subregionSize: new Vector3().copy(imageInfo.subregionSize),
+    subregionOffset: new Vector3().copy(imageInfo.subregionOffset),
+    physicalPixelSize: new Vector3().copy(imageInfo.physicalPixelSize),
+    transform: {
+      translation: new Vector3().copy(imageInfo.transform.translation),
+      rotation: new Vector3().copy(imageInfo.transform.rotation),
+    },
+  };
+}


### PR DESCRIPTION
Adds the ability to offload most volume loaders to a separate persistent worker, to avoid blocking updates and rendering on the "main thread."

This PR is a child of #176 and includes all its commits. Review that one first! I'll keep this one as a draft until that one merges.

### How it works:
Currently, the easiest and most generic way to create a loader is to call `createVolumeLoader`, which accepts a path and an options object and returns a loader of the appropriate type. The procedure to create a loader on a separate worker is quite similar, but includes a couple extra steps:
1. Create a new `LoadWorker`. This accepts arguments for initializing a cache and queue. Internally, `LoadWorker` spins up a new webworker and tells it to get a cache and queue going.
2. Before using the `LoadWorker`, await `LoadWorker.onOpen()`, which returns a promise that resolves when the above initialization step completes and the worker reports that it's ready.
3. Call `LoadWorker.createLoader`. This method has almost identical arguments as `createVolumeLoader` (it just doesn't accept a cache and queue, since loaders on the worker will use the worker's shared cache and queue instances) and returns a `WorkerLoader` which acts as a handle to the loader on the worker and can go wherever a normal `IVolumeLoader` can.
4. More loaders can be created via this method, but currently _only one loader can run on the worker at a time_, so any previous `WorkerLoader` will be invalidated and begin throwing errors when any of its methods are called. (There's no technical reason we can't run multiple loaders on the same worker, in fact we'd get some benefits by automatically sharing cache and queue, we're just not yet likely enough to use that functionality in practice to justify the effort of implementing it.)

### Worker implementation keyfiles
- src/workers/LoadWorkerHandle.ts includes most of the important stuff: `LoadWorker`, `WorkerLoader`, and all of the associated message tracking and bookkeeping.
- src/workers/types.ts rigorously lays out the contract for what messages to/from the loader look like
- src/workers/VolumeLoadWorker.ts contains the worker code, which is not all that interesting: just a map to various message handlers, most of which just call loader methods, and a bit of error handling glue.

### Changes to existing loaders
I had to make some changes to existing volume loaders to support working across the boundary between the main thread and the worker. Most significantly, most loaders are now implemented around a new abstract class called **`ThreadableVolumeLoader`**.

The most important methods of `IVolumeLoader` (the shared interface which all volume loaders implement) want to work directly with `Volume`s: `createVolume` builds and returns a `Volume`, and `loadVolumeData` accepts a `Volume` as an argument and modifies it directly. But transferring full `Volume`s to/from a worker would be impractical for a bunch of reasons. `ThreadableVolumeLoader` is an abstract class which introduces equivalent methods - `createImageInfo` and `loadRawChannelData`, respectively - that work with the `ImageInfo` and `LoadSpec` objects that describe a `Volume`. `LoadWorker` calls these lower-level methods and transfers the resulting changes to `ImageInfo` and/or `LoadSpec` back to the main thread, where direct changes can be made to the relevant `Volume`. `ThreadableVolumeLoader` also provides default implementations of `createVolume` and `loadVolumeData` around these new abstract methods, allowing a loader on the main thread to still use the old API without duplicated code. This has the added benefit of reducing a bit of boilerplate between loaders, since it turns out that the manipulations they were doing to `Volume` were all basically the same.

Additionally, `JsonImageInfoLoader` loaded images by creating an off-screen <img> tag and waiting for it to load. But since DOM nodes can't be created on a worker, I rewrote this section of the code to use the fetch API.