### PR TITLE
Multiresolution loading options in tweakpane

### DIFF
--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -178,9 +178,10 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
 
       const sliceInBounds = this.updateSlice();
       if (sliceInBounds) {
-        const sliceRatio = Math.floor(this.settings.zSlice) / this.volume.imageInfo.volumeSize.z;
+        const sliceLowerBound = Math.floor(this.settings.zSlice) / this.volume.imageInfo.volumeSize.z;
+        const sliceUpperBound = (Math.floor(this.settings.zSlice) + 1) / this.volume.imageInfo.volumeSize.z;
         this.volume.updateRequiredData({
-          subregion: new Box3(new Vector3(0, 0, sliceRatio), new Vector3(1, 1, sliceRatio)),
+          subregion: new Box3(new Vector3(0, 0, sliceLowerBound), new Vector3(1, 1, sliceUpperBound)),
         });
       }
     }

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -254,7 +254,7 @@ export default class Volume {
    * different scale level than is currently loaded.
    *
    * This checks for changes in properties that *can*, but do not *always*, change the scale level the loader picks.
-   * For example, a smaller subregion *may* mean a higher scale level will fit within memory constraints, or it may
+   * For example, a smaller `subregion` *may* mean a higher scale level will fit within memory constraints, or it may
    * not. A higher `scaleLevelBias` *may* nudge the volume into a higher scale level, or we may already be at the max
    * imposed by `multiscaleLevel`.
    */

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -252,6 +252,11 @@ export default class Volume {
   /**
    * Returns `true` iff differences between `loadSpec` and `loadSpecRequired` indicate a new load *may* get a
    * different scale level than is currently loaded.
+   *
+   * This checks for changes in properties that *can*, but do not *always*, change the scale level the loader picks.
+   * For example, a smaller subregion *may* mean a higher scale level will fit within memory constraints, or it may
+   * not. A higher `scaleLevelBias` *may* nudge the volume into a higher scale level, or we may already be at the max
+   * imposed by `multiscaleLevel`.
    */
   private mayLoadNewScaleLevel(): boolean {
     return (

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -242,7 +242,6 @@ export default class Volume {
 
   /** Call on any state update that may require new data to be loaded (subregion, enabled channels, time, etc.) */
   async updateRequiredData(required: Partial<LoadSpec>, onChannelLoaded?: PerChannelCallback): Promise<void> {
-    console.log("here");
     this.loadSpecRequired = { ...this.loadSpecRequired, ...required };
     let noReload =
       this.loadSpec.time === this.loadSpecRequired.time &&

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -743,7 +743,7 @@ export default class VolumeDrawable {
 
   setZSlice(slice: number): boolean {
     const sizez = this.volume.imageInfo.volumeSize.z;
-    if (this.settings.zSlice !== slice && slice < sizez && slice > 0) {
+    if (this.settings.zSlice !== slice && slice < sizez && slice >= 0) {
       this.settings.zSlice = slice;
       this.volumeRendering.updateSettings(this.settings, SettingsFlags.ROI);
       return true;

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -720,6 +720,12 @@ export default class VolumeDrawable {
   setupGui(pane: Pane): void {
     pane.addInput(this.settings, "translation").on("change", ({ value }) => this.setTranslation(value));
     pane.addInput(this.settings, "rotation").on("change", ({ value }) => this.setRotation(value));
+    pane
+      .addInput(this.volume.loadSpecRequired, "maxAtlasEdge")
+      .on("change", ({ value }) => this.volume.updateRequiredData({ maxAtlasEdge: value }));
+    pane
+      .addInput(this.volume.loadSpecRequired, "scaleLevelBias")
+      .on("change", ({ value }) => this.volume.updateRequiredData({ scaleLevelBias: value }));
 
     const pathtrace = pane.addFolder({ title: "Pathtrace", expanded: false });
     pathtrace

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -683,7 +683,7 @@ export default class VolumeDrawable {
         break;
       case RenderMode.SLICE:
         this.volumeRendering = new Atlas2DSlice(this.volume, this.settings);
-        this.volume.updateRequiredData({ subregion: new Box3(new Vector3(0, 0, 0.5), new Vector3(1, 1, 0.5)) });
+        // `updateRequiredData` called on construction, via `updateSettings`
         break;
       case RenderMode.RAYMARCH:
       default:

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -728,6 +728,9 @@ export default class VolumeDrawable {
     scaleFolder
       .addInput(this.volume.loadSpecRequired, "scaleLevelBias")
       .on("change", ({ value }) => this.volume.updateRequiredData({ scaleLevelBias: value }));
+    scaleFolder
+      .addInput(this.volume.loadSpecRequired, "multiscaleLevel")
+      .on("change", ({ value }) => this.volume.updateRequiredData({ multiscaleLevel: value }));
 
     const pathtrace = pane.addFolder({ title: "Pathtrace", expanded: false });
     pathtrace

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -720,10 +720,12 @@ export default class VolumeDrawable {
   setupGui(pane: Pane): void {
     pane.addInput(this.settings, "translation").on("change", ({ value }) => this.setTranslation(value));
     pane.addInput(this.settings, "rotation").on("change", ({ value }) => this.setRotation(value));
-    pane
+
+    const scaleFolder = pane.addFolder({ title: "Multiscale loading" });
+    scaleFolder
       .addInput(this.volume.loadSpecRequired, "maxAtlasEdge")
       .on("change", ({ value }) => this.volume.updateRequiredData({ maxAtlasEdge: value }));
-    pane
+    scaleFolder
       .addInput(this.volume.loadSpecRequired, "scaleLevelBias")
       .on("change", ({ value }) => this.volume.updateRequiredData({ scaleLevelBias: value }));
 

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -6,6 +6,14 @@ import { PrefetchDirection } from "./zarr_utils/types.js";
 
 export class LoadSpec {
   time = 0;
+  /** The max size of a volume atlas that may be produced by a load. Used to pick the appropriate multiscale level. */
+  maxAtlasEdge?: number;
+  /** An optional bias added to the scale level index after the optimal level is picked based on `maxAtlasEdge`. */
+  scaleLevelBias?: number;
+  /**
+   * The max scale level to load. Even when this is specified, the loader may pick a *lower* scale level based on
+   * limits imposed by `scaleLevelBias` and `maxAtlasEdge` (or their defaults if unspecified).
+   */
   multiscaleLevel?: number;
   /** Subregion of volume to load. If not specified, the entire volume is loaded. Specify as floats between 0-1. */
   subregion = new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1));

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -21,18 +21,12 @@ import {
   composeSubregion,
   computePackedAtlasDims,
   convertSubregionToPixels,
+  pickLevelToLoad,
   unitNameToSymbol,
 } from "./VolumeLoaderUtils.js";
 import ChunkPrefetchIterator from "./zarr_utils/ChunkPrefetchIterator.js";
 import WrappedStore from "./zarr_utils/WrappedStore.js";
-import {
-  getDimensionCount,
-  getScale,
-  orderByDimension,
-  orderByTCZYX,
-  pickLevelToLoad,
-  remapAxesToTCZYX,
-} from "./zarr_utils/utils.js";
+import { getDimensionCount, getScale, orderByDimension, orderByTCZYX, remapAxesToTCZYX } from "./zarr_utils/utils.js";
 import type {
   OMEZarrMetadata,
   SubscriberId,
@@ -223,7 +217,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
 
       dims.spaceUnit = spaceUnit;
       dims.timeUnit = timeUnit;
-      dims.shape = this.orderByTCZYX(level.shape, 1).map((val, idx) => Math.ceil(val * regionArr[idx]));
+      dims.shape = this.orderByTCZYX(level.shape, 1).map((val, idx) => Math.max(Math.ceil(val * regionArr[idx]), 1));
       dims.spacing = this.orderByTCZYX(scale, 1);
 
       return dims;

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -2,7 +2,7 @@ import { Box3, Vector2, Vector3 } from "three";
 
 import { ImageInfo } from "../Volume.js";
 
-const MAX_ATLAS_EDGE = 4096;
+export const MAX_ATLAS_EDGE = 4096;
 
 // Map from units to their symbols
 const UNIT_SYMBOLS = {

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -1,6 +1,3 @@
-import { Vector3 } from "three";
-import { LoadSpec } from "../IVolumeLoader.js";
-import { estimateLevelForAtlas } from "../VolumeLoaderUtils.js";
 import { OMEAxis, OMECoordinateTransformation, OMEDataset, OMEMultiscale, TCZYX } from "./types.js";
 
 /** Turns `axesTCZYX` into the number of dimensions in the array */
@@ -25,25 +22,6 @@ export function remapAxesToTCZYX(axes: OMEAxis[]): TCZYX<number> {
   }
 
   return axesTCZYX;
-}
-
-/**
- * Picks the best scale level to load based on scale level dimensions, a max atlas size, and a `LoadSpec`.
- * This works like `estimateLevelForAtlas` but factors in `LoadSpec`'s `subregion` property (shrinks the size of the
- * data, maybe enough to allow loading a higher level) and its `multiscaleLevel`, `maxAtlasEdge`, and `scaleLevelBias`
- * properties (which set how the loaded scale level is determined).
- */
-export function pickLevelToLoad(loadSpec: LoadSpec, spatialDimsZYX: [number, number, number][]): number {
-  const size = loadSpec.subregion.getSize(new Vector3());
-  const dims = spatialDimsZYX.map(([z, y, x]): [number, number, number] => [
-    Math.max(z * size.z, 1),
-    Math.max(y * size.y, 1),
-    Math.max(x * size.x, 1),
-  ]);
-
-  const optimalLevel = estimateLevelForAtlas(dims, loadSpec.maxAtlasEdge);
-  const levelToLoad = Math.max(optimalLevel + (loadSpec.scaleLevelBias ?? 0), loadSpec.multiscaleLevel ?? 0);
-  return Math.max(0, Math.min(dims.length - 1, levelToLoad));
 }
 
 /** Reorder an array of values [T, C, Z, Y, X] to the given dimension order */

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -30,7 +30,8 @@ export function remapAxesToTCZYX(axes: OMEAxis[]): TCZYX<number> {
 /**
  * Picks the best scale level to load based on scale level dimensions, a max atlas size, and a `LoadSpec`.
  * This works like `estimateLevelForAtlas` but factors in `LoadSpec`'s `subregion` property (shrinks the size of the
- * data, maybe enough to allow loading a higher level) and its `multiscaleLevel` property (sets a max scale level).
+ * data, maybe enough to allow loading a higher level) and its `multiscaleLevel`, `maxAtlasEdge`, and `scaleLevelBias`
+ * properties (which set how the loaded scale level is determined).
  */
 export function pickLevelToLoad(loadSpec: LoadSpec, spatialDimsZYX: [number, number, number][]): number {
   const size = loadSpec.subregion.getSize(new Vector3());
@@ -41,8 +42,8 @@ export function pickLevelToLoad(loadSpec: LoadSpec, spatialDimsZYX: [number, num
   ]);
 
   const optimalLevel = estimateLevelForAtlas(dims, loadSpec.maxAtlasEdge);
-  const levelToLoad = Math.max(0, Math.min(dims.length - 1, optimalLevel + (loadSpec.scaleLevelBias ?? 0)));
-  return Math.max(levelToLoad, loadSpec.multiscaleLevel ?? 0);
+  const levelToLoad = Math.max(optimalLevel + (loadSpec.scaleLevelBias ?? 0), loadSpec.multiscaleLevel ?? 0);
+  return Math.max(0, Math.min(dims.length - 1, levelToLoad));
 }
 
 /** Reorder an array of values [T, C, Z, Y, X] to the given dimension order */

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -40,8 +40,9 @@ export function pickLevelToLoad(loadSpec: LoadSpec, spatialDimsZYX: [number, num
     Math.max(x * size.x, 1),
   ]);
 
-  const optimalLevel = estimateLevelForAtlas(dims);
-  return Math.max(optimalLevel, loadSpec.multiscaleLevel ?? 0);
+  const optimalLevel = estimateLevelForAtlas(dims, loadSpec.maxAtlasEdge);
+  const levelToLoad = Math.max(0, Math.min(dims.length - 1, optimalLevel + (loadSpec.scaleLevelBias ?? 0)));
+  return Math.max(levelToLoad, loadSpec.multiscaleLevel ?? 0);
 }
 
 /** Reorder an array of values [T, C, Z, Y, X] to the given dimension order */


### PR DESCRIPTION
Review time: pretty quick (15min)

Resolves #184: exposes settings for picking which multiscale level to load via tweakpane.

The hidden tweakpane now contains the following options, under a folder labeled `Multiscale loading`:

- `multiscaleLevel` sets the *minimum* scale level that may be loaded. (Note that higher-indexed scale levels are more downsampled, and therefore *lower* resolution.) Loaders may still pick a higher (more downsampled) multiscale index based on the other settings below. Therefore, leaving this property at its default of 0 effectively disables enforcing a resolution level.
- `maxAtlasEdge` modifies the maximum atlas dimension used by the loader internally when deciding which scale level is appropriate to load. When not constrained by `multiscaleLevel`, the loader picks the highest-resolution scale level that can be packed into a texture atlas with sides no longer than `maxAtlasEdge`.
- `scaleLevelBias` allows nudging the scale level index determined based on `maxAtlasEdge`. E.g. if the loader determines (as described above) that level 1 is the least downsampled scale level it can load, but `scaleLevelBias` is 1, the loader will instead load level 2.

Internally, tweakpane modifies properties with the same names on `Volume.loadSpecRequired`, which represents the data requested for display based on current settings. It does this via `Volume.updateRequiredData`, which makes changes to `loadSpecRequired`, then checks if the changes indicate that new data needs to be loaded. Only `multiscaleLevel` existed in the `LoadSpec` type previously. This PR adds the other two, hooks them up to the `OMEZarrLoader` internals, and properly handles them in `updateRequiredData`'s reload check.

While I was testing, I found a bug that was causing the loader to unconditionally pick the highest available scale level in Z-slice mode, regardless of the value of `maxAtlasEdge`. So I fixed that too. This accounts for the changes to Atlas2DSlice.ts and VolumeDrawable.ts.

### Steps to test:

- `npm start` and open the viewer.
- Ctrl + Alt + 1 to reveal the hidden tweakpane.
- The options listed above should be present and work as described when a zarr volume is open.