### PR TITLE
Handle per-source chunk dimensions when prefetching zarr

### DIFF
--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -70,12 +70,13 @@ export default class ChunkPrefetchIterator {
 
     for (const [direction, start] of extrema.flat().entries()) {
       const dimension = direction >> 1;
+      const tczyxIndex = dimension + Number(dimension !== 0);
       let end: number | number[];
       if (direction & 1) {
         // Positive direction - end is either the max coordinate in the fetched set plus the max offset in this
         // dimension, or the max chunk coordinate in this dimension, whichever comes first
         const endsPerSource = tczyxChunksPerDimension.map((chunkDims) => {
-          return Math.min(start + tzyxMaxPrefetchOffset[dimension], chunkDims[dimension] - 1);
+          return Math.min(start + tzyxMaxPrefetchOffset[dimension], chunkDims[tczyxIndex] - 1);
         });
 
         // Save some time: if all sources have the same end, we can just store that

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -46,7 +46,7 @@ export default class ChunkPrefetchIterator {
   constructor(
     chunks: TCZYX<number>[],
     tzyxMaxPrefetchOffset: TZYX,
-    tczyxChunksPerDimension: TCZYX<number>[],
+    tczyxChunksPerSource: TCZYX<number>[],
     priorityDirections?: PrefetchDirection[]
   ) {
     // Get min and max chunk coordinates for T/Z/Y/X
@@ -75,7 +75,7 @@ export default class ChunkPrefetchIterator {
       if (direction & 1) {
         // Positive direction - end is either the max coordinate in the fetched set plus the max offset in this
         // dimension, or the max chunk coordinate in this dimension, whichever comes first
-        const endsPerSource = tczyxChunksPerDimension.map((chunkDims) => {
+        const endsPerSource = tczyxChunksPerSource.map((chunkDims) => {
           return Math.min(start + tzyxMaxPrefetchOffset[dimension], chunkDims[tczyxIndex] - 1);
         });
 
@@ -86,7 +86,7 @@ export default class ChunkPrefetchIterator {
           // Otherwise, expand our ends per source array to ends per channel
           end = [];
           for (const [i, sourceEnd] of endsPerSource.entries()) {
-            pushN(end, sourceEnd, tczyxChunksPerDimension[i][1]);
+            pushN(end, sourceEnd, tczyxChunksPerSource[i][1]);
           }
         }
         // end = Math.min(start + tzyxMaxPrefetchOffset[dimension], tczyxChunksPerDimension[dimension] - 1);

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -88,14 +88,12 @@ export default class ChunkPrefetchIterator {
           for (const [i, sourceEnd] of endsPerSource.entries()) {
             pushN(end, sourceEnd, tczyxChunksPerDimension[i][1]);
           }
-          console.log(end);
         }
         // end = Math.min(start + tzyxMaxPrefetchOffset[dimension], tczyxChunksPerDimension[dimension] - 1);
       } else {
         // Negative direction - end is either the min coordinate in the fetched set minus the max offset in this
         // dimension, or 0, whichever comes first
         end = Math.max(start - tzyxMaxPrefetchOffset[dimension], 0);
-        console.log(end);
       }
       const directionState = { direction, start, end, chunks: [] };
 

--- a/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
+++ b/src/loaders/zarr_utils/ChunkPrefetchIterator.ts
@@ -69,8 +69,8 @@ export default class ChunkPrefetchIterator {
     this.priorityDirectionStates = [];
 
     for (const [direction, start] of extrema.flat().entries()) {
-      const dimension = direction >> 1;
-      const tczyxIndex = dimension + Number(dimension !== 0);
+      const dimension = direction >> 1; // shave off sign bit to get index in TZYX
+      const tczyxIndex = dimension + Number(dimension !== 0); // convert TZYX -> TCZYX by skipping c (index 1)
       let end: number | number[];
       if (direction & 1) {
         // Positive direction - end is either the max coordinate in the fetched set plus the max offset in this

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -196,10 +196,6 @@ export function matchSourceScaleLevels(sources: ZarrSource[]): void {
         if (largestT !== currentT) {
           throw new Error("Incompatible zarr arrays: different numbers of timesteps");
         }
-        // ...they have different chunk sizes (TODO update prefetching so this restriction can be removed)
-        if (!smallestArr.chunks.every((val, idx) => val === currentArr.chunks[idx])) {
-          throw new Error("Incompatible zarr arrays: chunk shapes are mismatched");
-        }
       } else {
         allEqual = false;
         if (ordering > 0) {

--- a/src/test/ChunkPrefetchIterator.test.ts
+++ b/src/test/ChunkPrefetchIterator.test.ts
@@ -29,15 +29,17 @@ const EXPECTED_5X5X5X5_2 = [
   [2, 0, 2, 2, 4], // X++
 ];
 
-function validate(iter: ChunkPrefetchIterator, expected: number[][]) {
-  expect([...iter]).to.deep.equal(expected);
+function validate(iter: ChunkPrefetchIterator, expected: number[][], debug = false) {
+  const iterResult = [...iter];
+  if (debug) console.log(iterResult);
+  expect(iterResult).to.deep.equal(expected);
 }
 
 describe("ChunkPrefetchIterator", () => {
   it("iterates outward in TZYX order, negative then positive", () => {
     // 3x3x3x3, with one chunk in the center
-    const iterator = new ChunkPrefetchIterator([[1, 0, 1, 1, 1]], [1, 1, 1, 1], [3, 3, 3, 3]);
-    validate(iterator, EXPECTED_3X3X3X3);
+    const iterator = new ChunkPrefetchIterator([[1, 0, 1, 1, 1]], [1, 1, 1, 1], [[3, 1, 3, 3, 3]]);
+    validate(iterator, EXPECTED_3X3X3X3, true);
   });
 
   it("finds the borders of a set of multiple chunks and iterates outward from them", () => {
@@ -52,7 +54,7 @@ describe("ChunkPrefetchIterator", () => {
       [1, 0, 2, 2, 1],
       [1, 0, 2, 2, 2],
     ];
-    const iterator = new ChunkPrefetchIterator(fetchedChunks, [1, 1, 1, 1], [3, 4, 4, 4]);
+    const iterator = new ChunkPrefetchIterator(fetchedChunks, [1, 1, 1, 1], [[3, 1, 4, 4, 4]]);
 
     const expected = [
       ...fetchedChunks.map(([_t, c, z, y, x]) => [0, c, z, y, x]), // T-
@@ -69,7 +71,7 @@ describe("ChunkPrefetchIterator", () => {
 
   it("iterates through the same offset in all dimensions before increasing the offset", () => {
     // 5x5x5, with one chunk in the center
-    const iterator = new ChunkPrefetchIterator([[2, 0, 2, 2, 2]], [2, 2, 2, 2], [5, 5, 5, 5]);
+    const iterator = new ChunkPrefetchIterator([[2, 0, 2, 2, 2]], [2, 2, 2, 2], [[5, 1, 5, 5, 5]]);
 
     const expected = [
       // offset = 1
@@ -82,13 +84,13 @@ describe("ChunkPrefetchIterator", () => {
 
   it("stops at the max offset in each dimension", () => {
     // 5x5x5, with one chunk in the center
-    const iterator = new ChunkPrefetchIterator([[2, 0, 2, 2, 2]], [1, 1, 1, 1], [5, 5, 5, 5]);
+    const iterator = new ChunkPrefetchIterator([[2, 0, 2, 2, 2]], [1, 1, 1, 1], [[5, 1, 5, 5, 5]]);
     validate(iterator, EXPECTED_5X5X5X5_1); // never reaches offset = 2, as it does above
   });
 
   it("stops at the borders of the zarr", () => {
     // 3x3x3x3, with one chunk in the center
-    const iterator = new ChunkPrefetchIterator([[1, 0, 1, 1, 1]], [2, 2, 2, 2], [3, 3, 3, 3]);
+    const iterator = new ChunkPrefetchIterator([[1, 0, 1, 1, 1]], [2, 2, 2, 2], [[3, 1, 3, 3, 3]]);
     validate(iterator, EXPECTED_3X3X3X3);
   });
 
@@ -105,7 +107,7 @@ describe("ChunkPrefetchIterator", () => {
       [1, 0, 1, 2, 1], // 2, 1
       [1, 0, 1, 2, 2], // 2, 2
     ];
-    const iterator = new ChunkPrefetchIterator(fetchedChunks, [1, 1, 1, 1], [3, 3, 3, 3]);
+    const iterator = new ChunkPrefetchIterator(fetchedChunks, [1, 1, 1, 1], [[3, 1, 3, 3, 3]]);
 
     const expected = [
       ...fetchedChunks.map(([_t, c, z, y, x]) => [0, c, z, y, x]), // T-
@@ -119,7 +121,7 @@ describe("ChunkPrefetchIterator", () => {
 
   it("does not iterate in dimensions where the max offset is 0", () => {
     // 3x3x3x3, with one chunk in the center
-    const iterator = new ChunkPrefetchIterator([[1, 0, 1, 1, 1]], [1, 0, 1, 0], [3, 3, 3, 3]);
+    const iterator = new ChunkPrefetchIterator([[1, 0, 1, 1, 1]], [1, 0, 1, 0], [[3, 1, 3, 3, 3]]);
 
     const expected = [
       [0, 0, 1, 1, 1], // T-
@@ -137,7 +139,7 @@ describe("ChunkPrefetchIterator", () => {
     const iterator = new ChunkPrefetchIterator(
       [[2, 0, 2, 2, 2]],
       [2, 2, 2, 2],
-      [5, 5, 5, 5],
+      [[5, 1, 5, 5, 5]],
       [PrefetchDirection.T_PLUS, PrefetchDirection.Y_MINUS]
     );
 
@@ -164,7 +166,7 @@ describe("ChunkPrefetchIterator", () => {
       [2, 0, 1, 1, 2],
       [2, 0, 1, 1, 3],
     ];
-    const iterator = new ChunkPrefetchIterator(fetchedChunks, [2, 2, 2, 1], [3, 4, 4, 6]);
+    const iterator = new ChunkPrefetchIterator(fetchedChunks, [2, 2, 2, 1], [[3, 1, 4, 4, 6]]);
 
     // prettier-ignore
     const expected = [

--- a/src/test/ChunkPrefetchIterator.test.ts
+++ b/src/test/ChunkPrefetchIterator.test.ts
@@ -29,10 +29,8 @@ const EXPECTED_5X5X5X5_2 = [
   [2, 0, 2, 2, 4], // X++
 ];
 
-function validate(iter: ChunkPrefetchIterator, expected: number[][], debug = false) {
-  const iterResult = [...iter];
-  if (debug) console.log(iterResult);
-  expect(iterResult).to.deep.equal(expected);
+function validate(iter: ChunkPrefetchIterator, expected: number[][]) {
+  expect([...iter]).to.deep.equal(expected);
 }
 
 describe("ChunkPrefetchIterator", () => {
@@ -211,6 +209,6 @@ describe("ChunkPrefetchIterator", () => {
       // skip X--
       [0, 3, 0, 2, 3], // X++: all channels but channel 3 are maxed out
     ];
-    validate(iterator, expected, true);
+    validate(iterator, expected);
   });
 });


### PR DESCRIPTION
Review time: moderate (~30min)

#188 enabled loading into the same volume from multiple zarr sources (resolving most of #78), and included code to ensure those sources have scale levels with matching dimensions. However, its implementation has an important limitation: matching scale levels also must have matching chunk sizes. This limitation wasn't imposed due to any difficulties with fetching zarrs with different chunking strategies - zarrita will happily accept a slice into an array with any chunking strategy and work out which chunks to fetch on its own. But our *pre*fetching implementation assumed that it could safely apply the same chunk dimensions to every channel, which is not safe when different channels may come out of different source zarrs with different chunking strategies. So this PR allows us to deal with per-channel chunk dims when prefetching, removing the need for matching chunking strategies.

### Changes

- **ChunkPrefetchIterator.ts**: `ChunkPrefetchIterator` now accepts chunk sizes per source. The type of the corresponding field in the `ChunkPrefetchIterator` constructor was formerly `TZYX` (`[number, number, number, number]`), representing the number of chunks along those four axes. The type is now `TCZYX<number>[]`, representing the number of chunks along these four axes *per source*, and including C (the number of channels in the given source) to match up sources with channels.
- **OmeZarrLoader.ts**: now provides per-source dimensions.
- **ChunkPrefetchIterator.test.ts**: updated to use the new dimensions type described above, and added a test to verify that per-source bounds are handled as specified.
- **zarr_utils/utils.ts**: now that the above changes have been made, remove the restriction on matching chunking strategies.