### PR TITLE
Feature/lut refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ view3D.addVolume(aimg);
 for (let i = 0; i < volumeData.length; ++i) {
   aimg.setChannelDataFromVolume(i, volumeData[i]);
   // optional: initialize with a lookup table suitable for visualizing noisy biological data
-  aimg.channels[i].lutGenerator_percentiles(0.5, 0.998);
+  const hmin = aimg.getHistogram(i).findBinOfPercentile(0.5);
+  const hmax = aimg.getHistogram(i).findBinOfPercentile(0.983);
+  const lut = new Lut().createFromMinMax(hmin, hmax);
+  aimg.setLut(i, lut.lut);
 }
 
 // enable only the first 3 channels
@@ -101,7 +104,10 @@ export class VolumeViewer extends React.Component {
                 // download the volume data itself in the form of tiled png files
                 VolumeLoader.loadVolumeAtlasData(aimg, jsondata.images, (url, channelIndex) => {
                     // initialize each channel as it arrives and tell the view to update.
-                    aimg.channels[channelIndex].lutGenerator_percentiles(0.5, 0.998);
+                    const hmin = aimg.getHistogram(channelIndex).findBinOfPercentile(0.5);
+                    const hmax = aimg.getHistogram(channelIndex).findBinOfPercentile(0.983);
+                    const lut = new Lut().createFromMinMax(hmin, hmax);
+                    aimg.setLut(i, lut.lut);
 
                     this.view3D.setVolumeChannelEnabled(aimg, channelIndex, channelIndex < 3);
                     this.view3D.updateActiveChannels(aimg);

--- a/react-example/VolumeViewer.jsx
+++ b/react-example/VolumeViewer.jsx
@@ -31,8 +31,11 @@ export class VolumeViewer extends React.Component {
                     name: `${AICS_CELL_URL}/${img.name}`,
                 }));
                 VolumeLoader.loadVolumeAtlasData(aimg, jsondata.images, (url, channelIndex) => {
-                    aimg.channels[channelIndex].lutGenerator_percentiles(0.5, 0.998);
-
+                    const hmin = aimg.getHistogram(channelIndex).findBinOfPercentile(0.5);
+                    const hmax = aimg.getHistogram(channelIndex).findBinOfPercentile(0.983);
+                    const lut = new Lut().createFromMinMax(hmin, hmax);
+                    aimg.setLut(channelIndex, lut.lut);
+          
                     this.view3D.setVolumeChannelEnabled(aimg, channelIndex, channelIndex < 3);
                     this.view3D.updateActiveChannels(aimg);
 

--- a/react-example/gui-setup.js
+++ b/react-example/gui-setup.js
@@ -105,7 +105,9 @@ export function showChannelUI(volume, view3D, gui) {
       })(i),
       pct50_98: (function (j) {
         return function () {
-          const lut = volume.getHistogram(j).lutGenerator_percentiles(0.5, 0.998);
+          const hmin = volume.getHistogram(j).findBinOfPercentile(0.5);
+          const hmax = volume.getHistogram(j).findBinOfPercentile(0.983);
+          const lut = new Lut().createFromMinMax(hmin, hmax);
           volume.setLut(j, lut.lut);
           view3D.updateLuts(volume);
         };

--- a/react-example/gui-setup.js
+++ b/react-example/gui-setup.js
@@ -74,15 +74,8 @@ export function showChannelUI(volume, view3D, gui) {
       // this doesn't give good results currently but is an example of a per-channel button callback
       autoIJ: (function (j) {
         return function () {
-          const lut = volume.getHistogram(j).lutGenerator_auto2();
-          // TODO: get a proper transfer function editor
-          // const lut = { lut: makeColorGradient([
-          //     {offset:0, color:"black"},
-          //     {offset:0.2, color:"black"},
-          //     {offset:0.25, color:"red"},
-          //     {offset:0.5, color:"orange"},
-          //     {offset:1.0, color:"yellow"}])
-          // };
+          const [hmin, hmax] = volume.getHistogram(j).findAutoIJBins();
+          const lut = new Lut().createFromMinMax(hmin, hmax);
           volume.setLut(j, lut.lut);
           view3D.updateLuts(volume);
         };
@@ -90,7 +83,8 @@ export function showChannelUI(volume, view3D, gui) {
       // this doesn't give good results currently but is an example of a per-channel button callback
       auto0: (function (j) {
         return function () {
-          const lut = volume.getHistogram(j).lutGenerator_auto();
+          const [b, e] = volume.getHistogram(j).findAutoMinMax();
+          const lut = new Lut().createFromMinMax(b, e);
           volume.setLut(j, lut.lut);
           view3D.updateLuts(volume);
         };
@@ -98,7 +92,8 @@ export function showChannelUI(volume, view3D, gui) {
       // this doesn't give good results currently but is an example of a per-channel button callback
       bestFit: (function (j) {
         return function () {
-          const lut = volume.getHistogram(j).lutGenerator_bestFit();
+          const [hmin, hmax] = volume.getHistogram(j).findBestFitBins();
+          const lut = new Lut().createFromMinMax(hmin, hmax);
           volume.setLut(j, lut.lut);
           view3D.updateLuts(volume);
         };
@@ -209,7 +204,10 @@ export function showChannelUI(volume, view3D, gui) {
       .onChange(
         (function (j) {
           return function (value) {
-            volume.getChannel(j).lutGenerator_windowLevel(value, myState.infoObj.channelGui[j].level);
+            const hwindow = value;
+            const hlevel = myState.infoObj.channelGui[j].level;
+            const lut = new Lut().createFromWindowLevel(hwindow, hlevel);
+            volume.setLut(j, lut.lut);
             view3D.updateLuts(volume);
           };
         })(i)
@@ -223,7 +221,10 @@ export function showChannelUI(volume, view3D, gui) {
       .onChange(
         (function (j) {
           return function (value) {
-            volume.getChannel(j).lutGenerator_windowLevel(myState.infoObj.channelGui[j].window, value);
+            const hwindow = myState.infoObj.channelGui[j].window;
+            const hlevel = value;
+            const lut = new Lut().createFromWindowLevel(hwindow, hlevel);
+            volume.setLut(j, lut.lut);
             view3D.updateLuts(volume);
           };
         })(i)

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -1,5 +1,6 @@
 import { DataTexture, RedFormat, UnsignedByteType, RGBAFormat, LinearFilter, NearestFilter } from "three";
-import Histogram, { LUT_ARRAY_LENGTH, remapLut } from "./Histogram.js";
+import Histogram from "./Histogram.js";
+import { Lut, LUT_ARRAY_LENGTH, remapLut } from "./Lut.js";
 
 interface ChannelImageData {
   /** Returns the one-dimensional array containing the data in RGBA order, as integers in the range 0 to 255. */
@@ -262,7 +263,7 @@ export default class Channel {
     if (!this.loaded) {
       return;
     }
-    const lut = this.histogram.lutGenerator_windowLevel(wnd, lvl);
+    const lut = new Lut().createFromWindowLevel(wnd, lvl);
     this.setLut(lut.lut);
   }
 
@@ -270,7 +271,7 @@ export default class Channel {
     if (!this.loaded) {
       return;
     }
-    const lut = this.histogram.lutGenerator_minMax(imin, imax);
+    const lut = new Lut().createFromMinMax(imin, imax);
     this.setLut(lut.lut);
   }
 
@@ -278,7 +279,7 @@ export default class Channel {
     if (!this.loaded) {
       return;
     }
-    const lut = this.histogram.lutGenerator_fullRange();
+    const lut = new Lut().createFullRange();
     this.setLut(lut.lut);
   }
 
@@ -286,7 +287,7 @@ export default class Channel {
     if (!this.loaded) {
       return;
     }
-    const lut = this.histogram.lutGenerator_dataRange();
+    const lut = new Lut().createFromMinMax(this.histogram.getMin(), this.histogram.getMax());
     this.setLut(lut.lut);
   }
 
@@ -294,7 +295,8 @@ export default class Channel {
     if (!this.loaded) {
       return;
     }
-    const lut = this.histogram.lutGenerator_bestFit();
+    const [hmin, hmax] = this.histogram.findBestFitBins();
+    const lut = new Lut().createFromMinMax(hmin, hmax);
     this.setLut(lut.lut);
   }
 
@@ -303,7 +305,8 @@ export default class Channel {
     if (!this.loaded) {
       return;
     }
-    const lut = this.histogram.lutGenerator_auto2();
+    const [hmin, hmax] = this.histogram.findAutoIJBins();
+    const lut = new Lut().createFromMinMax(hmin, hmax);
     this.setLut(lut.lut);
   }
 
@@ -311,7 +314,8 @@ export default class Channel {
     if (!this.loaded) {
       return;
     }
-    const lut = this.histogram.lutGenerator_auto();
+    const [b, e] = this.histogram.findAutoMinMax();
+    const lut = new Lut().createFromMinMax(b, e);
     this.setLut(lut.lut);
   }
 
@@ -319,7 +323,7 @@ export default class Channel {
     if (!this.loaded) {
       return;
     }
-    const lut = this.histogram.lutGenerator_equalize();
+    const lut = new Lut().createFromEqHistogram(this.histogram);
     this.setLut(lut.lut);
   }
 
@@ -327,7 +331,9 @@ export default class Channel {
     if (!this.loaded) {
       return;
     }
-    const lut = this.histogram.lutGenerator_percentiles(lo, hi);
+    const hmin = this.histogram.findBinOfPercentile(lo);
+    const hmax = this.histogram.findBinOfPercentile(hi);
+    const lut = new Lut().createFromMinMax(hmin, hmax);
     this.setLut(lut.lut);
   }
   /* eslint-enable @typescript-eslint/naming-convention */

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -46,7 +46,8 @@ export default class Channel {
 
     // intensity remapping lookup table
     this.lut = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
-    this.lutGenerator_minMax(0, 255);
+    const lut = new Lut().createFromMinMax(0, 255);
+    this.setLut(lut.lut);
     // per-intensity color labeling (disabled initially)
     this.colorPalette = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
     // store in 0..1 range. 1 means fully colorPalette, 0 means fully lut.
@@ -141,7 +142,9 @@ export default class Channel {
     this.loaded = true;
     this.histogram = new Histogram(bitsArray);
 
-    this.lutGenerator_auto2();
+    const [hmin, hmax] = this.histogram.findAutoIJBins();
+    const lut = new Lut().createFromMinMax(hmin, hmax);
+    this.setLut(lut.lut);
   }
 
   // let's rearrange this.imgData.data into a 3d array.
@@ -257,84 +260,4 @@ export default class Channel {
   public setColorPaletteAlpha(alpha: number): void {
     this.colorPaletteAlpha = alpha;
   }
-
-  /* eslint-disable @typescript-eslint/naming-convention */
-  public lutGenerator_windowLevel(wnd: number, lvl: number): void {
-    if (!this.loaded) {
-      return;
-    }
-    const lut = new Lut().createFromWindowLevel(wnd, lvl);
-    this.setLut(lut.lut);
-  }
-
-  public lutGenerator_minMax(imin: number, imax: number): void {
-    if (!this.loaded) {
-      return;
-    }
-    const lut = new Lut().createFromMinMax(imin, imax);
-    this.setLut(lut.lut);
-  }
-
-  public lutGenerator_fullRange(): void {
-    if (!this.loaded) {
-      return;
-    }
-    const lut = new Lut().createFullRange();
-    this.setLut(lut.lut);
-  }
-
-  public lutGenerator_dataRange(): void {
-    if (!this.loaded) {
-      return;
-    }
-    const lut = new Lut().createFromMinMax(this.histogram.getMin(), this.histogram.getMax());
-    this.setLut(lut.lut);
-  }
-
-  public lutGenerator_bestFit(): void {
-    if (!this.loaded) {
-      return;
-    }
-    const [hmin, hmax] = this.histogram.findBestFitBins();
-    const lut = new Lut().createFromMinMax(hmin, hmax);
-    this.setLut(lut.lut);
-  }
-
-  // attempt to redo imagej's Auto
-  public lutGenerator_auto2(): void {
-    if (!this.loaded) {
-      return;
-    }
-    const [hmin, hmax] = this.histogram.findAutoIJBins();
-    const lut = new Lut().createFromMinMax(hmin, hmax);
-    this.setLut(lut.lut);
-  }
-
-  public lutGenerator_auto(): void {
-    if (!this.loaded) {
-      return;
-    }
-    const [b, e] = this.histogram.findAutoMinMax();
-    const lut = new Lut().createFromMinMax(b, e);
-    this.setLut(lut.lut);
-  }
-
-  public lutGenerator_equalize(): void {
-    if (!this.loaded) {
-      return;
-    }
-    const lut = new Lut().createFromEqHistogram(this.histogram);
-    this.setLut(lut.lut);
-  }
-
-  public lutGenerator_percentiles(lo: number, hi: number): void {
-    if (!this.loaded) {
-      return;
-    }
-    const hmin = this.histogram.findBinOfPercentile(lo);
-    const hmax = this.histogram.findBinOfPercentile(hi);
-    const lut = new Lut().createFromMinMax(hmin, hmax);
-    this.setLut(lut.lut);
-  }
-  /* eslint-enable @typescript-eslint/naming-convention */
 }

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -1,5 +1,3 @@
-import { Lut } from "./Lut.js";
-
 /**
  * Builds a histogram with 256 bins from a data array. Assume data is 8 bit single channel grayscale.
  * @class

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -1,17 +1,4 @@
-import { getColorByChannelIndex } from "./constants/colors.js";
-import { ControlPoint, Lut, LUT_ARRAY_LENGTH, LUT_ENTRIES } from "./Lut.js";
-
-function clamp(val: number, cmin: number, cmax: number): number {
-  return Math.min(Math.max(cmin, val), cmax);
-}
-
-function controlPointToRGBA(controlPoint) {
-  return [controlPoint.color[0], controlPoint.color[1], controlPoint.color[2], Math.floor(controlPoint.opacity * 255)];
-}
-
-function lerp(xmin, xmax, a) {
-  return a * (xmax - xmin) + xmin;
-}
+import { Lut } from "./Lut.js";
 
 /**
  * Builds a histogram with 256 bins from a data array. Assume data is 8 bit single channel grayscale.
@@ -81,213 +68,11 @@ export default class Histogram {
     return this.dataMax;
   }
 
-  /* eslint-disable @typescript-eslint/naming-convention */
-
-  /**
-   * Generate a Window/level lookup table
-   * @return {Lut}
-   * @param {number} wnd in 0..1 range
-   * @param {number} lvl in 0..1 range
-   */
-  lutGenerator_windowLevel(wnd: number, lvl: number): Lut {
-    // simple linear mapping for actual range
-    const b = lvl - wnd * 0.5;
-    const e = lvl + wnd * 0.5;
-    return this.lutGenerator_minMax(b * 255, e * 255);
+  getNumBins(): number {
+    return this.bins.length;
   }
-
-  /**
-   * Generate a piecewise linear lookup table that ramps up from 0 to 1 over the b to e domain.
-   * If e === b, then we use a step function with f(b) = 0 and f(b + 1) = 1
-   *  |
-   * 1|               +---------+-----
-   *  |              /
-   *  |             /
-   *  |            /
-   *  |           /
-   *  |          /
-   * 0+=========+---------------+-----
-   *  0         b    e         255
-   * @return {Lut}
-   * @param {number} b
-   * @param {number} e
-   */
-  lutGenerator_minMax(b: number, e: number): Lut {
-    if (e < b) {
-      // swap
-      const tmp = e;
-      e = b;
-      b = tmp;
-    }
-    const lut = new Uint8Array(LUT_ARRAY_LENGTH);
-    for (let x = 0; x < lut.length / 4; ++x) {
-      lut[x * 4 + 0] = 255;
-      lut[x * 4 + 1] = 255;
-      lut[x * 4 + 2] = 255;
-      if (x > e) {
-        lut[x * 4 + 3] = 255;
-      } else if (x <= b) {
-        lut[x * 4 + 3] = 0;
-      } else {
-        if (e === b) {
-          lut[x * 4 + 3] = 255;
-        } else {
-          const a = (x - b) / (e - b);
-          lut[x * 4 + 3] = lerp(0, 255, a);
-        }
-      }
-    }
-
-    // Edge case: b and e are both out of bounds
-    if (b < 0 && e < 0) {
-      return {
-        lut: lut,
-        controlPoints: [
-          { x: 0, opacity: 1, color: [255, 255, 255] },
-          { x: 255, opacity: 1, color: [255, 255, 255] },
-        ],
-      };
-    }
-    if (b >= 255 && e >= 255) {
-      return {
-        lut: lut,
-        controlPoints: [
-          { x: 0, opacity: 0, color: [255, 255, 255] },
-          { x: 255, opacity: 0, color: [255, 255, 255] },
-        ],
-      };
-    }
-
-    // Generate 2 to 4 control points for a minMax LUT, from left to right
-    const controlPoints: ControlPoint[] = [];
-
-    // Add starting point at x = 0
-    let startVal = 0;
-    if (b < 0) {
-      startVal = -b / (e - b);
-    }
-    controlPoints.push({ x: 0, opacity: startVal, color: [255, 255, 255] });
-
-    // If b > 0, add another point at (b, 0)
-    if (b > 0) {
-      controlPoints.push({ x: b, opacity: 0, color: [255, 255, 255] });
-    }
-
-    // If e < 255, Add another point at (e, 1)
-    if (e < 255) {
-      if (e === b) {
-        // Use b + 0.5 as x value instead of e to create a near-vertical ramp
-        controlPoints.push({ x: b + 0.5, opacity: 1, color: [255, 255, 255] });
-      } else {
-        controlPoints.push({ x: e, opacity: 1, color: [255, 255, 255] });
-      }
-    }
-
-    // Add ending point at x = 255
-    let endVal = 1;
-    if (e > 255) {
-      endVal = (255 - b) / (e - b);
-    }
-    controlPoints.push({ x: 255, opacity: endVal, color: [255, 255, 255] });
-
-    return {
-      lut: lut,
-      controlPoints: controlPoints,
-    };
-  }
-
-  /**
-   * Generate a straight 0-1 linear identity lookup table
-   * @return {Lut}
-   */
-  lutGenerator_fullRange(): Lut {
-    const lut = new Uint8Array(LUT_ARRAY_LENGTH);
-
-    // simple linear mapping for actual range
-    for (let x = 0; x < lut.length / 4; ++x) {
-      lut[x * 4 + 0] = 255;
-      lut[x * 4 + 1] = 255;
-      lut[x * 4 + 2] = 255;
-      lut[x * 4 + 3] = x;
-    }
-
-    return {
-      lut: lut,
-      controlPoints: [
-        { x: 0, opacity: 0, color: [255, 255, 255] },
-        { x: 255, opacity: 1, color: [255, 255, 255] },
-      ],
-    };
-  }
-
-  /**
-   * Generate a lookup table over the min to max range of the data values
-   * @return {Lut}
-   */
-  lutGenerator_dataRange(): Lut {
-    // simple linear mapping for actual range
-    const b = this.dataMin;
-    const e = this.dataMax;
-    return this.lutGenerator_minMax(b, e);
-  }
-
-  /**
-   * Generate a lookup table with a different color per intensity value
-   * @return {Lut}
-   */
-  lutGenerator_labelColors(): Lut {
-    const lut = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
-    // TODO specify type for control point
-    const controlPoints: ControlPoint[] = [];
-    controlPoints.push({ x: 0, opacity: 0, color: [0, 0, 0] });
-    let lastr = 0;
-    let lastg = 0;
-    let lastb = 0;
-    let lasta = 0;
-    let r = 0;
-    let g = 0;
-    let b = 0;
-    let a = 0;
-
-    // assumes exactly one bin per intensity value?
-    // skip zero!!!
-    for (let i = 1; i < this.bins.length; ++i) {
-      if (this.bins[i] > 0) {
-        const rgb = getColorByChannelIndex(i);
-
-        lut[i * 4 + 0] = rgb[0];
-        lut[i * 4 + 1] = rgb[1];
-        lut[i * 4 + 2] = rgb[2];
-        lut[i * 4 + 3] = 255;
-
-        r = rgb[0];
-        g = rgb[1];
-        b = rgb[2];
-        a = 1;
-      } else {
-        // add a zero control point?
-        r = 0;
-        g = 0;
-        b = 0;
-        a = 0;
-      }
-      // if current control point is same as last one don't add it
-      if (r !== lastr || g !== lastg || b !== lastb || a !== lasta) {
-        if (lasta === 0) {
-          controlPoints.push({ x: i - 0.5, opacity: lasta, color: [lastr, lastg, lastb] });
-        }
-        controlPoints.push({ x: i, opacity: a, color: [r, g, b] });
-        lastr = r;
-        lastg = g;
-        lastb = b;
-        lasta = a;
-      }
-    }
-
-    return {
-      lut: lut,
-      controlPoints: controlPoints,
-    };
+  getBin(i: number): number {
+    return this.bins[i];
   }
 
   /**
@@ -310,25 +95,8 @@ export default class Histogram {
     return i;
   }
 
-  /**
-   * Generate a lookup table based on histogram percentiles
-   * @return {Lut}
-   * @param {number} pmin
-   * @param {number} pmax
-   */
-  lutGenerator_percentiles(pmin: number, pmax: number): Lut {
-    // e.g. 0.50, 0.983 starts from 50th percentile bucket and ends at 98.3 percentile bucket.
-    const hmin = this.findBinOfPercentile(pmin);
-    const hmax = this.findBinOfPercentile(pmax);
-
-    return this.lutGenerator_minMax(hmin, hmax);
-  }
-
-  /**
-   * Generate a 10% / 90% lookup table
-   * @return {Lut}
-   */
-  lutGenerator_bestFit(): Lut {
+  // Generate a 10% / 90% lookup table
+  findBestFitBins(): [number, number] {
     const pixcount = this.nonzeroPixelCount;
     //const pixcount = this.imgData.data.length;
     const limit = pixcount / 10;
@@ -352,14 +120,11 @@ export default class Histogram {
     }
     const hmax = i;
 
-    return this.lutGenerator_minMax(hmin, hmax);
+    return [hmin, hmax];
   }
 
-  /**
-   * Generate a lookup table attempting to replicate ImageJ's "Auto" button
-   * @return {Lut}
-   */
-  lutGenerator_auto2(): Lut {
+  // Generate a lookup table attempting to replicate ImageJ's "Auto" button
+  findAutoIJBins(): [number, number] {
     const AUTO_THRESHOLD = 5000;
     const pixcount = this.nonzeroPixelCount;
     //  const pixcount = this.imgData.data.length;
@@ -383,18 +148,15 @@ export default class Histogram {
     }
 
     if (hmax < hmin) {
-      // just reset to whole range in this case.
-      return this.lutGenerator_fullRange();
-    } else {
-      return this.lutGenerator_minMax(hmin, hmax);
+      hmin = 0;
+      hmax = 255;
     }
+
+    return [hmin, hmax];
   }
 
-  /**
-   * Generate a lookup table using a percentile of the most commonly occurring value
-   * @return {Lut}
-   */
-  lutGenerator_auto(): Lut {
+  // Generate a lookup table using a percentile of the most commonly occurring value
+  findAutoMinMax(): [number, number] {
     // simple linear mapping cutting elements with small appearence
     // get 10% threshold
     const PERCENTAGE = 0.1;
@@ -413,262 +175,6 @@ export default class Histogram {
         break;
       }
     }
-
-    return this.lutGenerator_minMax(b, e);
+    return [b, e];
   }
-
-  /**
-   * Generate an "equalized" lookup table
-   * @return {Lut}
-   */
-  lutGenerator_equalize(): Lut {
-    const map: number[] = [];
-    for (let i = 0; i < this.bins.length; ++i) {
-      map[i] = 0;
-    }
-
-    // summed area table?
-    map[0] = this.bins[0];
-    for (let i = 1; i < this.bins.length; ++i) {
-      map[i] = map[i - 1] + this.bins[i];
-    }
-
-    const div = map[map.length - 1] - map[0];
-    if (div > 0) {
-      const lut = new Uint8Array(LUT_ARRAY_LENGTH);
-
-      // compute lut and track control points for the piecewise linear sections
-      const lutControlPoints: ControlPoint[] = [{ x: 0, opacity: 0, color: [255, 255, 255] }];
-      lut[0] = 255;
-      lut[1] = 255;
-      lut[2] = 255;
-      lut[3] = 0;
-      let slope = 0;
-      let lastSlope = 0;
-      let opacity = 0;
-      let lastOpacity = 0;
-      for (let i = 1; i < lut.length / 4; ++i) {
-        lut[i * 4 + 0] = 255;
-        lut[i * 4 + 1] = 255;
-        lut[i * 4 + 2] = 255;
-        lastOpacity = opacity;
-        opacity = clamp(Math.round(255 * (map[i] - map[0])), 0, 255);
-        lut[i * 4 + 3] = opacity;
-
-        slope = opacity - lastOpacity;
-        // if map[i]-map[i-1] is the same as map[i+1]-map[i] then we are in a linear segment and do not need a new control point
-        if (slope != lastSlope) {
-          lutControlPoints.push({ x: i - 1, opacity: lastOpacity / 255.0, color: [255, 255, 255] });
-          lastSlope = slope;
-        }
-      }
-
-      lutControlPoints.push({ x: 255, opacity: 1, color: [255, 255, 255] });
-
-      return {
-        lut: lut,
-        controlPoints: lutControlPoints,
-      };
-    } else {
-      // just reset to whole range in this case...?
-      return this.lutGenerator_fullRange();
-    }
-  }
-
-  // @param {Object[]} controlPoints - array of {x:number 0..255, opacity:number 0..1, color:array of 3 numbers 0..255}
-  // @return {Uint8Array} array of length 256*4 representing the rgba values of the gradient
-  lutGenerator_fromControlPoints(controlPoints: ControlPoint[]): Lut {
-    const lut = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
-
-    if (controlPoints.length === 0) {
-      return { lut: lut, controlPoints: controlPoints };
-    }
-
-    // ensure they are sorted in ascending order of x
-    controlPoints.sort((a, b) => a.x - b.x);
-
-    // special case only one control point.
-    if (controlPoints.length === 1) {
-      const rgba = controlPointToRGBA(controlPoints[0]);
-      // copy val from x to 255.
-      for (let x = controlPoints[0].x; x < 256; ++x) {
-        lut[x * 4 + 0] = rgba[0];
-        lut[x * 4 + 1] = rgba[1];
-        lut[x * 4 + 2] = rgba[2];
-        lut[x * 4 + 3] = rgba[3];
-      }
-      return { lut: lut, controlPoints: controlPoints };
-    }
-
-    let c0 = controlPoints[0];
-    let c1 = controlPoints[1];
-    let color0 = controlPointToRGBA(c0);
-    let color1 = controlPointToRGBA(c1);
-    let lastIndex = 1;
-    let a = 0;
-    // if the first control point is after 0, act like there are 0s going all the way up to it.
-    // or lerp up to the first point?
-    for (let x = c0.x; x < 256; ++x) {
-      while (x > c1.x) {
-        // advance control points
-        c0 = c1;
-        color0 = color1;
-        lastIndex++;
-        if (lastIndex >= controlPoints.length) {
-          // if the last control point is before 255, then we want to continue its value all the way to 255.
-          c1 = { x: 255, color: c1.color, opacity: c1.opacity };
-        } else {
-          c1 = controlPoints[lastIndex];
-        }
-        color1 = controlPointToRGBA(c1);
-      }
-      if (c1.x === c0.x) {
-        // use c1
-        a = 1.0;
-      } else {
-        a = (x - c0.x) / (c1.x - c0.x);
-      }
-      // lerp the colors
-      lut[x * 4 + 0] = lerp(color0[0], color1[0], a);
-      lut[x * 4 + 1] = lerp(color0[1], color1[1], a);
-      lut[x * 4 + 2] = lerp(color0[2], color1[2], a);
-      lut[x * 4 + 3] = lerp(color0[3], color1[3], a);
-    }
-    return { lut: lut, controlPoints: controlPoints };
-  }
-  /* eslint-enable @typescript-eslint/naming-convention */
 }
-
-// We have an intensity value that is in the range of valueMin to valueMax.
-// This domain is assumed to have been remapped from oldMin to oldMax.
-// We now wish to find the intensity value that corresponds to the same relative position in the new domain of newMin to newMax.
-// For our Luts valueMin will always be 0, and valueMax will always be 255.
-// oldMin and oldMax will be the domain of the original raw data intensities.
-// newMin and newMax will be the domain of the new raw data intensities.
-function remapDomain(
-  value: number,
-  valueMin: number,
-  valueMax: number,
-  oldMin: number,
-  oldMax: number,
-  newMin: number,
-  newMax: number
-): number {
-  const pctOfRange = (value - valueMin) / (valueMax - valueMin);
-  const newValue = (newMax - newMin) * pctOfRange + newMin;
-  // now locate this value as a relative index in the old range
-  const pctOfOldRange = (newValue - oldMin) / (oldMax - oldMin);
-  const remapped = valueMin + pctOfOldRange * (valueMax - valueMin);
-  return remapped;
-}
-
-// If the new max is greater than the old max, then
-// the lut's max end will move inward to the left.
-// This is another way of saying that the new max's index is greater than 255 in the old lut
-// If the new min is less than the old min, then
-// the lut's min end will move inward to the right.
-// This is another way of saying that the new min's index is less than 0 in the old lut
-export function remapLut(lut: Uint8Array, oldMin: number, oldMax: number, newMin: number, newMax: number): Uint8Array {
-  const newLut = new Uint8Array(LUT_ARRAY_LENGTH);
-
-  // we will find what intensity is at each index in the new range,
-  // and then try to sample the pre-existing lut as if it spans the old range.
-  // Build new lut by sampling from old lut.
-  for (let i = 0; i < LUT_ENTRIES; ++i) {
-    let iOld = remapDomain(i, 0, LUT_ENTRIES - 1, oldMin, oldMax, newMin, newMax);
-    if (iOld < 0) {
-      iOld = 0;
-    }
-    if (iOld > LUT_ENTRIES - 1) {
-      iOld = LUT_ENTRIES - 1;
-    }
-    // find the indices above and below for interpolation
-    const i0 = Math.floor(iOld);
-    const i1 = Math.ceil(iOld);
-    const pct = iOld - i0;
-
-    //console.log(`interpolating ${iOld}: ${lut[i0 * 4 + 3]}, ${lut[i1 * 4 + 3]}, ${pct}`);
-    newLut[i * 4 + 0] = Math.round(lerp(lut[i0 * 4 + 0], lut[i1 * 4 + 0], pct));
-    newLut[i * 4 + 1] = Math.round(lerp(lut[i0 * 4 + 1], lut[i1 * 4 + 1], pct));
-    newLut[i * 4 + 2] = Math.round(lerp(lut[i0 * 4 + 2], lut[i1 * 4 + 2], pct));
-    newLut[i * 4 + 3] = Math.round(lerp(lut[i0 * 4 + 3], lut[i1 * 4 + 3], pct));
-  }
-
-  return newLut;
-}
-
-export function remapControlPoints(
-  controlPoints: ControlPoint[],
-  oldMin: number,
-  oldMax: number,
-  newMin: number,
-  newMax: number
-): ControlPoint[] {
-  const newControlPoints: ControlPoint[] = [];
-
-  // assume control point x domain 0-255 is mapped to oldMin-oldMax
-
-  // remap all cp x values.
-  // interpolate all new colors and opacities
-  // then see if we need to clip?
-  for (let i = 0; i < controlPoints.length; ++i) {
-    const cp = controlPoints[i];
-    const iOld = remapDomain(cp.x, 0, LUT_ENTRIES - 1, oldMin, oldMax, newMin, newMax);
-    const newCP: ControlPoint = {
-      x: iOld,
-      opacity: cp.opacity,
-      color: [cp.color[0], cp.color[1], cp.color[2]],
-    };
-    newControlPoints.push(newCP);
-  }
-  // now fix up any control points that are out of bounds?
-  // For a CP less than 0, shift it to 0 and interpolate the values according to the slope
-  // For a CP greater than 255, shift it to 255 and interpolate the values according to the slope
-  // All others out of this range can then be dropped.
-  // We will look above and below each cp to see if it's on a boundary.
-  const resultControlPoints: ControlPoint[] = [];
-
-  for (let i = 0; i < newControlPoints.length; ++i) {
-    const cp = newControlPoints[i];
-    const cpPrev = i > 0 ? newControlPoints[i - 1] : cp;
-    const cpNext = i < newControlPoints.length - 1 ? newControlPoints[i + 1] : cp;
-
-    if (cp.x < 0 && cpNext.x > 0) {
-      // interpolate
-      const pct = (0 - cp.x) / (cpNext.x - cp.x);
-      cp.opacity = lerp(cp.opacity, cpNext.opacity, pct);
-      cp.color[0] = lerp(cp.color[0], cpNext.color[0], pct);
-      cp.color[1] = lerp(cp.color[1], cpNext.color[1], pct);
-      cp.color[2] = lerp(cp.color[2], cpNext.color[2], pct);
-      // shift cp to 0
-      cp.x = 0;
-    } else if (cp.x > 255 && cpPrev.x < 255) {
-      // interpolate
-      const pct = (cp.x - 255) / (cp.x - cpPrev.x);
-      cp.opacity = lerp(cpPrev.opacity, cp.opacity, pct);
-      cp.color[0] = lerp(cpPrev.color[0], cp.color[0], pct);
-      cp.color[1] = lerp(cpPrev.color[1], cp.color[1], pct);
-      cp.color[2] = lerp(cpPrev.color[2], cp.color[2], pct);
-      // shift cp to 255
-      cp.x = 255;
-    }
-    if (cp.x >= 0 && cp.x <= 255) {
-      resultControlPoints.push(cp);
-    }
-  }
-
-  // lastly, add a point for start and end if needed.
-  if (resultControlPoints[0].x !== 0) {
-    resultControlPoints.unshift({ x: 0, opacity: resultControlPoints[0].opacity, color: resultControlPoints[0].color });
-  }
-  if (resultControlPoints[resultControlPoints.length - 1].x !== 255) {
-    resultControlPoints.push({
-      x: 255,
-      opacity: resultControlPoints[resultControlPoints.length - 1].opacity,
-      color: resultControlPoints[resultControlPoints.length - 1].color,
-    });
-  }
-  return resultControlPoints;
-}
-
-export { LUT_ARRAY_LENGTH };

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -93,7 +93,7 @@ export default class Histogram {
     return i;
   }
 
-  // Generate a 10% / 90% lookup table
+  // Find bins at 10th / 90th percentile
   findBestFitBins(): [number, number] {
     const pixcount = this.nonzeroPixelCount;
     //const pixcount = this.imgData.data.length;
@@ -121,7 +121,7 @@ export default class Histogram {
     return [hmin, hmax];
   }
 
-  // Generate a lookup table attempting to replicate ImageJ's "Auto" button
+  // Find min and max bins attempting to replicate ImageJ's "Auto" button
   findAutoIJBins(): [number, number] {
     const AUTO_THRESHOLD = 5000;
     const pixcount = this.nonzeroPixelCount;
@@ -153,7 +153,7 @@ export default class Histogram {
     return [hmin, hmax];
   }
 
-  // Generate a lookup table using a percentile of the most commonly occurring value
+  // Find min and max bins using a percentile of the most commonly occurring value
   findAutoMinMax(): [number, number] {
     // simple linear mapping cutting elements with small appearence
     // get 10% threshold

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -1,4 +1,5 @@
 import { getColorByChannelIndex } from "./constants/colors.js";
+import { ControlPoint, Lut, LUT_ARRAY_LENGTH, LUT_ENTRIES } from "./Lut.js";
 
 function clamp(val: number, cmin: number, cmax: number): number {
   return Math.min(Math.max(cmin, val), cmax);
@@ -11,33 +12,6 @@ function controlPointToRGBA(controlPoint) {
 function lerp(xmin, xmax, a) {
   return a * (xmax - xmin) + xmin;
 }
-
-const LUT_ENTRIES = 256;
-const LUT_ARRAY_LENGTH = LUT_ENTRIES * 4;
-
-/**
- * @typedef {Object} ControlPoint Used for the TF (transfer function) editor GUI.
- * Need to be converted to LUT for rendering.
- * @property {number} x The X Coordinate
- * @property {number} opacity The Opacity, from 0 to 1
- * @property {Array.<number>} color The Color, 3 numbers from 0-255 for r,g,b
- */
-
-/**
- * @typedef {Object} Lut Used for rendering.
- * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array
- * (maps scalar intensity to a rgb color plus alpha, with each value from 0-255)
- * @property {Array.<ControlPoint>} controlPoints
- */
-export type ControlPoint = {
-  x: number;
-  opacity: number;
-  color: [number, number, number];
-};
-export type Lut = {
-  lut: Uint8Array;
-  controlPoints: ControlPoint[];
-};
 
 /**
  * Builds a histogram with 256 bins from a data array. Assume data is 8 bit single channel grayscale.

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -1,0 +1,31 @@
+export const LUT_ENTRIES = 256;
+export const LUT_ARRAY_LENGTH = LUT_ENTRIES * 4;
+
+/**
+ * @typedef {Object} ControlPoint Used for the TF (transfer function) editor GUI.
+ * Need to be converted to LUT for rendering.
+ * @property {number} x The X Coordinate
+ * @property {number} opacity The Opacity, from 0 to 1
+ * @property {Array.<number>} color The Color, 3 numbers from 0-255 for r,g,b
+ */
+export type ControlPoint = {
+  x: number;
+  opacity: number;
+  color: [number, number, number];
+};
+
+/**
+ * @typedef {Object} Lut Used for rendering.
+ * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array
+ * (maps scalar intensity to a rgb color plus alpha, with each value from 0-255)
+ * @property {Array.<ControlPoint>} controlPoints
+ */
+export class Lut {
+  public lut: Uint8Array;
+  public controlPoints: ControlPoint[];
+
+  constructor() {
+    this.lut = new Uint8Array(LUT_ARRAY_LENGTH);
+    this.controlPoints = [];
+  }
+}

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -1,3 +1,37 @@
+import { getColorByChannelIndex } from "./constants/colors.js";
+import Histogram from "./Histogram.js";
+
+function clamp(val: number, cmin: number, cmax: number): number {
+  return Math.min(Math.max(cmin, val), cmax);
+}
+
+function lerp(xmin, xmax, a) {
+  return a * (xmax - xmin) + xmin;
+}
+
+// We have an intensity value that is in the range of valueMin to valueMax.
+// This domain is assumed to have been remapped from oldMin to oldMax.
+// We now wish to find the intensity value that corresponds to the same relative position in the new domain of newMin to newMax.
+// For our Luts valueMin will always be 0, and valueMax will always be 255.
+// oldMin and oldMax will be the domain of the original raw data intensities.
+// newMin and newMax will be the domain of the new raw data intensities.
+function remapDomain(
+  value: number,
+  valueMin: number,
+  valueMax: number,
+  oldMin: number,
+  oldMax: number,
+  newMin: number,
+  newMax: number
+): number {
+  const pctOfRange = (value - valueMin) / (valueMax - valueMin);
+  const newValue = (newMax - newMin) * pctOfRange + newMin;
+  // now locate this value as a relative index in the old range
+  const pctOfOldRange = (newValue - oldMin) / (oldMax - oldMin);
+  const remapped = valueMin + pctOfOldRange * (valueMax - valueMin);
+  return remapped;
+}
+
 export const LUT_ENTRIES = 256;
 export const LUT_ARRAY_LENGTH = LUT_ENTRIES * 4;
 
@@ -14,6 +48,10 @@ export type ControlPoint = {
   color: [number, number, number];
 };
 
+function controlPointToRGBA(controlPoint) {
+  return [controlPoint.color[0], controlPoint.color[1], controlPoint.color[2], Math.floor(controlPoint.opacity * 255)];
+}
+
 /**
  * @typedef {Object} Lut Used for rendering.
  * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array
@@ -27,5 +65,436 @@ export class Lut {
   constructor() {
     this.lut = new Uint8Array(LUT_ARRAY_LENGTH);
     this.controlPoints = [];
+    this.createFullRange();
   }
+
+  /**
+   * Generate a piecewise linear lookup table that ramps up from 0 to 1 over the b to e domain.
+   * If e === b, then we use a step function with f(b) = 0 and f(b + 1) = 1
+   *  |
+   * 1|               +---------+-----
+   *  |              /
+   *  |             /
+   *  |            /
+   *  |           /
+   *  |          /
+   * 0+=========+---------------+-----
+   *  0         b    e         255
+   * @return {Lut}
+   * @param {number} b
+   * @param {number} e
+   */
+  createFromMinMax(b: number, e: number): Lut {
+    if (e < b) {
+      // swap
+      const tmp = e;
+      e = b;
+      b = tmp;
+    }
+    const lut = new Uint8Array(LUT_ARRAY_LENGTH);
+    for (let x = 0; x < lut.length / 4; ++x) {
+      lut[x * 4 + 0] = 255;
+      lut[x * 4 + 1] = 255;
+      lut[x * 4 + 2] = 255;
+      if (x > e) {
+        lut[x * 4 + 3] = 255;
+      } else if (x <= b) {
+        lut[x * 4 + 3] = 0;
+      } else {
+        if (e === b) {
+          lut[x * 4 + 3] = 255;
+        } else {
+          const a = (x - b) / (e - b);
+          lut[x * 4 + 3] = lerp(0, 255, a);
+        }
+      }
+    }
+
+    // Edge case: b and e are both out of bounds
+    if (b < 0 && e < 0) {
+      this.lut = lut;
+      this.controlPoints = [
+        { x: 0, opacity: 1, color: [255, 255, 255] },
+        { x: 255, opacity: 1, color: [255, 255, 255] },
+      ];
+      return this;
+    }
+    if (b >= 255 && e >= 255) {
+      this.lut = lut;
+      this.controlPoints = [
+        { x: 0, opacity: 0, color: [255, 255, 255] },
+        { x: 255, opacity: 0, color: [255, 255, 255] },
+      ];
+      return this;
+    }
+
+    // Generate 2 to 4 control points for a minMax LUT, from left to right
+    const controlPoints: ControlPoint[] = [];
+
+    // Add starting point at x = 0
+    let startVal = 0;
+    if (b < 0) {
+      startVal = -b / (e - b);
+    }
+    controlPoints.push({ x: 0, opacity: startVal, color: [255, 255, 255] });
+
+    // If b > 0, add another point at (b, 0)
+    if (b > 0) {
+      controlPoints.push({ x: b, opacity: 0, color: [255, 255, 255] });
+    }
+
+    // If e < 255, Add another point at (e, 1)
+    if (e < 255) {
+      if (e === b) {
+        // Use b + 0.5 as x value instead of e to create a near-vertical ramp
+        controlPoints.push({ x: b + 0.5, opacity: 1, color: [255, 255, 255] });
+      } else {
+        controlPoints.push({ x: e, opacity: 1, color: [255, 255, 255] });
+      }
+    }
+
+    // Add ending point at x = 255
+    let endVal = 1;
+    if (e > 255) {
+      endVal = (255 - b) / (e - b);
+    }
+    controlPoints.push({ x: 255, opacity: endVal, color: [255, 255, 255] });
+
+    this.lut = lut;
+    this.controlPoints = controlPoints;
+    return this;
+  }
+
+  // basically, the identity LUT with respect to opacity
+  createFullRange(): Lut {
+    const lut = new Uint8Array(LUT_ARRAY_LENGTH);
+
+    // simple linear mapping for actual range
+    for (let x = 0; x < lut.length / 4; ++x) {
+      lut[x * 4 + 0] = 255;
+      lut[x * 4 + 1] = 255;
+      lut[x * 4 + 2] = 255;
+      lut[x * 4 + 3] = x;
+    }
+
+    this.lut = lut;
+    this.controlPoints = [
+      { x: 0, opacity: 0, color: [255, 255, 255] },
+      { x: 255, opacity: 1, color: [255, 255, 255] },
+    ];
+    return this;
+  }
+
+  /**
+   * Generate a Window/level lookup table
+   * @return {Lut}
+   * @param {number} wnd in 0..1 range
+   * @param {number} lvl in 0..1 range
+   */
+  createFromWindowLevel(wnd: number, lvl: number): Lut {
+    // simple linear mapping for actual range
+    const b = lvl - wnd * 0.5;
+    const e = lvl + wnd * 0.5;
+    return this.createFromMinMax(b * 255, e * 255);
+  }
+
+  // @param {Object[]} controlPoints - array of {x:number 0..255, opacity:number 0..1, color:array of 3 numbers 0..255}
+  // @return {Uint8Array} array of length 256*4 representing the rgba values of the gradient
+  createFromControlPoints(controlPoints: ControlPoint[]): Lut {
+    const lut = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
+
+    if (controlPoints.length === 0) {
+      this.lut = lut;
+      this.controlPoints = controlPoints;
+      return this;
+    }
+
+    // ensure they are sorted in ascending order of x
+    controlPoints.sort((a, b) => a.x - b.x);
+
+    // special case only one control point.
+    if (controlPoints.length === 1) {
+      const rgba = controlPointToRGBA(controlPoints[0]);
+      // copy val from x to 255.
+      for (let x = controlPoints[0].x; x < 256; ++x) {
+        lut[x * 4 + 0] = rgba[0];
+        lut[x * 4 + 1] = rgba[1];
+        lut[x * 4 + 2] = rgba[2];
+        lut[x * 4 + 3] = rgba[3];
+      }
+      this.lut = lut;
+      this.controlPoints = controlPoints;
+      return this;
+    }
+
+    let c0 = controlPoints[0];
+    let c1 = controlPoints[1];
+    let color0 = controlPointToRGBA(c0);
+    let color1 = controlPointToRGBA(c1);
+    let lastIndex = 1;
+    let a = 0;
+    // if the first control point is after 0, act like there are 0s going all the way up to it.
+    // or lerp up to the first point?
+    for (let x = c0.x; x < 256; ++x) {
+      while (x > c1.x) {
+        // advance control points
+        c0 = c1;
+        color0 = color1;
+        lastIndex++;
+        if (lastIndex >= controlPoints.length) {
+          // if the last control point is before 255, then we want to continue its value all the way to 255.
+          c1 = { x: 255, color: c1.color, opacity: c1.opacity };
+        } else {
+          c1 = controlPoints[lastIndex];
+        }
+        color1 = controlPointToRGBA(c1);
+      }
+      if (c1.x === c0.x) {
+        // use c1
+        a = 1.0;
+      } else {
+        a = (x - c0.x) / (c1.x - c0.x);
+      }
+      // lerp the colors
+      lut[x * 4 + 0] = lerp(color0[0], color1[0], a);
+      lut[x * 4 + 1] = lerp(color0[1], color1[1], a);
+      lut[x * 4 + 2] = lerp(color0[2], color1[2], a);
+      lut[x * 4 + 3] = lerp(color0[3], color1[3], a);
+    }
+    this.lut = lut;
+    this.controlPoints = controlPoints;
+    return this;
+  }
+
+  /**
+   * Generate an "equalized" lookup table
+   * @return {Lut}
+   */
+  createFromEqHistogram(histogram: Histogram): Lut {
+    const map: number[] = [];
+    for (let i = 0; i < histogram.getNumBins(); ++i) {
+      map[i] = 0;
+    }
+
+    // summed area table?
+    map[0] = histogram.getBin(0);
+    for (let i = 1; i < histogram.getNumBins(); ++i) {
+      map[i] = map[i - 1] + histogram.getBin(i);
+    }
+
+    const div = map[map.length - 1] - map[0];
+    if (div > 0) {
+      const lut = new Uint8Array(LUT_ARRAY_LENGTH);
+
+      // compute lut and track control points for the piecewise linear sections
+      const lutControlPoints: ControlPoint[] = [{ x: 0, opacity: 0, color: [255, 255, 255] }];
+      lut[0] = 255;
+      lut[1] = 255;
+      lut[2] = 255;
+      lut[3] = 0;
+      let slope = 0;
+      let lastSlope = 0;
+      let opacity = 0;
+      let lastOpacity = 0;
+      for (let i = 1; i < lut.length / 4; ++i) {
+        lut[i * 4 + 0] = 255;
+        lut[i * 4 + 1] = 255;
+        lut[i * 4 + 2] = 255;
+        lastOpacity = opacity;
+        opacity = clamp(Math.round(255 * (map[i] - map[0])), 0, 255);
+        lut[i * 4 + 3] = opacity;
+
+        slope = opacity - lastOpacity;
+        // if map[i]-map[i-1] is the same as map[i+1]-map[i] then we are in a linear segment and do not need a new control point
+        if (slope != lastSlope) {
+          lutControlPoints.push({ x: i - 1, opacity: lastOpacity / 255.0, color: [255, 255, 255] });
+          lastSlope = slope;
+        }
+      }
+
+      lutControlPoints.push({ x: 255, opacity: 1, color: [255, 255, 255] });
+
+      this.lut = lut;
+      this.controlPoints = lutControlPoints;
+      return this;
+    } else {
+      // just reset to whole range in this case...?
+      return this.createFullRange();
+    }
+  }
+
+  /**
+   * Generate a lookup table with a different color per intensity value
+   * @return {Lut}
+   */
+  createLabelColors(histogram: Histogram): Lut {
+    const lut = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
+    // TODO specify type for control point
+    const controlPoints: ControlPoint[] = [];
+    controlPoints.push({ x: 0, opacity: 0, color: [0, 0, 0] });
+    let lastr = 0;
+    let lastg = 0;
+    let lastb = 0;
+    let lasta = 0;
+    let r = 0;
+    let g = 0;
+    let b = 0;
+    let a = 0;
+
+    // assumes exactly one bin per intensity value?
+    // skip zero!!!
+    for (let i = 1; i < histogram.getNumBins(); ++i) {
+      if (histogram.getBin(i) > 0) {
+        const rgb = getColorByChannelIndex(i);
+
+        lut[i * 4 + 0] = rgb[0];
+        lut[i * 4 + 1] = rgb[1];
+        lut[i * 4 + 2] = rgb[2];
+        lut[i * 4 + 3] = 255;
+
+        r = rgb[0];
+        g = rgb[1];
+        b = rgb[2];
+        a = 1;
+      } else {
+        // add a zero control point?
+        r = 0;
+        g = 0;
+        b = 0;
+        a = 0;
+      }
+      // if current control point is same as last one don't add it
+      if (r !== lastr || g !== lastg || b !== lastb || a !== lasta) {
+        if (lasta === 0) {
+          controlPoints.push({ x: i - 0.5, opacity: lasta, color: [lastr, lastg, lastb] });
+        }
+        controlPoints.push({ x: i, opacity: a, color: [r, g, b] });
+        lastr = r;
+        lastg = g;
+        lastb = b;
+        lasta = a;
+      }
+    }
+
+    this.lut = lut;
+    this.controlPoints = controlPoints;
+    return this;
+  }
+
+  // since this is not a "create" function, it doesn't need to return the object.
+  remapDomains(oldMin: number, oldMax: number, newMin: number, newMax: number) {
+    // no attempt is made here to ensure that lut and controlPoints are internally consistent.
+    // if they start out consistent, they should end up consistent. And vice versa.
+    this.lut = remapLut(this.lut, oldMin, oldMax, newMin, newMax);
+    this.controlPoints = remapControlPoints(this.controlPoints, oldMin, oldMax, newMin, newMax);
+  }
+}
+
+// If the new max is greater than the old max, then
+// the lut's max end will move inward to the left.
+// This is another way of saying that the new max's index is greater than 255 in the old lut
+// If the new min is less than the old min, then
+// the lut's min end will move inward to the right.
+// This is another way of saying that the new min's index is less than 0 in the old lut
+export function remapLut(lut: Uint8Array, oldMin: number, oldMax: number, newMin: number, newMax: number): Uint8Array {
+  const newLut = new Uint8Array(LUT_ARRAY_LENGTH);
+
+  // we will find what intensity is at each index in the new range,
+  // and then try to sample the pre-existing lut as if it spans the old range.
+  // Build new lut by sampling from old lut.
+  for (let i = 0; i < LUT_ENTRIES; ++i) {
+    let iOld = remapDomain(i, 0, LUT_ENTRIES - 1, oldMin, oldMax, newMin, newMax);
+    if (iOld < 0) {
+      iOld = 0;
+    }
+    if (iOld > LUT_ENTRIES - 1) {
+      iOld = LUT_ENTRIES - 1;
+    }
+    // find the indices above and below for interpolation
+    const i0 = Math.floor(iOld);
+    const i1 = Math.ceil(iOld);
+    const pct = iOld - i0;
+
+    //console.log(`interpolating ${iOld}: ${lut[i0 * 4 + 3]}, ${lut[i1 * 4 + 3]}, ${pct}`);
+    newLut[i * 4 + 0] = Math.round(lerp(lut[i0 * 4 + 0], lut[i1 * 4 + 0], pct));
+    newLut[i * 4 + 1] = Math.round(lerp(lut[i0 * 4 + 1], lut[i1 * 4 + 1], pct));
+    newLut[i * 4 + 2] = Math.round(lerp(lut[i0 * 4 + 2], lut[i1 * 4 + 2], pct));
+    newLut[i * 4 + 3] = Math.round(lerp(lut[i0 * 4 + 3], lut[i1 * 4 + 3], pct));
+  }
+
+  return newLut;
+}
+
+export function remapControlPoints(
+  controlPoints: ControlPoint[],
+  oldMin: number,
+  oldMax: number,
+  newMin: number,
+  newMax: number
+): ControlPoint[] {
+  const newControlPoints: ControlPoint[] = [];
+
+  // assume control point x domain 0-255 is mapped to oldMin-oldMax
+
+  // remap all cp x values.
+  // interpolate all new colors and opacities
+  // then see if we need to clip?
+  for (let i = 0; i < controlPoints.length; ++i) {
+    const cp = controlPoints[i];
+    const iOld = remapDomain(cp.x, 0, LUT_ENTRIES - 1, oldMin, oldMax, newMin, newMax);
+    const newCP: ControlPoint = {
+      x: iOld,
+      opacity: cp.opacity,
+      color: [cp.color[0], cp.color[1], cp.color[2]],
+    };
+    newControlPoints.push(newCP);
+  }
+  // now fix up any control points that are out of bounds?
+  // For a CP less than 0, shift it to 0 and interpolate the values according to the slope
+  // For a CP greater than 255, shift it to 255 and interpolate the values according to the slope
+  // All others out of this range can then be dropped.
+  // We will look above and below each cp to see if it's on a boundary.
+  const resultControlPoints: ControlPoint[] = [];
+
+  for (let i = 0; i < newControlPoints.length; ++i) {
+    const cp = newControlPoints[i];
+    const cpPrev = i > 0 ? newControlPoints[i - 1] : cp;
+    const cpNext = i < newControlPoints.length - 1 ? newControlPoints[i + 1] : cp;
+
+    if (cp.x < 0 && cpNext.x > 0) {
+      // interpolate
+      const pct = (0 - cp.x) / (cpNext.x - cp.x);
+      cp.opacity = lerp(cp.opacity, cpNext.opacity, pct);
+      cp.color[0] = lerp(cp.color[0], cpNext.color[0], pct);
+      cp.color[1] = lerp(cp.color[1], cpNext.color[1], pct);
+      cp.color[2] = lerp(cp.color[2], cpNext.color[2], pct);
+      // shift cp to 0
+      cp.x = 0;
+    } else if (cp.x > 255 && cpPrev.x < 255) {
+      // interpolate
+      const pct = (cp.x - 255) / (cp.x - cpPrev.x);
+      cp.opacity = lerp(cpPrev.opacity, cp.opacity, pct);
+      cp.color[0] = lerp(cpPrev.color[0], cp.color[0], pct);
+      cp.color[1] = lerp(cpPrev.color[1], cp.color[1], pct);
+      cp.color[2] = lerp(cpPrev.color[2], cp.color[2], pct);
+      // shift cp to 255
+      cp.x = 255;
+    }
+    if (cp.x >= 0 && cp.x <= 255) {
+      resultControlPoints.push(cp);
+    }
+  }
+
+  // lastly, add a point for start and end if needed.
+  if (resultControlPoints[0].x !== 0) {
+    resultControlPoints.unshift({ x: 0, opacity: resultControlPoints[0].opacity, color: resultControlPoints[0].color });
+  }
+  if (resultControlPoints[resultControlPoints.length - 1].x !== 255) {
+    resultControlPoints.push({
+      x: 255,
+      opacity: resultControlPoints[resultControlPoints.length - 1].opacity,
+      color: resultControlPoints[resultControlPoints.length - 1].color,
+    });
+  }
+  return resultControlPoints;
 }

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -329,7 +329,6 @@ export class Lut {
    */
   createLabelColors(histogram: Histogram): Lut {
     const lut = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
-    // TODO specify type for control point
     const controlPoints: ControlPoint[] = [];
     controlPoints.push({ x: 0, opacity: 0, color: [0, 0, 0] });
     let lastr = 0;

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -324,7 +324,8 @@ export class Lut {
   }
 
   /**
-   * Generate a lookup table with a different color per intensity value
+   * Generate a lookup table with a different color per intensity value.
+   * This translates to a unique color per histogram bin with more than zero pixels.
    * @return {Lut}
    */
   createLabelColors(histogram: Histogram): Lut {

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -28,7 +28,7 @@ import {
   pathTracingUniforms,
   pathTracingVertexShaderSrc,
 } from "./constants/volumePTshader.js";
-import { LUT_ARRAY_LENGTH } from "./Histogram.js";
+import { LUT_ARRAY_LENGTH } from "./Lut.js";
 import Volume from "./Volume.js";
 import { FUSE_DISABLED_RGB_COLOR, type FuseChannel, isOrthographicCamera } from "./types.js";
 import { ThreeJsPanel } from "./ThreeJsPanel.js";

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -4,7 +4,7 @@ import { Pane } from "tweakpane";
 import MeshVolume from "./MeshVolume.js";
 import RayMarchedAtlasVolume from "./RayMarchedAtlasVolume.js";
 import PathTracedVolume from "./PathTracedVolume.js";
-import { LUT_ARRAY_LENGTH } from "./Histogram.js";
+import { LUT_ARRAY_LENGTH } from "./Lut.js";
 import Volume from "./Volume.js";
 import type { VolumeDisplayOptions, VolumeChannelDisplayOptions, FuseChannel } from "./types.js";
 import { RenderMode } from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import VolumeCache from "./VolumeCache.js";
 import RequestQueue from "./utils/RequestQueue.js";
 import SubscribableRequestQueue from "./utils/SubscribableRequestQueue.js";
 import Histogram from "./Histogram.js";
+import { Lut } from "./Lut.js";
 import { ViewportCorner } from "./types.js";
 import { VolumeFileFormat, createVolumeLoader, PrefetchDirection } from "./loaders/index.js";
 import { LoadSpec } from "./loaders/IVolumeLoader.js";
@@ -17,13 +18,14 @@ import VolumeLoaderContext from "./workers/LoadWorkerHandle.js";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
 
 export type { ImageInfo } from "./Volume.js";
-export type { ControlPoint, Lut } from "./Histogram.js";
+export type { ControlPoint } from "./Lut.js";
 export type { CreateLoaderOptions } from "./loaders/index.js";
 export type { IVolumeLoader, PerChannelCallback } from "./loaders/IVolumeLoader.js";
 export type { ZarrLoaderFetchOptions } from "./loaders/OmeZarrLoader.js";
 export type { WorkerLoader } from "./workers/LoadWorkerHandle.js";
 export {
   Histogram,
+  Lut,
   View3d,
   Volume,
   LoadSpec,

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai";
 
-import type { ControlPoint, Lut } from "../Histogram";
-import Histogram from "../Histogram";
-import { remapLut, remapControlPoints } from "../Histogram";
+import type { ControlPoint } from "../Lut";
+import { Lut } from "../Lut";
+import Histogram, { remapLut, remapControlPoints } from "../Histogram";
 import VolumeMaker from "../VolumeMaker";
 
 function clamp(val, cmin, cmax) {

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -260,11 +260,13 @@ describe("test histogram", () => {
       });
       // TODO this test almost works but there are some very slight rounding errors
       // keeping things from being perfectly equal. Need to work out the precision issue.
-      // it("is consistent for windowLevel extending beyond bounds", () => {
-      //   const lut = histogram.lutGenerator_windowLevel(1.5, 0.5);
-      //   const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
-      //   expect(lut.lut).to.eql(secondlut.lut);
-      // });
+      it("is consistent for windowLevel extending beyond bounds", () => {
+        const lut = new Lut().createFromWindowLevel(1.5, 0.5);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
+        for (let i = 0; i < 256 * 4; ++i) {
+          expect(lut.lut[i]).to.be.closeTo(secondlut.lut[i], 1);
+        }
+      });
     });
 
     it("is consistent for fullRange", () => {

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai";
 
 import type { ControlPoint } from "../Lut";
-import { Lut } from "../Lut";
-import Histogram, { remapLut, remapControlPoints } from "../Histogram";
+import { Lut, remapLut, remapControlPoints } from "../Lut";
+import Histogram from "../Histogram";
 import VolumeMaker from "../VolumeMaker";
 
 function clamp(val, cmin, cmax) {
@@ -36,7 +36,7 @@ describe("test histogram", () => {
       { x: 128, color: [255, 255, 255], opacity: 1.0 },
       { x: 255, color: [255, 255, 255], opacity: 1.0 },
     ];
-    const lut = histogram.lutGenerator_fromControlPoints(controlPoints);
+    const lut = new Lut().createFromControlPoints(controlPoints);
     it("has interpolated opacity correctly", () => {
       expect(lut.lut[126 * 4 + 3]).to.equal(0);
       expect(lut.lut[127 * 4 + 3]).to.equal(127);
@@ -56,7 +56,7 @@ describe("test histogram", () => {
         { x: 1, color: [255, 255, 255], opacity: 1.0 },
         { x: 255, color: [255, 255, 255], opacity: 1.0 },
       ];
-      const lut = histogram.lutGenerator_fromControlPoints(controlPoints);
+      const lut = new Lut().createFromControlPoints(controlPoints);
       expect(lut.lut[0 * 4 + 3]).to.equal(0);
       expect(lut.lut[1 * 4 + 3]).to.equal(255);
       expect(lut.lut[2 * 4 + 3]).to.equal(255);
@@ -69,7 +69,7 @@ describe("test histogram", () => {
         { x: 1, color: [255, 255, 255], opacity: 1.0 },
         { x: 255, color: [255, 255, 255], opacity: 1.0 },
       ];
-      const lut = histogram.lutGenerator_fromControlPoints(controlPoints);
+      const lut = new Lut().createFromControlPoints(controlPoints);
       expect(lut.lut[0 * 4 + 3]).to.equal(0);
       expect(lut.lut[1 * 4 + 3]).to.equal(255);
       expect(lut.lut[2 * 4 + 3]).to.equal(255);
@@ -78,7 +78,7 @@ describe("test histogram", () => {
 
   describe("generated lut single control point", () => {
     const controlPoints: ControlPoint[] = [{ x: 127, color: [255, 255, 255], opacity: 1.0 }];
-    const lut = histogram.lutGenerator_fromControlPoints(controlPoints);
+    const lut = new Lut().createFromControlPoints(controlPoints);
     it("has interpolated opacity correctly", () => {
       expect(lut.lut[0 * 4 + 3]).to.equal(0);
       expect(lut.lut[126 * 4 + 3]).to.equal(0);
@@ -98,7 +98,7 @@ describe("test histogram", () => {
     const labeldata = new Uint8Array([1, 1, 1, 2, 2, 2, 4, 4, 4, 12, 12, 12]);
     const labelHistogram = new Histogram(labeldata);
 
-    const lutObj = labelHistogram.lutGenerator_labelColors();
+    const lutObj = new Lut().createLabelColors(labelHistogram);
     it("has nonzero opacity values where expected", () => {
       expect(lutObj.lut[0 * 4 + 3]).to.equal(0);
       expect(lutObj.lut[1 * 4 + 3]).to.equal(255);
@@ -112,7 +112,7 @@ describe("test histogram", () => {
     });
 
     // reconcile lut with control points
-    const secondlut = histogram.lutGenerator_fromControlPoints(lutObj.controlPoints);
+    const secondlut = new Lut().createFromControlPoints(lutObj.controlPoints);
     it("generates consistent lut from control points", () => {
       expect(secondlut.lut).to.eql(lutObj.lut);
     });
@@ -127,18 +127,18 @@ describe("test histogram", () => {
     const histogram = new Histogram(data);
     describe("lutGenerator_minMax", () => {
       it("is consistent for minMax (typical case)", () => {
-        const lut = histogram.lutGenerator_minMax(64, 192);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromMinMax(64, 192);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
       });
       it("is consistent for minMax full range", () => {
-        const lut = histogram.lutGenerator_minMax(0, 255);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromMinMax(0, 255);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
       });
       it("is consistent when min and max are both 0", () => {
-        const lut = histogram.lutGenerator_minMax(0, 0);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromMinMax(0, 0);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
         expect(lut.lut[3]).to.eql(0);
         expect(secondlut.lut[3]).to.eql(0);
@@ -152,8 +152,8 @@ describe("test histogram", () => {
         });
       });
       it("is consistent when min and max are the same positive number less than 255", () => {
-        const lut = histogram.lutGenerator_minMax(120, 120);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromMinMax(120, 120);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
         expect(lut.lut[3]).to.eql(0);
         expect(secondlut.lut[3]).to.eql(0);
@@ -169,8 +169,8 @@ describe("test histogram", () => {
         });
       });
       it("is consistent when min and max are both negative", () => {
-        const lut = histogram.lutGenerator_minMax(-10, -5);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromMinMax(-10, -5);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
         // Spot check but all opacity values should be 255
         expect(lut.lut[3]).to.eql(255);
@@ -184,8 +184,8 @@ describe("test histogram", () => {
         });
       });
       it("is consistent when min is 0 and max is 1", () => {
-        const lut = histogram.lutGenerator_minMax(0, 1);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromMinMax(0, 1);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
         expect(lut.lut[3]).to.eql(0);
         expect(secondlut.lut[3]).to.eql(0);
@@ -199,8 +199,8 @@ describe("test histogram", () => {
         });
       });
       it("is consistent when min is 244 and max is 255", () => {
-        const lut = histogram.lutGenerator_minMax(254, 255);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromMinMax(254, 255);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
         expect(lut.lut[3]).to.eql(0);
         expect(secondlut.lut[3]).to.eql(0);
@@ -214,8 +214,8 @@ describe("test histogram", () => {
         });
       });
       it("is consistent when min and max are both 255", () => {
-        const lut = histogram.lutGenerator_minMax(255, 255);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromMinMax(255, 255);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
         expect(lut.lut[3]).to.eql(0);
         expect(secondlut.lut[3]).to.eql(0);
@@ -226,8 +226,8 @@ describe("test histogram", () => {
         });
       });
       it("is consistent when min and max are both greater than 255", () => {
-        const lut = histogram.lutGenerator_minMax(300, 400);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromMinMax(300, 400);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
         // Spot check but all opacity values should be 0
         expect(lut.lut[3]).to.eql(0);
@@ -244,62 +244,67 @@ describe("test histogram", () => {
 
     describe("lutGenerator_windowLevel", () => {
       it("is consistent for windowLevel", () => {
-        const lut = histogram.lutGenerator_windowLevel(0.25, 0.333);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromWindowLevel(0.25, 0.333);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
       });
       it("is consistent for windowLevel extending below bounds", () => {
-        const lut = histogram.lutGenerator_windowLevel(0.5, 0.25);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromWindowLevel(0.5, 0.25);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
       });
       it("is consistent for windowLevel extending above bounds", () => {
-        const lut = histogram.lutGenerator_windowLevel(0.5, 0.75);
-        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        const lut = new Lut().createFromWindowLevel(0.5, 0.75);
+        const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
         expect(lut.lut).to.eql(secondlut.lut);
       });
       // TODO this test almost works but there are some very slight rounding errors
       // keeping things from being perfectly equal. Need to work out the precision issue.
       // it("is consistent for windowLevel extending beyond bounds", () => {
       //   const lut = histogram.lutGenerator_windowLevel(1.5, 0.5);
-      //   const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      //   const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
       //   expect(lut.lut).to.eql(secondlut.lut);
       // });
     });
 
     it("is consistent for fullRange", () => {
-      const lut = histogram.lutGenerator_fullRange();
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      const lut = new Lut().createFullRange();
+      const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
       expect(lut.lut).to.eql(secondlut.lut);
     });
     it("is consistent for dataRange", () => {
-      const lut = histogram.lutGenerator_dataRange();
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      const lut = new Lut().createFromMinMax(histogram.getMin(), histogram.getMax());
+      const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
       expect(lut.lut).to.eql(secondlut.lut);
     });
     it("is consistent for percentiles", () => {
-      const lut = histogram.lutGenerator_percentiles(0.5, 0.983);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      const hmin = histogram.findBinOfPercentile(0.5);
+      const hmax = histogram.findBinOfPercentile(0.983);
+      const lut = new Lut().createFromMinMax(hmin, hmax);
+      const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
       expect(lut.lut).to.eql(secondlut.lut);
     });
     it("is consistent for bestFit", () => {
-      const lut = histogram.lutGenerator_bestFit();
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      const [hmin, hmax] = histogram.findBestFitBins();
+      const lut = new Lut().createFromMinMax(hmin, hmax);
+      const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
       expect(lut.lut).to.eql(secondlut.lut);
     });
     it("is consistent for auto2", () => {
-      const lut = histogram.lutGenerator_auto2();
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      const [hmin, hmax] = histogram.findAutoIJBins();
+      const lut = new Lut().createFromMinMax(hmin, hmax);
+      const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
       expect(lut.lut).to.eql(secondlut.lut);
     });
     it("is consistent for auto", () => {
-      const lut = histogram.lutGenerator_auto();
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      const [b, e] = histogram.findAutoMinMax();
+      const lut = new Lut().createFromMinMax(b, e);
+      const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
       expect(lut.lut).to.eql(secondlut.lut);
     });
     it("is consistent for equalize", () => {
-      const lut = histogram.lutGenerator_equalize();
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      const lut = new Lut().createFromEqHistogram(histogram);
+      const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
       expect(lut.lut).to.eql(secondlut.lut);
     });
     it("is consistent for a degenerate set of white,0 control points", () => {
@@ -310,17 +315,16 @@ describe("test histogram", () => {
         lutArr[i * 4 + 2] = 255;
         lutArr[i * 4 + 3] = 0;
       }
-      const lut: Lut = {
-        lut: lutArr,
-        controlPoints: [
-          { x: 0, color: [255, 255, 255], opacity: 0 },
-          { x: 0, color: [255, 255, 255], opacity: 0 },
-          { x: 4, color: [255, 255, 255], opacity: 0 },
-          { x: 8, color: [255, 255, 255], opacity: 0 },
-          { x: 255, color: [255, 255, 255], opacity: 0 },
-        ],
-      };
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      const lut: Lut = new Lut();
+      lut.lut = lutArr;
+      lut.controlPoints = [
+        { x: 0, color: [255, 255, 255], opacity: 0 },
+        { x: 0, color: [255, 255, 255], opacity: 0 },
+        { x: 4, color: [255, 255, 255], opacity: 0 },
+        { x: 8, color: [255, 255, 255], opacity: 0 },
+        { x: 255, color: [255, 255, 255], opacity: 0 },
+      ];
+      const secondlut = new Lut().createFromControlPoints(lut.controlPoints);
       expect(lut.lut).to.eql(secondlut.lut);
     });
   });
@@ -328,11 +332,9 @@ describe("test histogram", () => {
 
 describe("test remapping lut when raw data range is updated", () => {
   it("remaps the lut when the new data range is completely contained", () => {
-    // histogram values itself doesn't matter.
-    const histogram = new Histogram(new Uint8Array(100));
     // the full 0-255 domain of this lut is representing the raw intensity range 50-100
     // we will choose a min/max range within the 0-255 domain of the lut.
-    const lut = histogram.lutGenerator_minMax(64, 192);
+    const lut = new Lut().createFromMinMax(64, 192);
     // this lut now has a ramp from 64 to 192 in the 0-255 domain
     // (which correspond exactly to the newMin-newMax range in the raw intensities)
     expect(lut.lut[63 * 4 + 3]).to.equal(0);
@@ -399,7 +401,7 @@ describe("test remapping lut when raw data range is updated", () => {
     expect(secondLut[254 * 4 + 3]).to.be.closeTo(254, 1);
     expect(secondLut[255 * 4 + 3]).to.be.closeTo(255, 1);
 
-    const compareLut = histogram.lutGenerator_minMax(0, 255);
+    const compareLut = new Lut().createFromMinMax(0, 255);
     for (let i = 0; i < 256 * 4; ++i) {
       expect(secondLut[i]).to.be.closeTo(compareLut.lut[i], 1);
     }
@@ -411,9 +413,7 @@ describe("test remapping lut when raw data range is updated", () => {
     }
   });
   it("remaps the lut when the new data range is identical to previous", () => {
-    // histogram values itself doesn't matter.
-    const histogram = new Histogram(new Uint8Array(100));
-    const lut = histogram.lutGenerator_minMax(0, 255);
+    const lut = new Lut().createFromMinMax(0, 255);
 
     // artificial min and max:
     const oldMin = 50;
@@ -427,15 +427,12 @@ describe("test remapping lut when raw data range is updated", () => {
   });
 
   it("remaps the lut when the new data range is completely overlapped", () => {
-    // histogram values itself doesn't matter.
-    const histogram = new Histogram(new Uint8Array(100));
-
     // artificial data min and max absolute intensities:
     const oldMin = 50;
     const oldMax = 100;
     // the full 0-255 domain of this lut is representing the above raw intensity domain 50-100.
     // For test, we will choose a min/max within the 0-255 domain of the lut.
-    const lut = histogram.lutGenerator_minMax(64, 192);
+    const lut = new Lut().createFromMinMax(64, 192);
     // this lut now has a ramp from 64 to 192 in the 0-255 range
     // (which correspond exactly to the newMin-newMax range in the raw intensities)
     expect(lut.lut[63 * 4 + 3]).to.equal(0);
@@ -503,7 +500,7 @@ describe("test remapping lut when raw data range is updated", () => {
     expect(secondLut[255 * 4 + 3]).to.equal(255);
 
     // 96, 160 were chosen above
-    const compareLut = histogram.lutGenerator_minMax(96, 160);
+    const compareLut = new Lut().createFromMinMax(96, 160);
     for (let i = 0; i < 256 * 4; ++i) {
       expect(secondLut[i]).to.be.closeTo(compareLut.lut[i], 1);
     }

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -3,7 +3,7 @@ import { Vector2, Vector3 } from "three";
 
 import Volume, { ImageInfo } from "../Volume";
 import VolumeMaker from "../VolumeMaker";
-import { LUT_ARRAY_LENGTH } from "../Histogram";
+import { LUT_ARRAY_LENGTH } from "../Lut";
 import Channel from "../Channel";
 
 // PREPARE SOME TEST DATA TO TRY TO DISPLAY A VOLUME.


### PR DESCRIPTION
Decoupling Lut from Histogram for future work.

There are some things about the way the lookup tables (Luts) and Histograms are handled that make it hard to update certain things. 
See #189  or https://github.com/allen-cell-animated/website-3d-cell-viewer/issues/192 for examples.

This PR is a first step and should introduce no functionality changes.

Key changes:

**Lut.ts** is a new module that is responsible only for a lookup table as array, plus control points to describe its piecewise linear function.
**Histogram.ts** no longer has any responsibilities for creating luts.  
**Channel.ts** no longer has any responsibilities for creating luts.
All the rest of the changes stem from these.

Again, no functionality is supposed to be changed as a result of this PR. 
It does have an API change for which there will need to be some changes in website-3d-cell-viewer.

