### PR TITLE
only consider enabled channels when determining if volume is loaded

### DIFF
--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -220,7 +220,6 @@ export default class Volume {
 
   private setUnloaded() {
     this.loaded = false;
-    // TODO this will cause problems once it is possible to skip loading some channels. Come back to this then.
     this.channels.forEach((channel) => {
       channel.loaded = false;
     });
@@ -319,7 +318,7 @@ export default class Volume {
 
   onChannelLoaded(batch: number[]): void {
     // check to see if all channels are now loaded, and fire an event(?)
-    if (this.channels.every((element) => element.loaded)) {
+    if (this.loadSpec.channels.every((channelIndex) => this.channels[channelIndex].loaded)) {
       this.loaded = true;
     }
     batch.forEach((channelIndex) => this.channelLoadCallback?.(this, channelIndex));


### PR DESCRIPTION
Currently, the `loaded` property of `Volume` is derived by `&&`-ing all the `loaded` properties of the volume's `Channel`s together. But since #173, disabled channels aren't necessarily loaded, causing certain volumes to be persistently marked unloaded when a load is triggered and not all channels are enabled.

This one-line fix considers only channels that we actually expect to load when deriving `loaded`.