### PR TITLE
Prefetch priority

### DIFF
--- a/src/constants/fuseShader.ts
+++ b/src/constants/fuseShader.ts
@@ -31,5 +31,5 @@ void main()
     // apply lut to intensity:
     vec4 pix = texture(lutSampler, vec2(intensity, 0.5));
     gl_FragColor = vec4(pix.xyz*pix.w, pix.w);
-}  
+}
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import RequestQueue from "./utils/RequestQueue";
 import SubscribableRequestQueue from "./utils/SubscribableRequestQueue";
 import Histogram from "./Histogram";
 import { ViewportCorner } from "./types";
-import { VolumeFileFormat, createVolumeLoader } from "./loaders";
+import { VolumeFileFormat, createVolumeLoader, PrefetchDirection } from "./loaders";
 import { LoadSpec } from "./loaders/IVolumeLoader";
 import { OMEZarrLoader } from "./loaders/OmeZarrLoader";
 import { JsonImageInfoLoader } from "./loaders/JsonImageInfoLoader";
@@ -31,6 +31,7 @@ export {
   VolumeCache,
   RequestQueue,
   SubscribableRequestQueue,
+  PrefetchDirection,
   OMEZarrLoader,
   JsonImageInfoLoader,
   TiffLoader,

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -2,6 +2,7 @@ import { Box3, Vector3 } from "three";
 
 import Volume, { ImageInfo } from "../Volume";
 import { buildDefaultMetadata } from "./VolumeLoaderUtils";
+import { PrefetchDirection } from "./zarr_utils/ChunkPrefetchIterator";
 
 export class LoadSpec {
   time = 0;
@@ -68,6 +69,9 @@ export interface IVolumeLoader {
   // in a way that they can be interrupted.
   // TODO explicitly passing a `LoadSpec` is now rarely useful. Remove?
   loadVolumeData(volume: Volume, loadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): void;
+
+  /** Change which directions to prioritize when prefetching. Currently only implemented on `OMEZarrLoader`. */
+  setPrefetchPriority(directions: PrefetchDirection[]): void;
 }
 
 /** Abstract class which allows loaders to accept and return types that are easier to transfer to/from a worker. */
@@ -97,6 +101,10 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
     loadSpec: LoadSpec,
     onData: RawChannelDataCallback
   ): Promise<Partial<LoadedVolumeInfo>>;
+
+  setPrefetchPriority(_directions: PrefetchDirection[]): void {
+    // no-op by default
+  }
 
   async createVolume(loadSpec: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<Volume> {
     const { imageInfo, loadSpec: adjustedLoadSpec } = await this.createImageInfo(loadSpec);

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -2,7 +2,7 @@ import { Box3, Vector3 } from "three";
 
 import Volume, { ImageInfo } from "../Volume";
 import { buildDefaultMetadata } from "./VolumeLoaderUtils";
-import { PrefetchDirection } from "./zarr_utils/ChunkPrefetchIterator";
+import { PrefetchDirection } from "./zarr_utils/types";
 
 export class LoadSpec {
   time = 0;

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -284,7 +284,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
    * Change which directions to prioritize when prefetching. All chunks will be prefetched in these directions before
    * any chunks are prefetched in any other directions.
    */
-  setPrefetchPriorityDirections(directions: PrefetchDirection[]): void {
+  setPrefetchPriority(directions: PrefetchDirection[]): void {
     this.priorityDirections = directions;
   }
 

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -161,7 +161,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     private axesTCZYX: TCZYX<number>,
     /** Handle to a `SubscribableRequestQueue` for smart concurrency management and request cancelling/reissuing. */
     private requestQueue: SubscribableRequestQueue,
-    /** Options to configure (pre)fetching behavior */
+    /** Options to configure (pre)fetching behavior. */
     private fetchOptions: ZarrLoaderFetchOptions = DEFAULT_FETCH_OPTIONS,
     /** Direction(s) to prioritize when prefetching. Stored separate from `fetchOptions` since it may be mutated. */
     private priorityDirections: PrefetchDirection[] = []
@@ -278,6 +278,10 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     });
 
     return result;
+  }
+
+  setPriorityDirections(directions: PrefetchDirection[]): void {
+    this.priorityDirections = directions;
   }
 
   loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]> {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -24,7 +24,8 @@ import {
   estimateLevelForAtlas,
   unitNameToSymbol,
 } from "./VolumeLoaderUtils";
-import ChunkPrefetchIterator, { PrefetchDirection } from "./zarr_utils/ChunkPrefetchIterator";
+import ChunkPrefetchIterator from "./zarr_utils/ChunkPrefetchIterator";
+import { PrefetchDirection } from "./zarr_utils/types";
 import WrappedStore from "./zarr_utils/WrappedStore";
 import {
   OMEAxis,

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -491,7 +491,6 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
 
     Promise.all(channelPromises).then(() => {
       this.requestQueue.removeSubscriber(subscriber, CHUNK_REQUEST_CANCEL_REASON);
-      setTimeout(() => this.beginPrefetch(keys, level), 1000);
     });
     return Promise.resolve({ imageInfo: updatedImageInfo });
   }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -280,7 +280,11 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     return result;
   }
 
-  setPriorityDirections(directions: PrefetchDirection[]): void {
+  /**
+   * Change which directions to prioritize when prefetching. All chunks will be prefetched in these directions before
+   * any chunks are prefetched in any other directions.
+   */
+  setPrefetchPriorityDirections(directions: PrefetchDirection[]): void {
     this.priorityDirections = directions;
   }
 

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -3,7 +3,7 @@ import { Box3, Vector2, Vector3 } from "three";
 
 import { ImageInfo } from "../Volume";
 
-const MAX_ATLAS_EDGE = 2048;
+const MAX_ATLAS_EDGE = 4096;
 
 // Map from units to their symbols
 const UNIT_SYMBOLS = {

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -6,6 +6,8 @@ import { TiffLoader } from "./TiffLoader";
 import VolumeCache from "../VolumeCache";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
 
+export { PrefetchDirection } from "./zarr_utils/ChunkPrefetchIterator";
+
 export const enum VolumeFileFormat {
   ZARR = "zarr",
   JSON = "json",

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -6,7 +6,7 @@ import { TiffLoader } from "./TiffLoader";
 import VolumeCache from "../VolumeCache";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
 
-export { PrefetchDirection } from "./zarr_utils/ChunkPrefetchIterator";
+export { PrefetchDirection } from "./zarr_utils/types";
 
 export const enum VolumeFileFormat {
   ZARR = "zarr",

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -11,7 +11,7 @@ type TZYX = [number, number, number, number];
  *
  * Note that this enum is mostly for documentation, and its variants are never explicitly used.
  */
-const enum PrefetchDirection {
+export const enum PrefetchDirection {
   T_MINUS = 0,
   T_PLUS = 1,
 
@@ -54,9 +54,15 @@ function updateMinMax(val: number, minmax: [number, number]): void {
  */
 // NOTE: Assumes `chunks` form a rectangular prism! Will create gaps otherwise! (in practice they always should)
 export default class ChunkPrefetchIterator {
-  directions: PrefetchDirectionState[];
+  directionStates: PrefetchDirectionState[];
+  priorityDirectionStates: PrefetchDirectionState[];
 
-  constructor(chunks: TCZYX<number>[], tzyxMaxPrefetchOffset: TZYX, tzyxNumChunks: TZYX) {
+  constructor(
+    chunks: TCZYX<number>[],
+    tzyxMaxPrefetchOffset: TZYX,
+    tzyxNumChunks: TZYX,
+    priorityDirections?: PrefetchDirection[]
+  ) {
     // Get min and max chunk coordinates for T/Z/Y/X
     const extrema: [number, number][] = [
       [Infinity, -Infinity],
@@ -73,39 +79,55 @@ export default class ChunkPrefetchIterator {
     }
 
     // Create `PrefetchDirectionState`s for each direction
-    const directions: PrefetchDirectionState[] = extrema.flat().map((start, direction) => {
+    this.directionStates = [];
+    this.priorityDirectionStates = [];
+
+    for (const [direction, start] of extrema.flat().entries()) {
       const dimension = direction >> 1;
+      let end: number;
       if (direction & 1) {
         // Positive direction - end is either the max coordinate in the fetched set plus the max offset in this
         // dimension, or the max chunk coordinate in this dimension, whichever comes first
-        const end = Math.min(start + tzyxMaxPrefetchOffset[dimension], tzyxNumChunks[dimension] - 1);
-        return { direction, start, end, chunks: [] };
+        end = Math.min(start + tzyxMaxPrefetchOffset[dimension], tzyxNumChunks[dimension] - 1);
       } else {
         // Negative direction - end is either the min coordinate in the fetched set minus the max offset in this
         // dimension, or 0, whichever comes first
-        const end = Math.max(start - tzyxMaxPrefetchOffset[dimension], 0);
-        return { direction, start, end, chunks: [] };
+        end = Math.max(start - tzyxMaxPrefetchOffset[dimension], 0);
       }
-    });
+      const directionState = { direction, start, end, chunks: [] };
+
+      if (priorityDirections && priorityDirections.includes(direction)) {
+        this.priorityDirectionStates.push(directionState);
+      } else {
+        this.directionStates.push(directionState);
+      }
+    }
 
     // Fill each `PrefetchDirectionState` with chunks at the border of the fetched set
     for (const chunk of chunks) {
-      for (const dir of directions) {
+      for (const dir of this.directionStates) {
         if (chunk[directionToIndex(dir.direction)] === dir.start) {
           dir.chunks.push(chunk);
         }
       }
     }
 
-    this.directions = directions;
+    // Filter out prioritized direction(s), if any
+    if (priorityDirections && priorityDirections.length > 0) {
+      for (const [idx, dir] of this.directionStates.entries()) {
+        if (priorityDirections.includes(dir.direction)) {
+          this.directionStates.splice(idx, 1);
+        }
+      }
+    }
   }
 
-  *[Symbol.iterator](): Iterator<TCZYX<number>> {
+  static *iterateDirections(directions: PrefetchDirectionState[]): Generator<TCZYX<number>> {
     let offset = 1;
 
-    while (this.directions.length > 0) {
+    while (directions.length > 0) {
       // Remove directions in which we have hit a boundary
-      this.directions = this.directions.filter((dir) => {
+      directions = directions.filter((dir) => {
         if (dir.direction & 1) {
           return dir.start + offset <= dir.end;
         } else {
@@ -114,7 +136,7 @@ export default class ChunkPrefetchIterator {
       });
 
       // Yield chunks one chunk farther out in every remaining direction
-      for (const dir of this.directions) {
+      for (const dir of directions) {
         for (const chunk of dir.chunks) {
           const newChunk = chunk.slice() as TCZYX<number>;
           newChunk[directionToIndex(dir.direction)] += offset * (dir.direction & 1 ? 1 : -1);
@@ -123,6 +145,20 @@ export default class ChunkPrefetchIterator {
       }
 
       offset += 1;
+    }
+  }
+
+  *[Symbol.iterator](): Iterator<TCZYX<number>> {
+    // Yield all chunks in priority direction(s) first, if any
+    if (this.priorityDirectionStates.length > 0) {
+      for (const chunk of ChunkPrefetchIterator.iterateDirections(this.priorityDirectionStates)) {
+        yield chunk;
+      }
+    }
+
+    // Then yield all chunks in other directions
+    for (const chunk of ChunkPrefetchIterator.iterateDirections(this.directionStates)) {
+      yield chunk;
     }
   }
 }

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -1,29 +1,6 @@
-import { TCZYX } from "./types";
+import { PrefetchDirection, TCZYX } from "./types";
 
 type TZYX = [number, number, number, number];
-
-/**
- * Directions in which to move outward from the loaded set of chunks while prefetching.
- *
- * Ordered in pairs of opposite directions both because that's a sensible order in which to prefetch for our purposes,
- * and because it lets us treat the least significant bit as the sign. So `direction >> 1` gives the index of the
- * direction in TZYX-ordered arrays, and `direction & 1` gives the sign of the direction (e.g. positive vs negative Z).
- *
- * Note that this enum is mostly for documentation, and its variants are never explicitly used.
- */
-export const enum PrefetchDirection {
-  T_MINUS = 0,
-  T_PLUS = 1,
-
-  Z_MINUS = 2,
-  Z_PLUS = 3,
-
-  Y_MINUS = 4,
-  Y_PLUS = 5,
-
-  X_MINUS = 6,
-  X_PLUS = 7,
-}
 
 type PrefetchDirectionState = {
   direction: PrefetchDirection;

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -110,13 +110,9 @@ export default class ChunkPrefetchIterator {
           dir.chunks.push(chunk);
         }
       }
-    }
-
-    // Filter out prioritized direction(s), if any
-    if (priorityDirections && priorityDirections.length > 0) {
-      for (const [idx, dir] of this.directionStates.entries()) {
-        if (priorityDirections.includes(dir.direction)) {
-          this.directionStates.splice(idx, 1);
+      for (const dir of this.priorityDirectionStates) {
+        if (chunk[directionToIndex(dir.direction)] === dir.start) {
+          dir.chunks.push(chunk);
         }
       }
     }

--- a/src/loaders/zarr_utils/types.ts
+++ b/src/loaders/zarr_utils/types.ts
@@ -3,6 +3,27 @@ import SubscribableRequestQueue from "../../utils/SubscribableRequestQueue";
 export type TCZYX<T> = [T, T, T, T, T];
 export type SubscriberId = ReturnType<SubscribableRequestQueue["addSubscriber"]>;
 
+/**
+ * Directions in which to move outward from the loaded set of chunks while prefetching.
+ *
+ * Ordered in pairs of opposite directions both because that's a sensible order in which to prefetch for our purposes,
+ * and because it lets us treat the least significant bit as the sign. So `direction >> 1` gives the index of the
+ * direction in TZYX-ordered arrays, and `direction & 1` gives the sign of the direction (e.g. positive vs negative Z).
+ */
+export const enum PrefetchDirection {
+  T_MINUS = 0,
+  T_PLUS = 1,
+
+  Z_MINUS = 2,
+  Z_PLUS = 3,
+
+  Y_MINUS = 4,
+  Y_PLUS = 5,
+
+  X_MINUS = 6,
+  X_PLUS = 7,
+}
+
 export type OMECoordinateTransformation =
   | {
       type: "identity";

--- a/src/test/ChunkPrefetchIterator.test.ts
+++ b/src/test/ChunkPrefetchIterator.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "chai";
 
 import { TCZYX } from "../loaders/zarr_utils/types";
-import ChunkPrefetchIterator, { PrefetchDirection } from "../loaders/zarr_utils/ChunkPrefetchIterator";
+import ChunkPrefetchIterator from "../loaders/zarr_utils/ChunkPrefetchIterator";
+import { PrefetchDirection } from "../loaders/zarr_utils/types";
 
 const EXPECTED_3X3X3X3 = [
   [0, 0, 1, 1, 1], // T-

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -1,7 +1,6 @@
 import VolumeCache from "../VolumeCache";
 import { VolumeFileFormat, createVolumeLoader, pathToFileType } from "../loaders";
 import { ThreadableVolumeLoader } from "../loaders/IVolumeLoader";
-import { OMEZarrLoader } from "../loaders/OmeZarrLoader";
 import RequestQueue from "../utils/RequestQueue";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
 import {

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -1,6 +1,7 @@
 import VolumeCache from "../VolumeCache";
 import { VolumeFileFormat, createVolumeLoader, pathToFileType } from "../loaders";
 import { ThreadableVolumeLoader } from "../loaders/IVolumeLoader";
+import { OMEZarrLoader } from "../loaders/OmeZarrLoader";
 import RequestQueue from "../utils/RequestQueue";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
 import {
@@ -76,6 +77,12 @@ const messageHandlers: { [T in WorkerMsgType]: MessageHandler<T> } = {
         (self as unknown as Worker).postMessage(message, copyOnLoad ? [] : [data.buffer]);
       }
     );
+  },
+
+  [WorkerMsgType.SET_PREFETCH_PRIORITY_DIRECTIONS]: (directions) => {
+    // Silently does nothing if the loader isn't an `OMEZarrLoader`
+    (loader as OMEZarrLoader | undefined)?.setPrefetchPriorityDirections?.(directions);
+    return Promise.resolve();
   },
 };
 

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -81,7 +81,7 @@ const messageHandlers: { [T in WorkerMsgType]: MessageHandler<T> } = {
 
   [WorkerMsgType.SET_PREFETCH_PRIORITY_DIRECTIONS]: (directions) => {
     // Silently does nothing if the loader isn't an `OMEZarrLoader`
-    (loader as OMEZarrLoader | undefined)?.setPrefetchPriorityDirections?.(directions);
+    loader?.setPrefetchPriority(directions);
     return Promise.resolve();
   },
 };

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -1,5 +1,5 @@
 import { ImageInfo } from "../Volume";
-import { CreateLoaderOptions } from "../loaders";
+import { CreateLoaderOptions, PrefetchDirection } from "../loaders";
 import { LoadSpec, LoadedVolumeInfo, VolumeDims } from "../loaders/IVolumeLoader";
 
 /** The types of requests that can be made to the worker. Mostly corresponds to methods on `IVolumeLoader`. */
@@ -9,6 +9,7 @@ export const enum WorkerMsgType {
   CREATE_VOLUME,
   LOAD_DIMS,
   LOAD_VOLUME_DATA,
+  SET_PREFETCH_PRIORITY_DIRECTIONS,
 }
 
 /** The kind of response a worker can return - `SUCCESS`, `ERROR`, or `EVENT`. */
@@ -44,6 +45,7 @@ export type WorkerRequestPayload<T extends WorkerMsgType> = {
     loaderId: number;
     loadId: number;
   };
+  [WorkerMsgType.SET_PREFETCH_PRIORITY_DIRECTIONS]: PrefetchDirection[];
 }[T];
 
 /** Maps each `WorkerMsgType` to the type of the payload of responses of that type. */
@@ -53,6 +55,7 @@ export type WorkerResponsePayload<T extends WorkerMsgType> = {
   [WorkerMsgType.CREATE_VOLUME]: LoadedVolumeInfo;
   [WorkerMsgType.LOAD_DIMS]: VolumeDims[];
   [WorkerMsgType.LOAD_VOLUME_DATA]: Partial<LoadedVolumeInfo>;
+  [WorkerMsgType.SET_PREFETCH_PRIORITY_DIRECTIONS]: void;
 }[T];
 
 /** Currently the only event a loader can produce is a `ChannelLoadEvent` when a single channel loads. */


### PR DESCRIPTION
Resolve #179: allows certain prefetch directions to be "prioritized," so e.g. if the user is playing through time, we don't waste fetches requesting adjacent z-slices at each timestep we visit.

- `ChunkPrefetchIterator`, which facilitates picking the chunks we prefetch, gets a new priority feature and a new unit test to match.
- `OMEZarrLoader` gets a new method, `setPrefetchPriorityDirections`, which sets priority. It also gets some new documentation, while I was there.
- `WorkerLoader` gets an identical method, and glue code to pass priority info into a workerized loader if it's an `OMEZarrLoader`.
- The whole package gets a new export: `PrefetchDirection`, the `const enum` previously used only internally to `ChunkPrefetchIterator`, which is now required to express prefetch direction priority.