### PR TITLE
Fully qualified imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "raw-loader": "^4.0.2",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "regenerator-runtime": "^0.13.9",
         "rimraf": "^3.0.2",
         "ts-node": "^10.9.2",
         "typescript": "^4.3.5",
@@ -10852,12 +10851,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
-    },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
@@ -21428,12 +21421,6 @@
       "requires": {
         "regenerate": "^1.4.2"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
     },
     "regenerator-transform": {
       "version": "0.15.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "raw-loader": "^4.0.2",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "regenerator-runtime": "^0.13.9",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^4.3.5",

--- a/public/index.ts
+++ b/public/index.ts
@@ -1,4 +1,3 @@
-import "regenerator-runtime/runtime";
 import { Vector2, Vector3 } from "three";
 import * as dat from "dat.gui";
 

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -15,12 +15,12 @@ import {
   Vector3,
 } from "three";
 import { Channel, Volume } from ".";
-import { sliceFragmentShaderSrc, sliceShaderUniforms, sliceVertexShaderSrc } from "./constants/volumeSliceShader";
-import { VolumeRenderImpl } from "./VolumeRenderImpl";
-import { SettingsFlags, VolumeRenderSettings } from "./VolumeRenderSettings";
-import FusedChannelData from "./FusedChannelData";
-import { FuseChannel } from "./types";
-import { ThreeJsPanel } from "./ThreeJsPanel";
+import { sliceFragmentShaderSrc, sliceShaderUniforms, sliceVertexShaderSrc } from "./constants/volumeSliceShader.js";
+import type { VolumeRenderImpl } from "./VolumeRenderImpl.js";
+import { SettingsFlags, VolumeRenderSettings } from "./VolumeRenderSettings.js";
+import FusedChannelData from "./FusedChannelData.js";
+import type { FuseChannel } from "./types.js";
+import { ThreeJsPanel } from "./ThreeJsPanel.js";
 
 const BOUNDING_BOX_DEFAULT_COLOR = new Color(0xffff00);
 

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -1,6 +1,5 @@
 import { DataTexture, RedFormat, UnsignedByteType, RGBAFormat, LinearFilter, NearestFilter } from "three";
-import Histogram from "./Histogram";
-import { LUT_ARRAY_LENGTH } from "./Histogram";
+import Histogram, { LUT_ARRAY_LENGTH } from "./Histogram.js";
 
 interface ChannelImageData {
   /** Returns the one-dimensional array containing the data in RGBA order, as integers in the range 0 to 255. */

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -17,8 +17,8 @@ import {
   CustomBlending,
   MaxEquation,
   Texture,
+  LinearFilter,
 } from "three";
-import { LinearFilter } from "three/src/constants";
 
 import Channel from "./Channel.js";
 import { fuseShaderSrc, fuseVertexShaderSrc } from "./constants/fuseShader.js";

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -20,9 +20,9 @@ import {
 } from "three";
 import { LinearFilter } from "three/src/constants";
 
-import Channel from "./Channel";
-import { fuseShaderSrc, fuseVertexShaderSrc } from "./constants/fuseShader";
-import { FuseChannel } from "./types";
+import Channel from "./Channel.js";
+import { fuseShaderSrc, fuseVertexShaderSrc } from "./constants/fuseShader.js";
+import type { FuseChannel } from "./types.js";
 
 // This is the owner of the fused RGBA volume texture atlas, and the mask texture atlas.
 // This module is responsible for updating the fused texture, given the read-only volume channel data.

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -1,4 +1,4 @@
-import { getColorByChannelIndex } from "./constants/colors";
+import { getColorByChannelIndex } from "./constants/colors.js";
 
 function clamp(val: number, cmin: number, cmax: number): number {
   return Math.min(Math.max(cmin, val), cmax);

--- a/src/MeshVolume.ts
+++ b/src/MeshVolume.ts
@@ -14,13 +14,13 @@ import {
 import { STLExporter } from "three/examples/jsm/exporters/STLExporter";
 import { GLTFExporter } from "three/examples/jsm/exporters/GLTFExporter";
 
-import { defaultMaterialSettings } from "./constants/materials";
+import { defaultMaterialSettings } from "./constants/materials.js";
 
-import FileSaver from "./FileSaver";
+import FileSaver from "./FileSaver.js";
 import NaiveSurfaceNets from "./NaiveSurfaceNets.js";
-import MarchingCubes from "./MarchingCubes";
-import Volume from "./Volume";
-import { Bounds } from "./types.js";
+import MarchingCubes from "./MarchingCubes.js";
+import Volume from "./Volume.js";
+import type { Bounds } from "./types.js";
 import { ThreeJsPanel } from "./ThreeJsPanel.js";
 
 // this cutoff is chosen to have a small buffer of values before the object is treated

--- a/src/MeshVolume.ts
+++ b/src/MeshVolume.ts
@@ -11,8 +11,8 @@ import {
   Plane,
   DoubleSide,
 } from "three";
-import { STLExporter } from "three/examples/jsm/exporters/STLExporter";
-import { GLTFExporter } from "three/examples/jsm/exporters/GLTFExporter";
+import { STLExporter } from "three/examples/jsm/exporters/STLExporter.js";
+import { GLTFExporter } from "three/examples/jsm/exporters/GLTFExporter.js";
 
 import { defaultMaterialSettings } from "./constants/materials.js";
 

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -21,20 +21,20 @@ import {
 } from "three";
 import { LinearFilter, NearestFilter } from "three/src/constants";
 
-import { denoiseFragmentShaderSrc, denoiseShaderUniforms, denoiseVertexShaderSrc } from "./constants/denoiseShader";
+import { denoiseFragmentShaderSrc, denoiseShaderUniforms, denoiseVertexShaderSrc } from "./constants/denoiseShader.js";
 import {
   pathTracingFragmentShaderSrc,
   pathTracingUniforms,
   pathTracingVertexShaderSrc,
-} from "./constants/volumePTshader";
-import { LUT_ARRAY_LENGTH } from "./Histogram";
-import Volume from "./Volume";
-import { FUSE_DISABLED_RGB_COLOR, FuseChannel, isOrthographicCamera } from "./types";
-import { ThreeJsPanel } from "./ThreeJsPanel";
-import { Light } from "./Light";
-import { VolumeRenderImpl } from "./VolumeRenderImpl";
-import { VolumeRenderSettings, SettingsFlags } from "./VolumeRenderSettings";
-import Channel from "./Channel";
+} from "./constants/volumePTshader.js";
+import { LUT_ARRAY_LENGTH } from "./Histogram.js";
+import Volume from "./Volume.js";
+import { FUSE_DISABLED_RGB_COLOR, type FuseChannel, isOrthographicCamera } from "./types.js";
+import { ThreeJsPanel } from "./ThreeJsPanel.js";
+import { Light } from "./Light.js";
+import type { VolumeRenderImpl } from "./VolumeRenderImpl.js";
+import { VolumeRenderSettings, SettingsFlags } from "./VolumeRenderSettings.js";
+import Channel from "./Channel.js";
 
 export default class PathTracedVolume implements VolumeRenderImpl {
   private settings: VolumeRenderSettings;

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -18,8 +18,9 @@ import {
   Vector2,
   Vector3,
   WebGLRenderTarget,
+  LinearFilter,
+  NearestFilter,
 } from "three";
-import { LinearFilter, NearestFilter } from "three/src/constants";
 
 import { denoiseFragmentShaderSrc, denoiseShaderUniforms, denoiseVertexShaderSrc } from "./constants/denoiseShader.js";
 import {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -17,18 +17,18 @@ import {
   Vector3,
 } from "three";
 
-import FusedChannelData from "./FusedChannelData";
+import FusedChannelData from "./FusedChannelData.js";
 import {
   rayMarchingVertexShaderSrc,
   rayMarchingFragmentShaderSrc,
   rayMarchingShaderUniforms,
-} from "./constants/volumeRayMarchShader";
-import { Volume } from ".";
-import Channel from "./Channel";
-import { ThreeJsPanel } from "./ThreeJsPanel";
-import { VolumeRenderImpl } from "./VolumeRenderImpl";
+} from "./constants/volumeRayMarchShader.js";
+import { Volume } from "./index.js";
+import Channel from "./Channel.js";
+import { ThreeJsPanel } from "./ThreeJsPanel.js";
+import type { VolumeRenderImpl } from "./VolumeRenderImpl.js";
 
-import { FuseChannel } from "./types";
+import type { FuseChannel } from "./types.js";
 import { VolumeRenderSettings, SettingsFlags } from "./VolumeRenderSettings";
 
 const BOUNDING_BOX_DEFAULT_COLOR = new Color(0xffff00);

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -29,7 +29,7 @@ import { ThreeJsPanel } from "./ThreeJsPanel.js";
 import type { VolumeRenderImpl } from "./VolumeRenderImpl.js";
 
 import type { FuseChannel } from "./types.js";
-import { VolumeRenderSettings, SettingsFlags } from "./VolumeRenderSettings";
+import { VolumeRenderSettings, SettingsFlags } from "./VolumeRenderSettings.js";
 
 const BOUNDING_BOX_DEFAULT_COLOR = new Color(0xffff00);
 

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -16,8 +16,8 @@ import {
 } from "three";
 
 import TrackballControls from "./TrackballControls.js";
-import Timing from "./Timing";
-import scaleBarSVG from "./constants/scaleBarSVG";
+import Timing from "./Timing.js";
+import scaleBarSVG from "./constants/scaleBarSVG.js";
 import { isOrthographicCamera, ViewportCorner, isTop, isRight } from "./types";
 
 const DEFAULT_PERSPECTIVE_CAMERA_DISTANCE = 5.0;

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -18,7 +18,7 @@ import {
 import TrackballControls from "./TrackballControls.js";
 import Timing from "./Timing.js";
 import scaleBarSVG from "./constants/scaleBarSVG.js";
-import { isOrthographicCamera, ViewportCorner, isTop, isRight } from "./types";
+import { isOrthographicCamera, ViewportCorner, isTop, isRight } from "./types.js";
 
 const DEFAULT_PERSPECTIVE_CAMERA_DISTANCE = 5.0;
 const DEFAULT_PERSPECTIVE_CAMERA_NEAR = 0.001;

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -11,20 +11,20 @@ import {
 } from "three";
 import { Pane } from "tweakpane";
 
-import { ThreeJsPanel } from "./ThreeJsPanel";
-import lightSettings from "./constants/lights";
-import VolumeDrawable from "./VolumeDrawable";
-import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light";
-import Volume from "./Volume";
+import { ThreeJsPanel } from "./ThreeJsPanel.js";
+import lightSettings from "./constants/lights.js";
+import VolumeDrawable from "./VolumeDrawable.js";
+import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
+import Volume from "./Volume.js";
 import {
-  VolumeChannelDisplayOptions,
-  VolumeDisplayOptions,
+  type VolumeChannelDisplayOptions,
+  type VolumeDisplayOptions,
   isOrthographicCamera,
   ViewportCorner,
   RenderMode,
-} from "./types";
-import { Axis } from "./VolumeRenderSettings";
-import { PerChannelCallback } from "./loaders/IVolumeLoader";
+} from "./types.js";
+import { Axis } from "./VolumeRenderSettings.js";
+import { PerChannelCallback } from "./loaders/IVolumeLoader.js";
 
 // Constants are kept for compatibility reasons.
 export const RENDERMODE_RAYMARCH = RenderMode.RAYMARCH;

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -1,10 +1,10 @@
 import { Vector2, Vector3 } from "three";
 
-import Channel from "./Channel";
-import Histogram from "./Histogram";
-import { getColorByChannelIndex } from "./constants/colors";
-import { IVolumeLoader, LoadSpec, PerChannelCallback } from "./loaders/IVolumeLoader";
-import { estimateLevelForAtlas } from "./loaders/VolumeLoaderUtils";
+import Channel from "./Channel.js";
+import Histogram from "./Histogram.js";
+import { getColorByChannelIndex } from "./constants/colors.js";
+import { type IVolumeLoader, LoadSpec, type PerChannelCallback } from "./loaders/IVolumeLoader.js";
+import { estimateLevelForAtlas } from "./loaders/VolumeLoaderUtils.js";
 
 export type ImageInfo = Readonly<{
   name: string;

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -1,19 +1,19 @@
 import { Vector3, Object3D, Euler, Vector2, Box3 } from "three";
-
-import MeshVolume from "./MeshVolume";
-import RayMarchedAtlasVolume from "./RayMarchedAtlasVolume";
-import PathTracedVolume from "./PathTracedVolume";
-import { LUT_ARRAY_LENGTH } from "./Histogram";
-import Volume from "./Volume";
-import { VolumeDisplayOptions, VolumeChannelDisplayOptions } from "./types";
-import { FuseChannel, RenderMode } from "./types";
-import { ThreeJsPanel } from "./ThreeJsPanel";
-import { Light } from "./Light";
-import Channel from "./Channel";
-import { VolumeRenderImpl } from "./VolumeRenderImpl";
 import { Pane } from "tweakpane";
-import Atlas2DSlice from "./Atlas2DSlice";
-import { VolumeRenderSettings, SettingsFlags, Axis } from "./VolumeRenderSettings";
+
+import MeshVolume from "./MeshVolume.js";
+import RayMarchedAtlasVolume from "./RayMarchedAtlasVolume.js";
+import PathTracedVolume from "./PathTracedVolume.js";
+import { LUT_ARRAY_LENGTH } from "./Histogram.js";
+import Volume from "./Volume.js";
+import type { VolumeDisplayOptions, VolumeChannelDisplayOptions, FuseChannel } from "./types.js";
+import { RenderMode } from "./types.js";
+import { ThreeJsPanel } from "./ThreeJsPanel.js";
+import { Light } from "./Light.js";
+import Channel from "./Channel.js";
+import type { VolumeRenderImpl } from "./VolumeRenderImpl.js";
+import Atlas2DSlice from "./Atlas2DSlice.js";
+import { VolumeRenderSettings, SettingsFlags, Axis } from "./VolumeRenderSettings.js";
 
 type ColorArray = [number, number, number];
 type ColorObject = { r: number; g: number; b: number };

--- a/src/VolumeRenderImpl.ts
+++ b/src/VolumeRenderImpl.ts
@@ -1,8 +1,9 @@
 import { Object3D } from "three";
-import { ThreeJsPanel } from "./ThreeJsPanel";
-import { SettingsFlags, VolumeRenderSettings } from "./VolumeRenderSettings";
-import { FuseChannel } from "./types";
-import Channel from "./Channel";
+
+import { ThreeJsPanel } from "./ThreeJsPanel.js";
+import { SettingsFlags, VolumeRenderSettings } from "./VolumeRenderSettings.js";
+import type { FuseChannel } from "./types.js";
+import Channel from "./Channel.js";
 
 export interface VolumeRenderImpl {
   /**

--- a/src/VolumeRenderSettings.ts
+++ b/src/VolumeRenderSettings.ts
@@ -1,6 +1,7 @@
 import { Euler, Vector2, Vector3 } from "three";
-import Volume from "./Volume";
-import { Bounds } from "./types";
+
+import Volume from "./Volume.js";
+import type { Bounds } from "./types.js";
 
 /**
  * Marks groups of related settings that may have changed.

--- a/src/constants/volumePTshader.ts
+++ b/src/constants/volumePTshader.ts
@@ -1,5 +1,5 @@
 import { Texture, Vector2, Vector3, Vector4 } from "three";
-import { Light, AREA_LIGHT, SKY_LIGHT } from "../Light";
+import { Light, AREA_LIGHT, SKY_LIGHT } from "../Light.js";
 import pathTraceVertexShader from "./shaders/pathtrace.vert";
 import pathTraceFragmentShader from "./shaders/pathtrace.frag";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,27 @@
-import { RENDERMODE_PATHTRACE, RENDERMODE_RAYMARCH, View3d } from "./View3d";
-import Volume from "./Volume";
-import Channel from "./Channel";
-import VolumeMaker from "./VolumeMaker";
-import VolumeCache from "./VolumeCache";
-import RequestQueue from "./utils/RequestQueue";
-import SubscribableRequestQueue from "./utils/SubscribableRequestQueue";
-import Histogram from "./Histogram";
-import { ViewportCorner } from "./types";
-import { VolumeFileFormat, createVolumeLoader, PrefetchDirection } from "./loaders";
-import { LoadSpec } from "./loaders/IVolumeLoader";
-import { OMEZarrLoader } from "./loaders/OmeZarrLoader";
-import { JsonImageInfoLoader } from "./loaders/JsonImageInfoLoader";
-import { TiffLoader } from "./loaders/TiffLoader";
-import VolumeLoaderContext from "./workers/LoadWorkerHandle";
+import { RENDERMODE_PATHTRACE, RENDERMODE_RAYMARCH, View3d } from "./View3d.js";
+import Volume from "./Volume.js";
+import Channel from "./Channel.js";
+import VolumeMaker from "./VolumeMaker.js";
+import VolumeCache from "./VolumeCache.js";
+import RequestQueue from "./utils/RequestQueue.js";
+import SubscribableRequestQueue from "./utils/SubscribableRequestQueue.js";
+import Histogram from "./Histogram.js";
+import { ViewportCorner } from "./types.js";
+import { VolumeFileFormat, createVolumeLoader, PrefetchDirection } from "./loaders/index.js";
+import { LoadSpec } from "./loaders/IVolumeLoader.js";
+import { OMEZarrLoader } from "./loaders/OmeZarrLoader.js";
+import { JsonImageInfoLoader } from "./loaders/JsonImageInfoLoader.js";
+import { TiffLoader } from "./loaders/TiffLoader.js";
+import VolumeLoaderContext from "./workers/LoadWorkerHandle.js";
 
-import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light";
+import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
 
-export type { ImageInfo } from "./Volume";
-export type { ControlPoint, Lut } from "./Histogram";
-export type { CreateLoaderOptions } from "./loaders";
-export type { IVolumeLoader, PerChannelCallback } from "./loaders/IVolumeLoader";
-export type { ZarrLoaderFetchOptions } from "./loaders/OmeZarrLoader";
-export type { WorkerLoader } from "./workers/LoadWorkerHandle";
+export type { ImageInfo } from "./Volume.js";
+export type { ControlPoint, Lut } from "./Histogram.js";
+export type { CreateLoaderOptions } from "./loaders/index.js";
+export type { IVolumeLoader, PerChannelCallback } from "./loaders/IVolumeLoader.js";
+export type { ZarrLoaderFetchOptions } from "./loaders/OmeZarrLoader.js";
+export type { WorkerLoader } from "./workers/LoadWorkerHandle.js";
 export {
   Histogram,
   View3d,

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -1,8 +1,8 @@
 import { Box3, Vector3 } from "three";
 
-import Volume, { ImageInfo } from "../Volume";
-import { buildDefaultMetadata } from "./VolumeLoaderUtils";
-import { PrefetchDirection } from "./zarr_utils/types";
+import Volume, { ImageInfo } from "../Volume.js";
+import { buildDefaultMetadata } from "./VolumeLoaderUtils.js";
+import { PrefetchDirection } from "./zarr_utils/types.js";
 
 export class LoadSpec {
   time = 0;

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -2,13 +2,13 @@ import { Box3, Vector2, Vector3 } from "three";
 
 import {
   ThreadableVolumeLoader,
-  LoadSpec,
-  RawChannelDataCallback,
+  type LoadSpec,
+  type RawChannelDataCallback,
   VolumeDims,
-  LoadedVolumeInfo,
-} from "./IVolumeLoader";
-import { ImageInfo } from "../Volume";
-import VolumeCache from "../VolumeCache";
+  type LoadedVolumeInfo,
+} from "./IVolumeLoader.js";
+import type { ImageInfo } from "../Volume.js";
+import VolumeCache from "../VolumeCache.js";
 
 interface PackedChannelsImage {
   name: string;

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -7,24 +7,24 @@ import { AbsolutePath } from "@zarrita/storage";
 // Getting it from the top-level package means we don't get its type. This is also a bug, but it's more acceptable.
 import { FetchStore } from "zarrita";
 
-import { ImageInfo } from "../Volume";
-import VolumeCache from "../VolumeCache";
-import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
+import { ImageInfo } from "../Volume.js";
+import VolumeCache from "../VolumeCache.js";
+import SubscribableRequestQueue from "../utils/SubscribableRequestQueue.js";
 import {
   ThreadableVolumeLoader,
   LoadSpec,
-  RawChannelDataCallback,
+  type RawChannelDataCallback,
   VolumeDims,
-  LoadedVolumeInfo,
-} from "./IVolumeLoader";
+  type LoadedVolumeInfo,
+} from "./IVolumeLoader.js";
 import {
   composeSubregion,
   computePackedAtlasDims,
   convertSubregionToPixels,
   unitNameToSymbol,
-} from "./VolumeLoaderUtils";
-import ChunkPrefetchIterator from "./zarr_utils/ChunkPrefetchIterator";
-import WrappedStore from "./zarr_utils/WrappedStore";
+} from "./VolumeLoaderUtils.js";
+import ChunkPrefetchIterator from "./zarr_utils/ChunkPrefetchIterator.js";
+import WrappedStore from "./zarr_utils/WrappedStore.js";
 import {
   getDimensionCount,
   getScale,
@@ -32,8 +32,8 @@ import {
   orderByTCZYX,
   pickLevelToLoad,
   remapAxesToTCZYX,
-} from "./zarr_utils/utils";
-import {
+} from "./zarr_utils/utils.js";
+import type {
   OMEZarrMetadata,
   SubscriberId,
   TCZYX,
@@ -41,7 +41,7 @@ import {
   NumericZarrArray,
   OMEMultiscale,
   OmeroTransitionalMetadata,
-} from "./zarr_utils/types";
+} from "./zarr_utils/types.js";
 
 const CHUNK_REQUEST_CANCEL_REASON = "chunk request cancelled";
 

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -6,9 +6,9 @@ import {
   RawChannelDataCallback,
   VolumeDims,
   LoadedVolumeInfo,
-} from "./IVolumeLoader";
-import { ImageInfo } from "../Volume";
-import { JsonImageInfoLoader } from "./JsonImageInfoLoader";
+} from "./IVolumeLoader.js";
+import { ImageInfo } from "../Volume.js";
+import { JsonImageInfoLoader } from "./JsonImageInfoLoader.js";
 
 class OpenCellLoader extends ThreadableVolumeLoader {
   async loadDims(_: LoadSpec): Promise<VolumeDims[]> {

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -4,12 +4,12 @@ import { Vector3 } from "three";
 import {
   ThreadableVolumeLoader,
   LoadSpec,
-  RawChannelDataCallback,
+  type RawChannelDataCallback,
   VolumeDims,
-  LoadedVolumeInfo,
-} from "./IVolumeLoader";
-import { computePackedAtlasDims } from "./VolumeLoaderUtils";
-import { ImageInfo } from "../Volume";
+  type LoadedVolumeInfo,
+} from "./IVolumeLoader.js";
+import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
+import type { ImageInfo } from "../Volume.js";
 
 function prepareXML(xml: string): string {
   // trim trailing unicode zeros?

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -1,7 +1,7 @@
 import "regenerator-runtime/runtime";
 import { Box3, Vector2, Vector3 } from "three";
 
-import { ImageInfo } from "../Volume";
+import { ImageInfo } from "../Volume.js";
 
 const MAX_ATLAS_EDGE = 4096;
 

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -1,4 +1,3 @@
-import "regenerator-runtime/runtime";
 import { Box3, Vector2, Vector3 } from "three";
 
 import { ImageInfo } from "../Volume.js";

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -1,10 +1,9 @@
-import { ThreadableVolumeLoader } from "./IVolumeLoader";
-
-import { OMEZarrLoader, ZarrLoaderFetchOptions } from "./OmeZarrLoader";
-import { JsonImageInfoLoader } from "./JsonImageInfoLoader";
-import { TiffLoader } from "./TiffLoader";
-import VolumeCache from "../VolumeCache";
-import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
+import { ThreadableVolumeLoader } from "./IVolumeLoader.js";
+import { OMEZarrLoader, type ZarrLoaderFetchOptions } from "./OmeZarrLoader.js";
+import { JsonImageInfoLoader } from "./JsonImageInfoLoader.js";
+import { TiffLoader } from "./TiffLoader.js";
+import VolumeCache from "../VolumeCache.js";
+import SubscribableRequestQueue from "../utils/SubscribableRequestQueue.js";
 
 export { PrefetchDirection } from "./zarr_utils/types";
 

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -5,7 +5,7 @@ import { TiffLoader } from "./TiffLoader.js";
 import VolumeCache from "../VolumeCache.js";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue.js";
 
-export { PrefetchDirection } from "./zarr_utils/types";
+export { PrefetchDirection } from "./zarr_utils/types.js";
 
 export const enum VolumeFileFormat {
   ZARR = "zarr",

--- a/src/loaders/zarr_utils/types.ts
+++ b/src/loaders/zarr_utils/types.ts
@@ -1,7 +1,7 @@
 import * as zarr from "@zarrita/core";
 
-import WrappedStore from "./WrappedStore";
-import SubscribableRequestQueue from "../../utils/SubscribableRequestQueue";
+import type WrappedStore from "./WrappedStore.js";
+import type SubscribableRequestQueue from "../../utils/SubscribableRequestQueue.js";
 
 export type TCZYX<T> = [T, T, T, T, T];
 export type SubscriberId = ReturnType<SubscribableRequestQueue["addSubscriber"]>;

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -1,7 +1,7 @@
 import { Vector3 } from "three";
-import { LoadSpec } from "../IVolumeLoader";
-import { estimateLevelForAtlas } from "../VolumeLoaderUtils";
-import { OMEAxis, OMECoordinateTransformation, OMEDataset, OMEMultiscale, TCZYX } from "./types";
+import { LoadSpec } from "../IVolumeLoader.js";
+import { estimateLevelForAtlas } from "../VolumeLoaderUtils.js";
+import { OMEAxis, OMECoordinateTransformation, OMEDataset, OMEMultiscale, TCZYX } from "./types.js";
 
 /** Turns `axesTCZYX` into the number of dimensions in the array */
 export const getDimensionCount = ([t, c, z]: TCZYX<number>) => 2 + Number(t > -1) + Number(c > -1) + Number(z > -1);

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -1,4 +1,4 @@
-import RequestQueue from "./RequestQueue";
+import RequestQueue from "./RequestQueue.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Resolver = (value?: any) => void;

--- a/src/workers/LoadWorkerHandle.ts
+++ b/src/workers/LoadWorkerHandle.ts
@@ -1,23 +1,23 @@
-import { ImageInfo } from "../Volume";
-import { CreateLoaderOptions, PrefetchDirection, VolumeFileFormat, pathToFileType } from "../loaders";
+import { ImageInfo } from "../Volume.js";
+import { CreateLoaderOptions, PrefetchDirection, VolumeFileFormat, pathToFileType } from "../loaders/index.js";
 import {
   ThreadableVolumeLoader,
   LoadSpec,
   RawChannelDataCallback,
   VolumeDims,
   LoadedVolumeInfo,
-} from "../loaders/IVolumeLoader";
-import { TiffLoader } from "../loaders/TiffLoader";
+} from "../loaders/IVolumeLoader.js";
+import { TiffLoader } from "../loaders/TiffLoader.js";
 import {
   WorkerMsgType,
-  WorkerRequest,
-  WorkerRequestPayload,
-  WorkerResponse,
-  WorkerResponsePayload,
-  ChannelLoadEvent,
+  type WorkerRequest,
+  type WorkerRequestPayload,
+  type WorkerResponse,
+  type WorkerResponsePayload,
+  type ChannelLoadEvent,
   WorkerResponseResult,
-} from "./types";
-import { rebuildImageInfo, rebuildLoadSpec } from "./util";
+} from "./types.js";
+import { rebuildImageInfo, rebuildLoadSpec } from "./util.js";
 
 type StoredPromise<T extends WorkerMsgType> = {
   type: T;

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -1,17 +1,11 @@
-import VolumeCache from "../VolumeCache";
-import { VolumeFileFormat, createVolumeLoader, pathToFileType } from "../loaders";
-import { ThreadableVolumeLoader } from "../loaders/IVolumeLoader";
-import RequestQueue from "../utils/RequestQueue";
-import SubscribableRequestQueue from "../utils/SubscribableRequestQueue";
-import {
-  WorkerMsgType,
-  WorkerRequest,
-  WorkerRequestPayload,
-  WorkerResponse,
-  WorkerResponseResult,
-  WorkerResponsePayload,
-} from "./types";
-import { rebuildImageInfo, rebuildLoadSpec } from "./util";
+import VolumeCache from "../VolumeCache.js";
+import { VolumeFileFormat, createVolumeLoader, pathToFileType } from "../loaders/index.js";
+import { ThreadableVolumeLoader } from "../loaders/IVolumeLoader.js";
+import RequestQueue from "../utils/RequestQueue.js";
+import SubscribableRequestQueue from "../utils/SubscribableRequestQueue.js";
+import type { WorkerRequest, WorkerRequestPayload, WorkerResponse, WorkerResponsePayload } from "./types.js";
+import { WorkerMsgType, WorkerResponseResult } from "./types.js";
+import { rebuildImageInfo, rebuildLoadSpec } from "./util.js";
 
 let cache: VolumeCache | undefined = undefined;
 let queue: RequestQueue | undefined = undefined;

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -1,6 +1,6 @@
-import { ImageInfo } from "../Volume";
-import { CreateLoaderOptions, PrefetchDirection } from "../loaders";
-import { LoadSpec, LoadedVolumeInfo, VolumeDims } from "../loaders/IVolumeLoader";
+import type { ImageInfo } from "../Volume.js";
+import type { CreateLoaderOptions, PrefetchDirection } from "../loaders/index.js";
+import type { LoadSpec, LoadedVolumeInfo, VolumeDims } from "../loaders/IVolumeLoader.js";
 
 /** The types of requests that can be made to the worker. Mostly corresponds to methods on `IVolumeLoader`. */
 export const enum WorkerMsgType {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -58,6 +58,9 @@ export default {
   ],
   resolve: {
     extensions: [".js", ".ts"],
+    extensionAlias: {
+      ".js": [".js", ".ts"],
+    }
   },
   module: {
     rules: [


### PR DESCRIPTION
Review time: pretty quick (15min)

#186 added `"type": "module"` to package.json. Unknown to us, doing this caused this package to come under stricter module resolution rules. Specifically, paths to modules must be fully specified: no leaving off the .js extension in a file path, and no expecting the resolver to implicitly find an index.js if the path is a directory. So while the test app still works just fine on main, the package breaks when used by any downstream packages (website-3d-cell-viewer).

The rules and (conflicting) standards around how the JS module system should work are... complicated... but TypeScript's [current guidance](https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-specifiers-are-not-transformed) seems to be that modules should be referenced by the fully qualified path they will have *after they are built*, and TypeScript will handle resolving back from js-land to ts-land when type checking:

> There is no compiler option that enables transforming, substituting, or rewriting module specifiers. Consequently, module specifiers must be written in a way that works for the code’s target runtime or bundler, and it’s TypeScript’s job to understand those *output*-relative specifiers.

So this PR fixes the issue by fully specifying all imports across this project, as TypeScript tells us to do. It also adds a bunch of `type` keywords to imports to help TypeScript know to elide them.

### Steps to verify:

- Link your local copy of this package to website-3d-cell-viewer: run `npm link` in volume-viewer and `npm link @aics/volume-viewer` in website-3d-cell-viewer.

Then, for whichever branch you want to test:
- `npm run build` volume-viewer
- `npm start` website-3d-cell-viewer

Expected behavior on `main`: lots of errors.

Expected behavior on this branch (`fix/fully-qualified-imports`): works just fine.