### PR TITLE
consistent transfer functions when playing through time

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ view3D.addVolume(aimg);
 // each element in volumeData is a flattened 3d volume stored in xyz order in a Uint8Array.
 // Intensities must have been be scaled to fit in uint8.
 for (let i = 0; i < volumeData.length; ++i) {
-  aimg.setChannelDataFromVolume(i, volumeData[i]);
+  aimg.setChannelDataFromVolume(i, volumeData[i], [0, 255]);
   // optional: initialize with a lookup table suitable for visualizing noisy biological data
   aimg.channels[i].lutGenerator_percentiles(0.5, 0.998);
 }

--- a/public/index.ts
+++ b/public/index.ts
@@ -21,6 +21,7 @@ import { OpenCellLoader } from "../src/loaders/OpenCellLoader";
 import { State, TestDataSpec } from "./types";
 import { getDefaultImageInfo } from "../src/Volume";
 import VolumeLoaderContext from "../src/workers/LoadWorkerHandle";
+import { DATARANGE_UINT8 } from "../src/types";
 
 const CACHE_MAX_SIZE = 1_000_000_000;
 const CONCURRENCY_LIMIT = 8;
@@ -848,7 +849,7 @@ function loadImageData(jsonData: ImageInfo, volumeData: Uint8Array[]) {
     // according to jsonData.tile_width*jsonData.tile_height*jsonData.tiles
     // (first row of first plane is the first data in
     // the layout, then second row of first plane, etc)
-    vol.setChannelDataFromVolume(i, volumeData[i]);
+    vol.setChannelDataFromVolume(i, volumeData[i], DATARANGE_UINT8);
 
     setInitialRenderMode();
 

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -93,17 +93,7 @@ export default class Channel {
   }
 
   public setRawDataRange(min: number, max: number): void {
-    // If the new max is greater than the old max, then
-    // the lut's max end will move inward to the left.
-    // This is another way of saying that the new max's index is greater than 255 in the old lut
-
-    // if the new min is less than the old min, then
-    // the lut's min end will move inward to the right.
-    // This is another way of saying that the new min's index is less than 0 in the old lut
-
-    // remap the lut which was based on originalMin and originalMax to new min and max
-    // this is done by scaling the lut values by the ratio of the new range to the old range
-
+    // remap the lut which was based on rawMin and rawMax to new min and max
     const newLut = remapLut(this.lut, this.rawMin, this.rawMax, min, max);
     this.rawMin = min;
     this.rawMax = max;

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -1,5 +1,5 @@
 import { DataTexture, RedFormat, UnsignedByteType, RGBAFormat, LinearFilter, NearestFilter } from "three";
-import Histogram, { LUT_ARRAY_LENGTH } from "./Histogram.js";
+import Histogram, { LUT_ARRAY_LENGTH, updateLutForNewRange } from "./Histogram.js";
 
 interface ChannelImageData {
   /** Returns the one-dimensional array containing the data in RGBA order, as integers in the range 0 to 255. */
@@ -23,10 +23,14 @@ export default class Channel {
   public dims: [number, number, number];
   public dataTexture: DataTexture;
   public lutTexture: DataTexture;
+  public rawMin: number;
+  public rawMax: number;
 
   constructor(name: string) {
     this.loaded = false;
     this.imgData = { data: new Uint8ClampedArray(), width: 0, height: 0 };
+    this.rawMin = 0;
+    this.rawMax = 0;
 
     // on gpu
     this.dataTexture = new DataTexture(new Uint8Array(), 0, 0);
@@ -85,6 +89,24 @@ export default class Channel {
     this.lutTexture.needsUpdate = true;
 
     return ret;
+  }
+
+  public setRawDataRange(min: number, max: number): void {
+    // If the new max is greater than the old max, then
+    // the lut's max end will move inward to the left.
+    // This is another way of saying that the new max's index is greater than 255 in the old lut
+
+    // if the new min is less than the old min, then
+    // the lut's min end will move inward to the right.
+    // This is another way of saying that the new min's index is less than 0 in the old lut
+
+    // remap the lut which was based on originalMin and originalMax to new min and max
+    // this is done by scaling the lut values by the ratio of the new range to the old range
+
+    const newLut = updateLutForNewRange(this.lut, this.rawMin, this.rawMax, min, max);
+    this.rawMin = min;
+    this.rawMax = max;
+    this.lut = newLut;
   }
 
   public getHistogram(): Histogram {

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -602,12 +602,7 @@ export function remapLut(lut: Uint8Array, oldMin: number, oldMax: number, newMin
   // Build new lut by sampling from old lut.
   for (let i = 0; i < LUT_ENTRIES; ++i) {
     let iOld = remapDomain(i, 0, LUT_ENTRIES - 1, oldMin, oldMax, newMin, newMax);
-    if (iOld < 0) {
-      iOld = 0;
-    }
-    if (iOld > LUT_ENTRIES - 1) {
-      iOld = LUT_ENTRIES - 1;
-    }
+    iOld = clamp(iOld, 0, LUT_ENTRIES-1);
     // find the indices above and below for interpolation
     const i0 = Math.floor(iOld);
     const i1 = Math.ceil(iOld);

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -565,13 +565,7 @@ export default class Histogram {
   /* eslint-enable @typescript-eslint/naming-convention */
 }
 
-export function updateLutForNewRange(
-  lut: Uint8Array,
-  oldMin: number,
-  oldMax: number,
-  newMin: number,
-  newMax: number
-): Uint8Array {
+export function remapLut(lut: Uint8Array, oldMin: number, oldMax: number, newMin: number, newMax: number): Uint8Array {
   const newLut = new Uint8Array(LUT_ARRAY_LENGTH);
 
   // we will find what intensity is at each index in the new range,

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -588,6 +588,12 @@ function remapDomain(
   return remapped;
 }
 
+// If the new max is greater than the old max, then
+// the lut's max end will move inward to the left.
+// This is another way of saying that the new max's index is greater than 255 in the old lut
+// If the new min is less than the old min, then
+// the lut's min end will move inward to the right.
+// This is another way of saying that the new min's index is less than 0 in the old lut
 export function remapLut(lut: Uint8Array, oldMin: number, oldMax: number, newMin: number, newMax: number): Uint8Array {
   const newLut = new Uint8Array(LUT_ARRAY_LENGTH);
 

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -579,10 +579,10 @@ function lookupInterp(lut: Uint8Array, pct: number): [number, number, number, nu
   //console.log(i0, i1, ai, a);
   //console.log(lut[i0], lut[i1]);
   return [
-    lut[i0 + 0] * ai + lut[i1 + 0] * a,
-    lut[i0 + 1] * ai + lut[i1 + 1] * a,
-    lut[i0 + 2] * ai + lut[i1 + 2] * a,
-    lut[i0 + 3] * ai + lut[i1 + 3] * a,
+    Math.round(lut[i0 + 0] * ai + lut[i1 + 0] * a),
+    Math.round(lut[i0 + 1] * ai + lut[i1 + 1] * a),
+    Math.round(lut[i0 + 2] * ai + lut[i1 + 2] * a),
+    Math.round(lut[i0 + 3] * ai + lut[i1 + 3] * a),
   ];
 }
 

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -565,4 +565,69 @@ export default class Histogram {
   /* eslint-enable @typescript-eslint/naming-convention */
 }
 
+function lookupInterp(lut: Uint8Array, x: number): [number, number, number, number] {
+  const i = Math.floor(x);
+  const a = x - i;
+  const ai = 1 - a;
+  const i0 = i * 4;
+  let i1 = i0 + 4;
+  if (i1 > 255) {
+    i1 = 255;
+  }
+  return [
+    lut[i0 + 0] * ai + lut[i1 + 0] * a,
+    lut[i0 + 1] * ai + lut[i1 + 1] * a,
+    lut[i0 + 2] * ai + lut[i1 + 2] * a,
+    lut[i0 + 3] * ai + lut[i1 + 3] * a,
+  ];
+}
+
+export function updateLutForNewRange(
+  lut: Uint8Array,
+  oldMin: number,
+  oldMax: number,
+  newMin: number,
+  newMax: number
+): Uint8Array {
+  const newRange = newMax - newMin;
+  const oldRange = oldMax - oldMin;
+  const scale = newRange / oldRange;
+
+  const newLut = new Uint8Array(LUT_ARRAY_LENGTH);
+
+  // find what lut index corresponds to the new min and max
+  const minIndex = Math.floor(((newMin - oldMin) / oldRange) * LUT_ENTRIES);
+  const maxIndex = Math.floor(((newMax - oldMin) / oldRange) * LUT_ENTRIES);
+  // if either of these values is inside the range, then we will need to extend.
+  // start with the min end of the range
+  if (minIndex > 0) {
+    for (let i = 0; i < minIndex; ++i) {
+      newLut[i * 4 + 0] = lut[minIndex * 4 + 0];
+      newLut[i * 4 + 1] = lut[minIndex * 4 + 1];
+      newLut[i * 4 + 2] = lut[minIndex * 4 + 2];
+      newLut[i * 4 + 3] = lut[minIndex * 4 + 3];
+    }
+  }
+  //now do the middle part.  This is where we scale (stretch/compress) the domain.
+  for (let i = Math.max(minIndex, 0); i < Math.min(LUT_ENTRIES, maxIndex); ++i) {
+    const newIndex = Math.floor((i - minIndex) / scale); // ?????
+    // lerp the values!
+    const val = lookupInterp(lut, newIndex);
+    newLut[newIndex * 4 + 0] = val[0];
+    newLut[newIndex * 4 + 1] = val[1];
+    newLut[newIndex * 4 + 2] = val[2];
+    newLut[newIndex * 4 + 3] = val[3];
+  }
+  // now do the max end of the range
+  if (maxIndex < LUT_ENTRIES) {
+    for (let i = maxIndex; i < LUT_ENTRIES; ++i) {
+      newLut[i * 4 + 0] = lut[maxIndex * 4 + 0];
+      newLut[i * 4 + 1] = lut[maxIndex * 4 + 1];
+      newLut[i * 4 + 2] = lut[maxIndex * 4 + 2];
+      newLut[i * 4 + 3] = lut[maxIndex * 4 + 3];
+    }
+  }
+  return newLut;
+}
+
 export { LUT_ARRAY_LENGTH };

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -576,13 +576,12 @@ function lookupInterp(lut: Uint8Array, pct: number): [number, number, number, nu
   if (i1 > LUT_ARRAY_LENGTH - 4) {
     i1 = LUT_ARRAY_LENGTH - 4;
   }
-  //console.log(i0, i1, ai, a);
-  //console.log(lut[i0], lut[i1]);
+  // TODO why does ceil work here and not round?
   return [
-    Math.round(lut[i0 + 0] * ai + lut[i1 + 0] * a),
-    Math.round(lut[i0 + 1] * ai + lut[i1 + 1] * a),
-    Math.round(lut[i0 + 2] * ai + lut[i1 + 2] * a),
-    Math.round(lut[i0 + 3] * ai + lut[i1 + 3] * a),
+    Math.ceil(lut[i0 + 0] * ai + lut[i1 + 0] * a),
+    Math.ceil(lut[i0 + 1] * ai + lut[i1 + 1] * a),
+    Math.ceil(lut[i0 + 2] * ai + lut[i1 + 2] * a),
+    Math.ceil(lut[i0 + 3] * ai + lut[i1 + 3] * a),
   ];
 }
 

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -565,6 +565,29 @@ export default class Histogram {
   /* eslint-enable @typescript-eslint/naming-convention */
 }
 
+// We have an intensity value that is in the range of valueMin to valueMax.
+// This domain is assumed to have been remapped from oldMin to oldMax.
+// We now wish to find the intensity value that corresponds to the same relative position in the new domain of newMin to newMax.
+// For our Luts valueMin will always be 0, and valueMax will always be 255.
+// oldMin and oldMax will be the domain of the original raw data intensities.
+// newMin and newMax will be the domain of the new raw data intensities.
+function remapDomain(
+  value: number,
+  valueMin: number,
+  valueMax: number,
+  oldMin: number,
+  oldMax: number,
+  newMin: number,
+  newMax: number
+): number {
+  const pctOfRange = (value - valueMin) / (valueMax - valueMin);
+  const newValue = (newMax - newMin) * pctOfRange + newMin;
+  // now locate this value as a relative index in the old range
+  const pctOfOldRange = (newValue - oldMin) / (oldMax - oldMin);
+  const remapped = valueMin + pctOfOldRange * (valueMax - valueMin);
+  return remapped;
+}
+
 export function remapLut(lut: Uint8Array, oldMin: number, oldMax: number, newMin: number, newMax: number): Uint8Array {
   const newLut = new Uint8Array(LUT_ARRAY_LENGTH);
 
@@ -572,22 +595,14 @@ export function remapLut(lut: Uint8Array, oldMin: number, oldMax: number, newMin
   // and then try to sample the pre-existing lut as if it spans the old range.
   // Build new lut by sampling from old lut.
   for (let i = 0; i < LUT_ENTRIES; ++i) {
-    const pctOfRange = i / (LUT_ENTRIES - 1);
-    const newIntensityOfI = (newMax - newMin) * pctOfRange + newMin;
-    // now locate this intensity value as a relative index in the old range
-    let pctOfOldRange = (newIntensityOfI - oldMin) / (oldMax - oldMin);
-    //console.log(`Ii=${newIntensityOfI}, pctOfRange=${pctOfRange}, pctOfOldRange=${pctOfOldRange}`);
-
-    // note that this clamping will not "continue" a slope at the edge of the domain.
-    // it will flatline.
-    if (pctOfOldRange < 0) {
-      pctOfOldRange = 0;
+    let iOld = remapDomain(i, 0, LUT_ENTRIES - 1, oldMin, oldMax, newMin, newMax);
+    if (iOld < 0) {
+      iOld = 0;
     }
-    if (pctOfOldRange > 1) {
-      pctOfOldRange = 1;
+    if (iOld > LUT_ENTRIES - 1) {
+      iOld = LUT_ENTRIES - 1;
     }
-    // get the two indices that pctOfOldRange is between
-    const iOld = pctOfOldRange * (LUT_ENTRIES - 1);
+    // find the indices above and below for interpolation
     const i0 = Math.floor(iOld);
     const i1 = Math.ceil(iOld);
     const pct = iOld - i0;
@@ -600,6 +615,80 @@ export function remapLut(lut: Uint8Array, oldMin: number, oldMax: number, newMin
   }
 
   return newLut;
+}
+
+export function remapControlPoints(
+  controlPoints: ControlPoint[],
+  oldMin: number,
+  oldMax: number,
+  newMin: number,
+  newMax: number
+): ControlPoint[] {
+  const newControlPoints: ControlPoint[] = [];
+
+  // assume control point x domain 0-255 is mapped to oldMin-oldMax
+
+  // remap all cp x values.
+  // interpolate all new colors and opacities
+  // then see if we need to clip?
+  for (let i = 0; i < controlPoints.length; ++i) {
+    const cp = controlPoints[i];
+    const iOld = remapDomain(cp.x, 0, LUT_ENTRIES - 1, oldMin, oldMax, newMin, newMax);
+    const newCP: ControlPoint = {
+      x: iOld,
+      opacity: cp.opacity,
+      color: [cp.color[0], cp.color[1], cp.color[2]],
+    };
+    newControlPoints.push(newCP);
+  }
+  // now fix up any control points that are out of bounds?
+  // For a CP less than 0, shift it to 0 and interpolate the values according to the slope
+  // For a CP greater than 255, shift it to 255 and interpolate the values according to the slope
+  // All others out of this range can then be dropped.
+  // We will look above and below each cp to see if it's on a boundary.
+  const resultControlPoints: ControlPoint[] = [];
+
+  for (let i = 0; i < newControlPoints.length; ++i) {
+    const cp = newControlPoints[i];
+    const cpPrev = i > 0 ? newControlPoints[i - 1] : cp;
+    const cpNext = i < newControlPoints.length - 1 ? newControlPoints[i + 1] : cp;
+
+    if (cp.x < 0 && cpNext.x > 0) {
+      // interpolate
+      const pct = (0 - cp.x) / (cpNext.x - cp.x);
+      cp.opacity = lerp(cp.opacity, cpNext.opacity, pct);
+      cp.color[0] = lerp(cp.color[0], cpNext.color[0], pct);
+      cp.color[1] = lerp(cp.color[1], cpNext.color[1], pct);
+      cp.color[2] = lerp(cp.color[2], cpNext.color[2], pct);
+      // shift cp to 0
+      cp.x = 0;
+    } else if (cp.x > 255 && cpPrev.x < 255) {
+      // interpolate
+      const pct = (cp.x - 255) / (cp.x - cpPrev.x);
+      cp.opacity = lerp(cpPrev.opacity, cp.opacity, pct);
+      cp.color[0] = lerp(cpPrev.color[0], cp.color[0], pct);
+      cp.color[1] = lerp(cpPrev.color[1], cp.color[1], pct);
+      cp.color[2] = lerp(cpPrev.color[2], cp.color[2], pct);
+      // shift cp to 255
+      cp.x = 255;
+    }
+    if (cp.x >= 0 && cp.x <= 255) {
+      resultControlPoints.push(cp);
+    }
+  }
+
+  // lastly, add a point for start and end if needed.
+  if (resultControlPoints[0].x !== 0) {
+    resultControlPoints.unshift({ x: 0, opacity: resultControlPoints[0].opacity, color: resultControlPoints[0].color });
+  }
+  if (resultControlPoints[resultControlPoints.length - 1].x !== 255) {
+    resultControlPoints.push({
+      x: 255,
+      opacity: resultControlPoints[resultControlPoints.length - 1].opacity,
+      color: resultControlPoints[resultControlPoints.length - 1].color,
+    });
+  }
+  return resultControlPoints;
 }
 
 export { LUT_ARRAY_LENGTH };

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -345,7 +345,7 @@ export default class Volume {
    * @param {number} channelIndex
    * @param {Uint8Array} volumeData
    */
-  setChannelDataFromVolume(channelIndex: number, volumeData: Uint8Array): void {
+  setChannelDataFromVolume(channelIndex: number, volumeData: Uint8Array, range: [number, number] = [0, 255]): void {
     const { subregionSize, atlasTileDims } = this.imageInfo;
     this.channels[channelIndex].setFromVolumeData(
       volumeData,
@@ -353,7 +353,9 @@ export default class Volume {
       subregionSize.y,
       subregionSize.z,
       atlasTileDims.x * subregionSize.x,
-      atlasTileDims.y * subregionSize.y
+      atlasTileDims.y * subregionSize.y,
+      range[0],
+      range[1]
     );
     this.onChannelLoaded([channelIndex]);
   }

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -373,7 +373,7 @@ export default class Volume {
    * @param {number} channelIndex
    * @param {Uint8Array} volumeData
    */
-  setChannelDataFromVolume(channelIndex: number, volumeData: Uint8Array, range: [number, number] = [0, 255]): void {
+  setChannelDataFromVolume(channelIndex: number, volumeData: Uint8Array, range: [number, number]): void {
     const { subregionSize, atlasTileDims } = this.imageInfo;
     this.channels[channelIndex].setFromVolumeData(
       volumeData,

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -41,8 +41,19 @@ export type LoadedVolumeInfo = {
  */
 export type PerChannelCallback = (volume: Volume, channelIndex: number) => void;
 
-// allow lists of channel indices and data arrays to be passed to the callback
-export type RawChannelDataCallback = (channelIndex: number[], data: Uint8Array[], ranges: [number, number][], atlasDims?: [number, number]) => void;
+/**
+ * @callback RawChannelDataCallback - allow lists of channel indices and data arrays to be passed to the callback
+ * @param {number[]} channelIndex - The indices of the channels that were loaded
+ * @param {Uint8Array[]} data - The raw data for each channel (renormalized to 0-255 range)
+ * @param {[number, number][]} ranges - The min and max values for each channel in their original range
+ * @param {[number, number]} atlasDims - The dimensions of the atlas, if the data is in an atlas format
+ */
+export type RawChannelDataCallback = (
+  channelIndex: number[],
+  data: Uint8Array[],
+  ranges: [number, number][],
+  atlasDims?: [number, number]
+) => void;
 
 /**
  * Loads volume data from a source specified by a `LoadSpec`.
@@ -138,10 +149,11 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
       for (let i = 0; i < channelIndices.length; i++) {
         const channelIndex = channelIndices[i];
         const data = dataArrays[i];
+        const range = ranges[i];
         if (atlasDims) {
           volume.setChannelDataFromAtlas(channelIndex, data, atlasDims[0], atlasDims[1]);
         } else {
-          volume.setChannelDataFromVolume(channelIndex, data);
+          volume.setChannelDataFromVolume(channelIndex, data, range);
         }
         onChannelLoaded?.(volume, channelIndex);
       }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -42,7 +42,7 @@ export type LoadedVolumeInfo = {
 export type PerChannelCallback = (volume: Volume, channelIndex: number) => void;
 
 // allow lists of channel indices and data arrays to be passed to the callback
-export type RawChannelDataCallback = (channelIndex: number[], data: Uint8Array[], atlasDims?: [number, number]) => void;
+export type RawChannelDataCallback = (channelIndex: number[], data: Uint8Array[], ranges: [number, number][], atlasDims?: [number, number]) => void;
 
 /**
  * Loads volume data from a source specified by a `LoadSpec`.
@@ -134,7 +134,7 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
     loadSpecOverride?: LoadSpec,
     onChannelLoaded?: PerChannelCallback
   ): Promise<void> {
-    const onChannelData: RawChannelDataCallback = (channelIndices, dataArrays, atlasDims) => {
+    const onChannelData: RawChannelDataCallback = (channelIndices, dataArrays, ranges, atlasDims) => {
       for (let i = 0; i < channelIndices.length; i++) {
         const channelIndex = channelIndices[i];
         const data = dataArrays[i];

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -9,6 +9,7 @@ import {
 } from "./IVolumeLoader.js";
 import type { ImageInfo } from "../Volume.js";
 import VolumeCache from "../VolumeCache.js";
+import { DATARANGE_UINT8 } from "../types.js";
 
 interface PackedChannelsImage {
   name: string;
@@ -220,7 +221,8 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
         const chindex = image.channels[j];
         const cacheResult = cache?.get(`${image.name}/${chindex}`);
         if (cacheResult) {
-          onData([chindex], [new Uint8Array(cacheResult)], [[0, 255]]);
+          // all data coming from this loader is natively 8-bit
+          onData([chindex], [new Uint8Array(cacheResult)], [DATARANGE_UINT8]);
         } else {
           cacheHit = false;
           // we can stop checking because we know we are going to have to fetch the whole batch
@@ -270,7 +272,8 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
         const chindex = image.channels[ch];
         cache?.insert(`${image.name}/${chindex}`, channelsBits[ch]);
         // NOTE: the atlas dimensions passed in here are currently unused by `JSONImageInfoLoader`
-        onData([chindex], [channelsBits[ch]], [[0, 255]], [bitmap.width, bitmap.height]);
+        // all data coming from this loader is natively 8-bit
+        onData([chindex], [channelsBits[ch]], [DATARANGE_UINT8], [bitmap.width, bitmap.height]);
       }
     });
   }

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -175,7 +175,8 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
 
     const w = imageInfo.atlasTileDims.x * imageInfo.volumeSize.x;
     const h = imageInfo.atlasTileDims.y * imageInfo.volumeSize.y;
-    const wrappedOnData = (ch: number[], data: Uint8Array[]) => onData(ch, data, [w, h]);
+    const wrappedOnData = (ch: number[], data: Uint8Array[], ranges: [number, number][]) =>
+      onData(ch, data, ranges, [w, h]);
     JsonImageInfoLoader.loadVolumeAtlasData(images, wrappedOnData, this.cache);
 
     const adjustedLoadSpec = {
@@ -219,7 +220,7 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
         const chindex = image.channels[j];
         const cacheResult = cache?.get(`${image.name}/${chindex}`);
         if (cacheResult) {
-          onData([chindex], [new Uint8Array(cacheResult)]);
+          onData([chindex], [new Uint8Array(cacheResult)], [[0, 255]]);
         } else {
           cacheHit = false;
           // we can stop checking because we know we are going to have to fetch the whole batch
@@ -269,7 +270,7 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
         const chindex = image.channels[ch];
         cache?.insert(`${image.name}/${chindex}`, channelsBits[ch]);
         // NOTE: the atlas dimensions passed in here are currently unused by `JSONImageInfoLoader`
-        onData([chindex], [channelsBits[ch]], [bitmap.width, bitmap.height]);
+        onData([chindex], [channelsBits[ch]], [[0, 255]], [bitmap.width, bitmap.height]);
       }
     });
   }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -264,7 +264,9 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
 
     const channelNames = this.omeroMetadata.channels.map((ch) => ch.label);
 
-    const scale5d = this.getScale(levelToLoad);
+    // for physicalPixelSize, we use the scale of the first level
+    const scale5d = this.getScale(0);
+    // assume that ImageInfo wants the timeScale of level 0
     const timeScale = hasT ? scale5d[t] : 1;
 
     const imgdata: ImageInfo = {

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -9,6 +9,7 @@ import {
 } from "./IVolumeLoader.js";
 import { ImageInfo } from "../Volume.js";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader.js";
+import { DATARANGE_UINT8 } from "../types.js";
 
 class OpenCellLoader extends ThreadableVolumeLoader {
   async loadDims(_: LoadSpec): Promise<VolumeDims[]> {
@@ -77,7 +78,8 @@ class OpenCellLoader extends ThreadableVolumeLoader {
 
     const w = imageInfo.atlasTileDims.x * imageInfo.volumeSize.x;
     const h = imageInfo.atlasTileDims.y * imageInfo.volumeSize.y;
-    JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, data) => onData(ch, data, [[0, 255]], [w, h]));
+    // all data coming from this loader is natively 8-bit
+    JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, data) => onData(ch, data, [DATARANGE_UINT8], [w, h]));
     return Promise.resolve({});
   }
 }

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -77,7 +77,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
 
     const w = imageInfo.atlasTileDims.x * imageInfo.volumeSize.x;
     const h = imageInfo.atlasTileDims.y * imageInfo.volumeSize.y;
-    JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, data) => onData(ch, data, [w, h]));
+    JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, data) => onData(ch, data, [[0, 255]], [w, h]));
     return Promise.resolve({});
   }
 }

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -178,7 +178,8 @@ class TiffLoader extends ThreadableVolumeLoader {
       worker.onmessage = (e) => {
         const u8 = e.data.data;
         const channel = e.data.channel;
-        onData(channel, u8);
+        const range = e.data.range;
+        onData([channel], [u8], [range]);
         worker.terminate();
       };
       worker.onerror = (e) => {

--- a/src/test/lut.test.js
+++ b/src/test/lut.test.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 
 import Histogram from "../Histogram";
+import { updateLutForNewRange } from "../Histogram";
 import VolumeMaker from "../VolumeMaker";
 
 function clamp(val, cmin, cmax) {
@@ -323,3 +324,23 @@ describe("test histogram", () => {
     });
   });
 });
+
+// describe("test remapping lut when raw data range is updated", () => {
+//   it("remaps the lut when the new data range is completely contained", () => {
+
+//     const histogram = new Histogram(new Uint8Array(100));
+
+//     // artificial min and max:
+//     const oldMin = 50;
+//     const oldMax = 100;
+//     const lut = histogram.lutGenerator_minMax(64, 192);
+//     const secondLut = updateLutForNewRange(lut, oldMin, oldMax, 62.5, 87.5);
+//     // the new lut must represent the range 25-75, and the old lut represented 50-100
+//     // so the min/max slope of our lut should be reduced, or stretched horizontally
+//     // the new lut should slope up linearly from 0 to 255.
+
+//     const compareLut = histogram.lutGenerator_minMax(0, 255);
+//     expect(secondLut).to.eql(compareLut.lut);
+//   });
+// });
+

--- a/src/test/lut.test.js
+++ b/src/test/lut.test.js
@@ -325,22 +325,28 @@ describe("test histogram", () => {
   });
 });
 
-// describe("test remapping lut when raw data range is updated", () => {
-//   it("remaps the lut when the new data range is completely contained", () => {
+describe("test remapping lut when raw data range is updated", () => {
+  it("remaps the lut when the new data range is completely contained", () => {
 
-//     const histogram = new Histogram(new Uint8Array(100));
+    const histogram = new Histogram(new Uint8Array(100));
 
-//     // artificial min and max:
-//     const oldMin = 50;
-//     const oldMax = 100;
-//     const lut = histogram.lutGenerator_minMax(64, 192);
-//     const secondLut = updateLutForNewRange(lut, oldMin, oldMax, 62.5, 87.5);
-//     // the new lut must represent the range 25-75, and the old lut represented 50-100
-//     // so the min/max slope of our lut should be reduced, or stretched horizontally
-//     // the new lut should slope up linearly from 0 to 255.
+    // artificial min and max:
+    const oldMin = 50;
+    const oldMax = 100;
+    const lut = histogram.lutGenerator_minMax(64, 192);
+    const secondLut = updateLutForNewRange(lut.lut, oldMin, oldMax, 62.5, 87.5);
+    // the new lut must represent the range 25-75, and the old lut represented 50-100
+    // so the min/max slope of our lut should be reduced, or stretched horizontally
+    // the new lut should slope up linearly from 0 to 255.
 
-//     const compareLut = histogram.lutGenerator_minMax(0, 255);
-//     expect(secondLut).to.eql(compareLut.lut);
-//   });
-// });
+    const compareLut = histogram.lutGenerator_minMax(0, 255);
+    for (let i = 0; i < 256; i++) {
+      expect(secondLut[i * 4 + 0]).to.equal(compareLut.lut[i * 4 + 0]);
+      expect(secondLut[i * 4 + 1]).to.equal(compareLut.lut[i * 4 + 1]);
+      expect(secondLut[i * 4 + 2]).to.equal(compareLut.lut[i * 4 + 2]);
+      expect(secondLut[i * 4 + 3]).to.equal(compareLut.lut[i * 4 + 3]);
+    }
+    //expect(secondLut).to.eql(compareLut.lut);
+  });
+});
 

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -328,6 +328,7 @@ describe("test histogram", () => {
 
 describe("test remapping lut when raw data range is updated", () => {
   it("remaps the lut when the new data range is completely contained", () => {
+    // histogram values itself doesn't matter.
     const histogram = new Histogram(new Uint8Array(100));
     // the full 0-255 domain of this lut is representing the raw intensity range 50-100
     // we will choose a min/max range within the 0-255 domain of the lut.
@@ -346,8 +347,8 @@ describe("test remapping lut when raw data range is updated", () => {
     const oldMax = 100;
 
     // to test this, I will find the values that should exactly fit this ramp in the new range.
-    const newMin = (1.0 + 64 / 255) * oldMin;
-    const newMax = (1.0 + 192 / 255) * oldMin;
+    const newMin = oldMin + (oldMax - oldMin) * (64 / 255);
+    const newMax = oldMin + (oldMax - oldMin) * (192 / 255);
 
     // now, remap for a new raw intensity range of newMin to newMax.
     // because the actual slope started at newMin, and ended at newMax,
@@ -385,6 +386,7 @@ describe("test remapping lut when raw data range is updated", () => {
     }
   });
   it("remaps the lut when the new data range is identical to previous", () => {
+    // histogram values itself doesn't matter.
     const histogram = new Histogram(new Uint8Array(100));
     const lut = histogram.lutGenerator_minMax(0, 255);
 
@@ -406,7 +408,7 @@ describe("test remapping lut when raw data range is updated", () => {
     // artificial data min and max absolute intensities:
     const oldMin = 50;
     const oldMax = 100;
-    // the full 0-255 domain of this lut is representing the raw intensity domain 50-100.
+    // the full 0-255 domain of this lut is representing the above raw intensity domain 50-100.
     // For test, we will choose a min/max within the 0-255 domain of the lut.
     const lut = histogram.lutGenerator_minMax(64, 192);
     // this lut now has a ramp from 64 to 192 in the 0-255 range
@@ -421,12 +423,12 @@ describe("test remapping lut when raw data range is updated", () => {
     // lets remap so that the new lut has a minmax of 96-160
     // we will carefully pick these values so that it's easy to check the result.
 
-    // the min and max inflection points are at:
+    // Because we chose (64, 192) in the lut above, the min and max inflection points are at:
     const mini = oldMin + (64 / 255) * (oldMax - oldMin);
     const maxi = oldMin + (192 / 255) * (oldMax - oldMin);
     //console.log((mini + maxi) / 2);
 
-    // what do the overall min and max have to be for mini and maxi to map to 96 and 160?
+    // what do the data min and max have to be for mini and maxi to map to 96 and 160?
     // should now span 1/4 of the range, still centered.
     const totalrange = (maxi - mini) / ((160 - 96) / (255 - 0));
     // symmetrical spread about the center

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import type { ControlPoint, Lut } from "../Histogram";
 import Histogram from "../Histogram";
-import { updateLutForNewRange } from "../Histogram";
+import { remapLut } from "../Histogram";
 import VolumeMaker from "../VolumeMaker";
 
 function clamp(val, cmin, cmax) {
@@ -352,7 +352,7 @@ describe("test remapping lut when raw data range is updated", () => {
     // now, remap for a new raw intensity range of newMin to newMax.
     // because the actual slope started at newMin, and ended at newMax,
     // we expect this new lut to ramp up linearly from 0 to 255.
-    const secondLut = updateLutForNewRange(lut.lut, oldMin, oldMax, newMin, newMax);
+    const secondLut = remapLut(lut.lut, oldMin, oldMax, newMin, newMax);
     // the new lut must represent the range 25-75, and the old lut represented 50-100
     // so the min/max slope of our lut should be reduced, or stretched horizontally
     // the new lut should slope up linearly from 0 to 255.
@@ -379,7 +379,7 @@ describe("test remapping lut when raw data range is updated", () => {
     }
 
     // for good measure, just test the reverse mapping too.
-    const thirdLut = updateLutForNewRange(secondLut, newMin, newMax, oldMin, oldMax);
+    const thirdLut = remapLut(secondLut, newMin, newMax, oldMin, oldMax);
     for (let i = 0; i < 256 * 4; ++i) {
       expect(thirdLut[i]).to.be.closeTo(lut.lut[i], 1);
     }
@@ -393,7 +393,7 @@ describe("test remapping lut when raw data range is updated", () => {
     const oldMax = 100;
     const newMin = oldMin;
     const newMax = oldMax;
-    const secondLut = updateLutForNewRange(lut.lut, oldMin, oldMax, newMin, newMax);
+    const secondLut = remapLut(lut.lut, oldMin, oldMax, newMin, newMax);
     for (let i = 0; i < 256 * 4; ++i) {
       expect(secondLut[i]).to.eql(lut.lut[i]);
     }
@@ -434,7 +434,7 @@ describe("test remapping lut when raw data range is updated", () => {
     const newMax = (oldMin + oldMax) / 2 + totalrange / 2;
 
     // now, remap for a new raw intensity range of newMin to newMax.
-    const secondLut = updateLutForNewRange(lut.lut, oldMin, oldMax, newMin, newMax);
+    const secondLut = remapLut(lut.lut, oldMin, oldMax, newMin, newMax);
     expect(secondLut[0 * 4 + 3]).to.equal(0);
     expect(secondLut[1 * 4 + 3]).to.equal(0);
     expect(secondLut[2 * 4 + 3]).to.equal(0);
@@ -457,7 +457,7 @@ describe("test remapping lut when raw data range is updated", () => {
     }
 
     // for good measure, just test the reverse mapping too.
-    const thirdLut = updateLutForNewRange(secondLut, newMin, newMax, oldMin, oldMax);
+    const thirdLut = remapLut(secondLut, newMin, newMax, oldMin, oldMax);
     for (let i = 0; i < 256 * 4; ++i) {
       expect(thirdLut[i]).to.be.closeTo(lut.lut[i], 1);
     }

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -347,8 +347,33 @@ describe("test remapping lut when raw data range is updated", () => {
     const oldMax = 100;
 
     // to test this, I will find the values that should exactly fit this ramp in the new range.
+    /**
+     * Old LUT:
+     * 255 |           o ------o
+     *     |          /
+     *     |         /
+     *     |        /
+     *   0 | o----o
+     *     +-------------------
+     *       0    64    192    255
+     *       v    v     v      v
+     * data: 50   62.5  87.6   100
+     */
     const newMin = oldMin + (oldMax - oldMin) * (64 / 255);
     const newMax = oldMin + (oldMax - oldMin) * (192 / 255);
+
+    /**
+     * New LUT:
+     * 255 |      o
+     *     |     /
+     *     |    /
+     *     |   /
+     *   0 | o
+     *     +--------
+     *       0     255
+     *       v     v
+     * data: 62.5  87.6
+     */
 
     // now, remap for a new raw intensity range of newMin to newMax.
     // because the actual slope started at newMin, and ended at newMax,
@@ -420,6 +445,19 @@ describe("test remapping lut when raw data range is updated", () => {
     expect(lut.lut[192 * 4 + 3]).to.equal(255);
     expect(lut.lut[193 * 4 + 3]).to.equal(255);
 
+    /**
+     * Old LUT:
+     * 255 |           o ------o
+     *     |          /
+     *     |         /
+     *     |        /
+     *   0 | o----o
+     *     +-------------------
+     *       0    64    192    255
+     *       v    v     v      v
+     * data: 50   62.5  87.6   100
+     */
+
     // lets remap so that the new lut has a minmax of 96-160
     // we will carefully pick these values so that it's easy to check the result.
 
@@ -434,6 +472,18 @@ describe("test remapping lut when raw data range is updated", () => {
     // symmetrical spread about the center
     const newMin = (oldMin + oldMax) / 2 - totalrange / 2;
     const newMax = (oldMin + oldMax) / 2 + totalrange / 2;
+    /**
+     * NEW LUT:
+     * 255 |             o--------o
+     *     |            /
+     *     |           /
+     *     |          /
+     *   0 | o------o
+     *     +------------------------
+     *       0      96  160      255
+     *       v      v    v        v
+     * data: 25   62.5  87.6     125
+     */
 
     // now, remap for a new raw intensity range of newMin to newMax.
     const secondLut = remapLut(lut.lut, oldMin, oldMax, newMin, newMax);
@@ -476,7 +526,6 @@ describe("test remapping control points when raw data range is updated", () => {
     ];
     const cp2 = remapControlPoints(cp, 0, 255, 64, 192);
     const positions = cp2.map((cp) => Math.round(cp.x));
-    console.log(positions);
     expect(positions).to.include.members([0, 64, 96, 160, 192, 255]);
   });
   it("remaps the control points correctly when new intensity range expanded", () => {

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import type { ControlPoint, Lut } from "../Histogram";
 import Histogram from "../Histogram";
-import { remapLut } from "../Histogram";
+import { remapLut, remapControlPoints } from "../Histogram";
 import VolumeMaker from "../VolumeMaker";
 
 function clamp(val, cmin, cmax) {
@@ -461,5 +461,31 @@ describe("test remapping lut when raw data range is updated", () => {
     for (let i = 0; i < 256 * 4; ++i) {
       expect(thirdLut[i]).to.be.closeTo(lut.lut[i], 1);
     }
+  });
+});
+
+describe("test remapping control points when raw data range is updated", () => {
+  it("remaps the control points correctly when new intensity range contracted", () => {
+    const cp: ControlPoint[] = [
+      { x: 0, color: [255, 255, 255], opacity: 0 },
+      { x: 64, color: [255, 255, 255], opacity: 0 },
+      { x: 192, color: [255, 255, 255], opacity: 1.0 },
+      { x: 255, color: [255, 255, 255], opacity: 1.0 },
+    ];
+    const cp2 = remapControlPoints(cp, 0, 255, 64, 192);
+    const positions = cp2.map((cp) => Math.round(cp.x));
+    console.log(positions);
+    expect(positions).to.include.members([0, 64, 96, 160, 192, 255]);
+  });
+  it("remaps the control points correctly when new intensity range expanded", () => {
+    const cp: ControlPoint[] = [
+      { x: 0, color: [255, 255, 255], opacity: 0 },
+      { x: 64, color: [255, 255, 255], opacity: 0 },
+      { x: 192, color: [255, 255, 255], opacity: 1.0 },
+      { x: 255, color: [255, 255, 255], opacity: 1.0 },
+    ];
+    const cp2 = remapControlPoints(cp, 0, 255, -64, 320);
+    const positions = cp2.map((cp) => Math.round(cp.x));
+    expect(positions).to.include.members([0, 32, 225, 255]);
   });
 });

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 
+import type { ControlPoint, Lut } from "../Histogram";
 import Histogram from "../Histogram";
 import { updateLutForNewRange } from "../Histogram";
 import VolumeMaker from "../VolumeMaker";
@@ -15,21 +16,21 @@ describe("test histogram", () => {
   describe("binary volume data", () => {
     it("has a min of 255", () => {
       // histogram dataMin is the min nonzero value
-      expect(histogram.dataMin).to.equal(255);
+      expect(histogram.getMin()).to.equal(255);
     });
     it("has a max of 255", () => {
-      expect(histogram.dataMax).to.equal(255);
+      expect(histogram.getMax()).to.equal(255);
     });
     it("is created", () => {
       expect(histogram.maxBin).to.equal(255);
-      expect(histogram.bins[255]).to.be.greaterThan(0);
-      expect(histogram.bins[128]).to.equal(0);
-      expect(histogram.bins[0]).to.be.greaterThan(0);
+      expect(histogram["bins"][255]).to.be.greaterThan(0);
+      expect(histogram["bins"][128]).to.equal(0);
+      expect(histogram["bins"][0]).to.be.greaterThan(0);
     });
   });
 
   describe("generated lut from control points", () => {
-    const controlPoints = [
+    const controlPoints: ControlPoint[] = [
       { x: 0, color: [255, 255, 255], opacity: 0 },
       { x: 126, color: [255, 255, 255], opacity: 0 },
       { x: 128, color: [255, 255, 255], opacity: 1.0 },
@@ -50,7 +51,7 @@ describe("test histogram", () => {
 
   describe("interpolates opacity across consecutive control points", () => {
     it("has interpolated opacity correctly", () => {
-      const controlPoints = [
+      const controlPoints: ControlPoint[] = [
         { x: 0, color: [255, 255, 255], opacity: 0 },
         { x: 1, color: [255, 255, 255], opacity: 1.0 },
         { x: 255, color: [255, 255, 255], opacity: 1.0 },
@@ -61,7 +62,7 @@ describe("test histogram", () => {
       expect(lut.lut[2 * 4 + 3]).to.equal(255);
     });
     it("has interpolated opacity correctly with fractional control point positions", () => {
-      const controlPoints = [
+      const controlPoints: ControlPoint[] = [
         { x: 0, color: [255, 255, 255], opacity: 0 },
         { x: 0.1, color: [255, 255, 255], opacity: 0 },
         { x: 0.9, color: [255, 255, 255], opacity: 1.0 },
@@ -76,7 +77,7 @@ describe("test histogram", () => {
   });
 
   describe("generated lut single control point", () => {
-    const controlPoints = [{ x: 127, color: [255, 255, 255], opacity: 1.0 }];
+    const controlPoints: ControlPoint[] = [{ x: 127, color: [255, 255, 255], opacity: 1.0 }];
     const lut = histogram.lutGenerator_fromControlPoints(controlPoints);
     it("has interpolated opacity correctly", () => {
       expect(lut.lut[0 * 4 + 3]).to.equal(0);
@@ -146,9 +147,9 @@ describe("test histogram", () => {
         expect(lut.lut[255 * 4 + 3]).to.eql(255);
         expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
         // Make sure no NaN values
-        lut.controlPoints.forEach(controlPoint => {
+        lut.controlPoints.forEach((controlPoint) => {
           expect(controlPoint.opacity).to.be.finite;
-        })
+        });
       });
       it("is consistent when min and max are the same positive number less than 255", () => {
         const lut = histogram.lutGenerator_minMax(120, 120);
@@ -163,9 +164,9 @@ describe("test histogram", () => {
         expect(lut.lut[255 * 4 + 3]).to.eql(255);
         expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
         // Make sure no NaN values
-        lut.controlPoints.forEach(controlPoint => {
+        lut.controlPoints.forEach((controlPoint) => {
           expect(controlPoint.opacity).to.be.finite;
-        })
+        });
       });
       it("is consistent when min and max are both negative", () => {
         const lut = histogram.lutGenerator_minMax(-10, -5);
@@ -178,9 +179,9 @@ describe("test histogram", () => {
         expect(secondlut.lut[120 * 4 + 3]).to.eql(255);
         expect(lut.lut[255 * 4 + 3]).to.eql(255);
         expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
-        lut.controlPoints.forEach(controlPoint => {
+        lut.controlPoints.forEach((controlPoint) => {
           expect(controlPoint.opacity).to.eql(1);
-        })
+        });
       });
       it("is consistent when min is 0 and max is 1", () => {
         const lut = histogram.lutGenerator_minMax(0, 1);
@@ -193,9 +194,9 @@ describe("test histogram", () => {
         expect(lut.lut[255 * 4 + 3]).to.eql(255);
         expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
         // Make sure no NaN values
-        lut.controlPoints.forEach(controlPoint => {
+        lut.controlPoints.forEach((controlPoint) => {
           expect(controlPoint.opacity).to.be.finite;
-        })
+        });
       });
       it("is consistent when min is 244 and max is 255", () => {
         const lut = histogram.lutGenerator_minMax(254, 255);
@@ -208,9 +209,9 @@ describe("test histogram", () => {
         expect(lut.lut[255 * 4 + 3]).to.eql(255);
         expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
         // Make sure no NaN values
-        lut.controlPoints.forEach(controlPoint => {
+        lut.controlPoints.forEach((controlPoint) => {
           expect(controlPoint.opacity).to.be.finite;
-        })
+        });
       });
       it("is consistent when min and max are both 255", () => {
         const lut = histogram.lutGenerator_minMax(255, 255);
@@ -220,9 +221,9 @@ describe("test histogram", () => {
         expect(secondlut.lut[3]).to.eql(0);
         expect(lut.lut[255 * 4 + 3]).to.eql(0);
         expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
-        lut.controlPoints.forEach(controlPoint => {
+        lut.controlPoints.forEach((controlPoint) => {
           expect(controlPoint.opacity).to.eql(0);
-        })
+        });
       });
       it("is consistent when min and max are both greater than 255", () => {
         const lut = histogram.lutGenerator_minMax(300, 400);
@@ -235,9 +236,9 @@ describe("test histogram", () => {
         expect(secondlut.lut[120 * 4 + 3]).to.eql(0);
         expect(lut.lut[255 * 4 + 3]).to.eql(0);
         expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
-        lut.controlPoints.forEach(controlPoint => {
+        lut.controlPoints.forEach((controlPoint) => {
           expect(controlPoint.opacity).to.eql(0);
-        })
+        });
       });
     });
 
@@ -309,7 +310,7 @@ describe("test histogram", () => {
         lutArr[i * 4 + 2] = 255;
         lutArr[i * 4 + 3] = 0;
       }
-      const lut = {
+      const lut: Lut = {
         lut: lutArr,
         controlPoints: [
           { x: 0, color: [255, 255, 255], opacity: 0 },
@@ -327,26 +328,54 @@ describe("test histogram", () => {
 
 describe("test remapping lut when raw data range is updated", () => {
   it("remaps the lut when the new data range is completely contained", () => {
-
     const histogram = new Histogram(new Uint8Array(100));
 
     // artificial min and max:
     const oldMin = 50;
     const oldMax = 100;
+    // the full 0-255 range of this lut is representing the raw intensity range 50-100
+    // we will choose a min/max range within the 0-255 range of the lut.
     const lut = histogram.lutGenerator_minMax(64, 192);
+    // this lut now has a ramp from 62.5 to 87.5 in the 0-255 range (from 64 to 192)
+    console.log(lut.lut);
+    expect(lut.lut[63 * 4 + 3]).to.equal(0);
+    expect(lut.lut[64 * 4 + 3]).to.equal(0);
+    expect(lut.lut[65 * 4 + 3]).to.be.greaterThan(0);
+    expect(lut.lut[191 * 4 + 3]).to.be.lessThan(255);
+    expect(lut.lut[192 * 4 + 3]).to.equal(255);
+    expect(lut.lut[193 * 4 + 3]).to.equal(255);
+    // now, remap for a new raw intensity range of 62.5 to 87.5.
+    // because the actual slope started at 62.5, and ended at 87.5,
+    // we expect this new lut to ramp up linearly from 0 to 255.
     const secondLut = updateLutForNewRange(lut.lut, oldMin, oldMax, 62.5, 87.5);
     // the new lut must represent the range 25-75, and the old lut represented 50-100
     // so the min/max slope of our lut should be reduced, or stretched horizontally
     // the new lut should slope up linearly from 0 to 255.
+    expect(secondLut[0 * 4 + 3]).to.equal(0);
+    expect(secondLut[1 * 4 + 3]).to.equal(1);
+    expect(secondLut[2 * 4 + 3]).to.equal(2);
+    expect(secondLut[3 * 4 + 3]).to.equal(3);
+    expect(secondLut[63 * 4 + 3]).to.equal(63);
+    expect(secondLut[64 * 4 + 3]).to.equal(64);
+    expect(secondLut[65 * 4 + 3]).to.equal(65);
+    expect(secondLut[191 * 4 + 3]).to.equal(191);
+    expect(secondLut[192 * 4 + 3]).to.equal(192);
+    expect(secondLut[193 * 4 + 3]).to.equal(193);
+    expect(secondLut[255 * 4 + 3]).to.equal(255);
 
     const compareLut = histogram.lutGenerator_minMax(0, 255);
-    for (let i = 0; i < 256; i++) {
-      expect(secondLut[i * 4 + 0]).to.equal(compareLut.lut[i * 4 + 0]);
-      expect(secondLut[i * 4 + 1]).to.equal(compareLut.lut[i * 4 + 1]);
-      expect(secondLut[i * 4 + 2]).to.equal(compareLut.lut[i * 4 + 2]);
-      expect(secondLut[i * 4 + 3]).to.equal(compareLut.lut[i * 4 + 3]);
-    }
+    expect(compareLut.lut[63 * 4 + 3]).to.equal(63);
+    expect(compareLut.lut[64 * 4 + 3]).to.equal(64);
+    expect(compareLut.lut[65 * 4 + 3]).to.equal(65);
+    expect(compareLut.lut[191 * 4 + 3]).to.equal(191);
+    expect(compareLut.lut[192 * 4 + 3]).to.equal(192);
+    expect(compareLut.lut[193 * 4 + 3]).to.equal(193);
+    // for (let i = 0; i < 256; i++) {
+    //   expect(secondLut[i * 4 + 0]).to.closeTo(compareLut.lut[i * 4 + 0], 1);
+    //   expect(secondLut[i * 4 + 1]).to.closeTo(compareLut.lut[i * 4 + 1], 1);
+    //   expect(secondLut[i * 4 + 2]).to.closeTo(compareLut.lut[i * 4 + 2], 1);
+    //   expect(secondLut[i * 4 + 3]).to.closeTo(compareLut.lut[i * 4 + 3], 1);
+    // }
     //expect(secondLut).to.eql(compareLut.lut);
   });
 });
-

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -336,7 +336,13 @@ describe("test remapping lut when raw data range is updated", () => {
     // the full 0-255 range of this lut is representing the raw intensity range 50-100
     // we will choose a min/max range within the 0-255 range of the lut.
     const lut = histogram.lutGenerator_minMax(64, 192);
-    // this lut now has a ramp from 62.5 to 87.5 in the 0-255 range (from 64 to 192)
+
+    // to test this, I will find the values that should exactly fit this ramp in the new range.
+    const newMin = (1.0 + 64 / 255) * oldMin;
+    const newMax = (1.0 + 192 / 255) * oldMin;
+
+    // this lut now has a ramp from 64 to 192 in the 0-255 range
+    // (which correspond exactly to the newMin-newMax range in the raw intensities)
     console.log(lut.lut);
     expect(lut.lut[63 * 4 + 3]).to.equal(0);
     expect(lut.lut[64 * 4 + 3]).to.equal(0);
@@ -344,10 +350,10 @@ describe("test remapping lut when raw data range is updated", () => {
     expect(lut.lut[191 * 4 + 3]).to.be.lessThan(255);
     expect(lut.lut[192 * 4 + 3]).to.equal(255);
     expect(lut.lut[193 * 4 + 3]).to.equal(255);
-    // now, remap for a new raw intensity range of 62.5 to 87.5.
-    // because the actual slope started at 62.5, and ended at 87.5,
+    // now, remap for a new raw intensity range of newMin to newMax.
+    // because the actual slope started at newMin, and ended at newMax,
     // we expect this new lut to ramp up linearly from 0 to 255.
-    const secondLut = updateLutForNewRange(lut.lut, oldMin, oldMax, 62.5, 87.5);
+    const secondLut = updateLutForNewRange(lut.lut, oldMin, oldMax, newMin, newMax);
     // the new lut must represent the range 25-75, and the old lut represented 50-100
     // so the min/max slope of our lut should be reduced, or stretched horizontally
     // the new lut should slope up linearly from 0 to 255.
@@ -356,11 +362,18 @@ describe("test remapping lut when raw data range is updated", () => {
     expect(secondLut[2 * 4 + 3]).to.equal(2);
     expect(secondLut[3 * 4 + 3]).to.equal(3);
     expect(secondLut[63 * 4 + 3]).to.equal(63);
+
     expect(secondLut[64 * 4 + 3]).to.equal(64);
     expect(secondLut[65 * 4 + 3]).to.equal(65);
+    expect(secondLut[126 * 4 + 3]).to.equal(126);
+    expect(secondLut[127 * 4 + 3]).to.equal(127);
+    expect(secondLut[128 * 4 + 3]).to.equal(128);
+
     expect(secondLut[191 * 4 + 3]).to.equal(191);
     expect(secondLut[192 * 4 + 3]).to.equal(192);
     expect(secondLut[193 * 4 + 3]).to.equal(193);
+    expect(secondLut[253 * 4 + 3]).to.equal(253);
+    expect(secondLut[254 * 4 + 3]).to.equal(254);
     expect(secondLut[255 * 4 + 3]).to.equal(255);
 
     const compareLut = histogram.lutGenerator_minMax(0, 255);
@@ -370,12 +383,12 @@ describe("test remapping lut when raw data range is updated", () => {
     expect(compareLut.lut[191 * 4 + 3]).to.equal(191);
     expect(compareLut.lut[192 * 4 + 3]).to.equal(192);
     expect(compareLut.lut[193 * 4 + 3]).to.equal(193);
-    // for (let i = 0; i < 256; i++) {
-    //   expect(secondLut[i * 4 + 0]).to.closeTo(compareLut.lut[i * 4 + 0], 1);
-    //   expect(secondLut[i * 4 + 1]).to.closeTo(compareLut.lut[i * 4 + 1], 1);
-    //   expect(secondLut[i * 4 + 2]).to.closeTo(compareLut.lut[i * 4 + 2], 1);
-    //   expect(secondLut[i * 4 + 3]).to.closeTo(compareLut.lut[i * 4 + 3], 1);
-    // }
-    //expect(secondLut).to.eql(compareLut.lut);
+    for (let i = 0; i < 256; i++) {
+      expect(secondLut[i * 4 + 0]).to.closeTo(compareLut.lut[i * 4 + 0], 1);
+      expect(secondLut[i * 4 + 1]).to.closeTo(compareLut.lut[i * 4 + 1], 1);
+      expect(secondLut[i * 4 + 2]).to.closeTo(compareLut.lut[i * 4 + 2], 1);
+      expect(secondLut[i * 4 + 3]).to.closeTo(compareLut.lut[i * 4 + 3], 1);
+    }
+    expect(secondLut).to.eql(compareLut.lut);
   });
 });

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -329,27 +329,26 @@ describe("test histogram", () => {
 describe("test remapping lut when raw data range is updated", () => {
   it("remaps the lut when the new data range is completely contained", () => {
     const histogram = new Histogram(new Uint8Array(100));
-
-    // artificial min and max:
-    const oldMin = 50;
-    const oldMax = 100;
-    // the full 0-255 range of this lut is representing the raw intensity range 50-100
-    // we will choose a min/max range within the 0-255 range of the lut.
+    // the full 0-255 domain of this lut is representing the raw intensity range 50-100
+    // we will choose a min/max range within the 0-255 domain of the lut.
     const lut = histogram.lutGenerator_minMax(64, 192);
-
-    // to test this, I will find the values that should exactly fit this ramp in the new range.
-    const newMin = (1.0 + 64 / 255) * oldMin;
-    const newMax = (1.0 + 192 / 255) * oldMin;
-
-    // this lut now has a ramp from 64 to 192 in the 0-255 range
+    // this lut now has a ramp from 64 to 192 in the 0-255 domain
     // (which correspond exactly to the newMin-newMax range in the raw intensities)
-    console.log(lut.lut);
     expect(lut.lut[63 * 4 + 3]).to.equal(0);
     expect(lut.lut[64 * 4 + 3]).to.equal(0);
     expect(lut.lut[65 * 4 + 3]).to.be.greaterThan(0);
     expect(lut.lut[191 * 4 + 3]).to.be.lessThan(255);
     expect(lut.lut[192 * 4 + 3]).to.equal(255);
     expect(lut.lut[193 * 4 + 3]).to.equal(255);
+
+    // artificial data min and max:
+    const oldMin = 50;
+    const oldMax = 100;
+
+    // to test this, I will find the values that should exactly fit this ramp in the new range.
+    const newMin = (1.0 + 64 / 255) * oldMin;
+    const newMax = (1.0 + 192 / 255) * oldMin;
+
     // now, remap for a new raw intensity range of newMin to newMax.
     // because the actual slope started at newMin, and ended at newMax,
     // we expect this new lut to ramp up linearly from 0 to 255.
@@ -358,37 +357,109 @@ describe("test remapping lut when raw data range is updated", () => {
     // so the min/max slope of our lut should be reduced, or stretched horizontally
     // the new lut should slope up linearly from 0 to 255.
     expect(secondLut[0 * 4 + 3]).to.equal(0);
-    expect(secondLut[1 * 4 + 3]).to.equal(1);
-    expect(secondLut[2 * 4 + 3]).to.equal(2);
-    expect(secondLut[3 * 4 + 3]).to.equal(3);
-    expect(secondLut[63 * 4 + 3]).to.equal(63);
-
-    expect(secondLut[64 * 4 + 3]).to.equal(64);
-    expect(secondLut[65 * 4 + 3]).to.equal(65);
-    expect(secondLut[126 * 4 + 3]).to.equal(126);
-    expect(secondLut[127 * 4 + 3]).to.equal(127);
-    expect(secondLut[128 * 4 + 3]).to.equal(128);
-
-    expect(secondLut[191 * 4 + 3]).to.equal(191);
-    expect(secondLut[192 * 4 + 3]).to.equal(192);
-    expect(secondLut[193 * 4 + 3]).to.equal(193);
-    expect(secondLut[253 * 4 + 3]).to.equal(253);
-    expect(secondLut[254 * 4 + 3]).to.equal(254);
-    expect(secondLut[255 * 4 + 3]).to.equal(255);
+    expect(secondLut[1 * 4 + 3]).to.be.closeTo(1, 1);
+    expect(secondLut[2 * 4 + 3]).to.be.closeTo(2, 1);
+    expect(secondLut[3 * 4 + 3]).to.be.closeTo(3, 1);
+    expect(secondLut[63 * 4 + 3]).to.be.closeTo(63, 1);
+    expect(secondLut[64 * 4 + 3]).to.be.closeTo(64, 1);
+    expect(secondLut[65 * 4 + 3]).to.be.closeTo(65, 1);
+    expect(secondLut[126 * 4 + 3]).to.be.closeTo(126, 1);
+    expect(secondLut[127 * 4 + 3]).to.be.closeTo(127, 1);
+    expect(secondLut[128 * 4 + 3]).to.be.closeTo(128, 1);
+    expect(secondLut[191 * 4 + 3]).to.be.closeTo(191, 1);
+    expect(secondLut[192 * 4 + 3]).to.be.closeTo(192, 1);
+    expect(secondLut[193 * 4 + 3]).to.be.closeTo(193, 1);
+    expect(secondLut[253 * 4 + 3]).to.be.closeTo(253, 1);
+    expect(secondLut[254 * 4 + 3]).to.be.closeTo(254, 1);
+    expect(secondLut[255 * 4 + 3]).to.be.closeTo(255, 1);
 
     const compareLut = histogram.lutGenerator_minMax(0, 255);
-    expect(compareLut.lut[63 * 4 + 3]).to.equal(63);
-    expect(compareLut.lut[64 * 4 + 3]).to.equal(64);
-    expect(compareLut.lut[65 * 4 + 3]).to.equal(65);
-    expect(compareLut.lut[191 * 4 + 3]).to.equal(191);
-    expect(compareLut.lut[192 * 4 + 3]).to.equal(192);
-    expect(compareLut.lut[193 * 4 + 3]).to.equal(193);
-    for (let i = 0; i < 256; i++) {
-      expect(secondLut[i * 4 + 0]).to.closeTo(compareLut.lut[i * 4 + 0], 1);
-      expect(secondLut[i * 4 + 1]).to.closeTo(compareLut.lut[i * 4 + 1], 1);
-      expect(secondLut[i * 4 + 2]).to.closeTo(compareLut.lut[i * 4 + 2], 1);
-      expect(secondLut[i * 4 + 3]).to.closeTo(compareLut.lut[i * 4 + 3], 1);
+    for (let i = 0; i < 256 * 4; ++i) {
+      expect(secondLut[i]).to.be.closeTo(compareLut.lut[i], 1);
     }
-    expect(secondLut).to.eql(compareLut.lut);
+
+    // for good measure, just test the reverse mapping too.
+    const thirdLut = updateLutForNewRange(secondLut, newMin, newMax, oldMin, oldMax);
+    for (let i = 0; i < 256 * 4; ++i) {
+      expect(thirdLut[i]).to.be.closeTo(lut.lut[i], 1);
+    }
+  });
+  it("remaps the lut when the new data range is identical to previous", () => {
+    const histogram = new Histogram(new Uint8Array(100));
+    const lut = histogram.lutGenerator_minMax(0, 255);
+
+    // artificial min and max:
+    const oldMin = 50;
+    const oldMax = 100;
+    const newMin = oldMin;
+    const newMax = oldMax;
+    const secondLut = updateLutForNewRange(lut.lut, oldMin, oldMax, newMin, newMax);
+    for (let i = 0; i < 256 * 4; ++i) {
+      expect(secondLut[i]).to.eql(lut.lut[i]);
+    }
+  });
+
+  it("remaps the lut when the new data range is completely overlapped", () => {
+    // histogram values itself doesn't matter.
+    const histogram = new Histogram(new Uint8Array(100));
+
+    // artificial data min and max absolute intensities:
+    const oldMin = 50;
+    const oldMax = 100;
+    // the full 0-255 domain of this lut is representing the raw intensity domain 50-100.
+    // For test, we will choose a min/max within the 0-255 domain of the lut.
+    const lut = histogram.lutGenerator_minMax(64, 192);
+    // this lut now has a ramp from 64 to 192 in the 0-255 range
+    // (which correspond exactly to the newMin-newMax range in the raw intensities)
+    expect(lut.lut[63 * 4 + 3]).to.equal(0);
+    expect(lut.lut[64 * 4 + 3]).to.equal(0);
+    expect(lut.lut[65 * 4 + 3]).to.be.greaterThan(0);
+    expect(lut.lut[191 * 4 + 3]).to.be.lessThan(255);
+    expect(lut.lut[192 * 4 + 3]).to.equal(255);
+    expect(lut.lut[193 * 4 + 3]).to.equal(255);
+
+    // lets remap so that the new lut has a minmax of 96-160
+    // we will carefully pick these values so that it's easy to check the result.
+
+    // the min and max inflection points are at:
+    const mini = oldMin + (64 / 255) * (oldMax - oldMin);
+    const maxi = oldMin + (192 / 255) * (oldMax - oldMin);
+    //console.log((mini + maxi) / 2);
+
+    // what do the overall min and max have to be for mini and maxi to map to 96 and 160?
+    // should now span 1/4 of the range, still centered.
+    const totalrange = (maxi - mini) / ((160 - 96) / (255 - 0));
+    // symmetrical spread about the center
+    const newMin = (oldMin + oldMax) / 2 - totalrange / 2;
+    const newMax = (oldMin + oldMax) / 2 + totalrange / 2;
+
+    // now, remap for a new raw intensity range of newMin to newMax.
+    const secondLut = updateLutForNewRange(lut.lut, oldMin, oldMax, newMin, newMax);
+    expect(secondLut[0 * 4 + 3]).to.equal(0);
+    expect(secondLut[1 * 4 + 3]).to.equal(0);
+    expect(secondLut[2 * 4 + 3]).to.equal(0);
+    expect(secondLut[3 * 4 + 3]).to.equal(0);
+    expect(secondLut[63 * 4 + 3]).to.equal(0);
+    expect(secondLut[64 * 4 + 3]).to.equal(0);
+    expect(secondLut[65 * 4 + 3]).to.equal(0);
+    expect(secondLut[128 * 4 + 3]).to.be.closeTo(128, 1);
+    expect(secondLut[191 * 4 + 3]).to.equal(255);
+    expect(secondLut[192 * 4 + 3]).to.equal(255);
+    expect(secondLut[193 * 4 + 3]).to.equal(255);
+    expect(secondLut[253 * 4 + 3]).to.equal(255);
+    expect(secondLut[254 * 4 + 3]).to.equal(255);
+    expect(secondLut[255 * 4 + 3]).to.equal(255);
+
+    // 96, 160 were chosen above
+    const compareLut = histogram.lutGenerator_minMax(96, 160);
+    for (let i = 0; i < 256 * 4; ++i) {
+      expect(secondLut[i]).to.be.closeTo(compareLut.lut[i], 1);
+    }
+
+    // for good measure, just test the reverse mapping too.
+    const thirdLut = updateLutForNewRange(secondLut, newMin, newMax, oldMin, oldMax);
+    for (let i = 0; i < 256 * 4; ++i) {
+      expect(thirdLut[i]).to.be.closeTo(lut.lut[i], 1);
+    }
   });
 });

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -5,6 +5,7 @@ import Volume, { ImageInfo } from "../Volume";
 import VolumeMaker from "../VolumeMaker";
 import { LUT_ARRAY_LENGTH } from "../Histogram";
 import Channel from "../Channel";
+import { DATARANGE_UINT8 } from "../types";
 
 // PREPARE SOME TEST DATA TO TRY TO DISPLAY A VOLUME.
 const testimgdata: ImageInfo = {
@@ -86,14 +87,14 @@ describe("test volume", () => {
 
       const conedata = VolumeMaker.createCone(size.x, size.y, size.z, size.x / 8, size.z);
 
-      v.setChannelDataFromVolume(0, conedata);
+      v.setChannelDataFromVolume(0, conedata, DATARANGE_UINT8);
 
       const c0 = v.getChannel(0);
       checkChannelDataConstruction(c0, 0, testimgdata);
 
       const spheredata = VolumeMaker.createSphere(size.x, size.y, size.z, size.z / 4);
 
-      v.setChannelDataFromVolume(1, spheredata);
+      v.setChannelDataFromVolume(1, spheredata, DATARANGE_UINT8);
 
       const c1 = v.getChannel(1);
       checkChannelDataConstruction(c1, 1, testimgdata);

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,3 +99,5 @@ export const isTop = (corner: ViewportCorner): boolean =>
   corner === ViewportCorner.TOP_LEFT || corner === ViewportCorner.TOP_RIGHT;
 export const isRight = (corner: ViewportCorner): boolean =>
   corner === ViewportCorner.TOP_RIGHT || corner === ViewportCorner.BOTTOM_RIGHT;
+
+export const DATARANGE_UINT8: [number, number] = [0, 255];

--- a/src/workers/FetchTiffWorker.ts
+++ b/src/workers/FetchTiffWorker.ts
@@ -114,6 +114,6 @@ self.onmessage = async function (e) {
   for (let j = 0; j < src.length; ++j) {
     out[j] = ((src[j] - chmin) / (chmax - chmin)) * 255;
   }
-  const results = { data: out, channel: channelIndex };
+  const results = { data: out, channel: channelIndex, range: [chmin, chmax] };
   (self as unknown as Worker).postMessage(results, [results.data.buffer]);
 };

--- a/src/workers/LoadWorkerHandle.ts
+++ b/src/workers/LoadWorkerHandle.ts
@@ -265,7 +265,7 @@ class WorkerLoader extends ThreadableVolumeLoader {
       return;
     }
 
-    this.currentLoadCallback?.(e.channelIndex, e.data, e.atlasDims);
+    this.currentLoadCallback?.(e.channelIndex, e.data, e.ranges, e.atlasDims);
   }
 }
 

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -58,13 +58,14 @@ const messageHandlers: { [T in WorkerMsgType]: MessageHandler<T> } = {
     return await loader.loadRawChannelData(
       rebuildImageInfo(imageInfo),
       rebuildLoadSpec(loadSpec),
-      (channelIndex, data, atlasDims) => {
+      (channelIndex, data, ranges, atlasDims) => {
         const message: WorkerResponse<WorkerMsgType> = {
           responseResult: WorkerResponseResult.EVENT,
           loaderId,
           loadId,
           channelIndex,
           data,
+          ranges,
           atlasDims,
         };
         const dataTransfers = data.map((d) => d.buffer);

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -67,6 +67,7 @@ export type ChannelLoadEvent = {
   loadId: number;
   channelIndex: number[];
   data: Uint8Array[];
+  ranges: [number, number][];
   atlasDims?: [number, number];
 };
 


### PR DESCRIPTION
Use case:
1. We always renormalize intensity data from originalMin and originalMax into the 0..255 range, and the transfer function lookup tables are based on that 0..255 range
2. When playing through time, we wish to have a consistent transfer function across time changes
3. When playing through time, if intensity ranges are changing, then our 0..255 range is not consistently representing the same intensity range.

Fix:
Store the absolute min and max intensity when loading and renormalizing channel data.  Then we can use that to rescale/remap the transfer function lookup table.
These changes ignore the "atlas" input path because atlases are always representing a 0..255 data range and would never be remapped.
A future PR will have to integrate these changes with the website-3d-cell-viewer front end.

Bonus fix: 
volume scaling was accidentally using the wrong multiresolution level.
