### PR TITLE
Channel object now uses the Lut object

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ for (let i = 0; i < volumeData.length; ++i) {
   const hmin = aimg.getHistogram(i).findBinOfPercentile(0.5);
   const hmax = aimg.getHistogram(i).findBinOfPercentile(0.983);
   const lut = new Lut().createFromMinMax(hmin, hmax);
-  aimg.setLut(i, lut.lut);
+  aimg.setLut(i, lut);
 }
 
 // enable only the first 3 channels
@@ -107,7 +107,7 @@ export class VolumeViewer extends React.Component {
                     const hmin = aimg.getHistogram(channelIndex).findBinOfPercentile(0.5);
                     const hmax = aimg.getHistogram(channelIndex).findBinOfPercentile(0.983);
                     const lut = new Lut().createFromMinMax(hmin, hmax);
-                    aimg.setLut(i, lut.lut);
+                    aimg.setLut(i, lut);
 
                     this.view3D.setVolumeChannelEnabled(aimg, channelIndex, channelIndex < 3);
                     this.view3D.updateActiveChannels(aimg);

--- a/public/index.ts
+++ b/public/index.ts
@@ -636,7 +636,7 @@ function showChannelUI(volume: Volume) {
         return function () {
           const [hmin, hmax] = volume.getHistogram(j).findAutoIJBins();
           const lut = new Lut().createFromMinMax(hmin, hmax);
-          volume.setLut(j, lut.lut);
+          volume.setLut(j, lut);
           view3D.updateLuts(volume);
         };
       })(i),
@@ -645,7 +645,7 @@ function showChannelUI(volume: Volume) {
         return function () {
           const [b, e] = volume.getHistogram(j).findAutoMinMax();
           const lut = new Lut().createFromMinMax(b, e);
-          volume.setLut(j, lut.lut);
+          volume.setLut(j, lut);
           view3D.updateLuts(volume);
         };
       })(i),
@@ -654,7 +654,7 @@ function showChannelUI(volume: Volume) {
         return function () {
           const [hmin, hmax] = volume.getHistogram(j).findBestFitBins();
           const lut = new Lut().createFromMinMax(hmin, hmax);
-          volume.setLut(j, lut.lut);
+          volume.setLut(j, lut);
           view3D.updateLuts(volume);
         };
       })(i),
@@ -664,7 +664,7 @@ function showChannelUI(volume: Volume) {
           const hmin = volume.getHistogram(j).findBinOfPercentile(0.5);
           const hmax = volume.getHistogram(j).findBinOfPercentile(0.983);
           const lut = new Lut().createFromMinMax(hmin, hmax);
-          volume.setLut(j, lut.lut);
+          volume.setLut(j, lut);
           view3D.updateLuts(volume);
         };
       })(i),
@@ -779,7 +779,7 @@ function showChannelUI(volume: Volume) {
             const hwindow = value;
             const hlevel = myState.channelGui[j].level;
             const lut = new Lut().createFromWindowLevel(hwindow, hlevel);
-            volume.setLut(j, lut.lut);
+            volume.setLut(j, lut);
             view3D.updateLuts(volume);
           };
         })(i)
@@ -795,7 +795,7 @@ function showChannelUI(volume: Volume) {
             const hwindow = myState.channelGui[j].window;
             const hlevel = value;
             const lut = new Lut().createFromWindowLevel(hwindow, hlevel);
-            volume.setLut(j, lut.lut);
+            volume.setLut(j, lut);
             view3D.updateLuts(volume);
           };
         })(i)
@@ -880,10 +880,7 @@ function loadImageData(jsonData: ImageInfo, volumeData: Uint8Array[]) {
 function onChannelDataArrived(v: Volume, channelIndex: number) {
   const currentVol = v; // myState.volume;
 
-  const hmin = currentVol.getHistogram(channelIndex).findBinOfPercentile(0.5);
-  const hmax = currentVol.getHistogram(channelIndex).findBinOfPercentile(0.983);
-  const lut = new Lut().createFromMinMax(hmin, hmax);
-  currentVol.setLut(channelIndex, lut.lut);
+  // optionally can set the LUT here (for example if this is first time loading)
 
   view3D.onVolumeData(currentVol, [channelIndex]);
   view3D.setVolumeChannelEnabled(currentVol, channelIndex, myState.channelGui[channelIndex].enabled);

--- a/react-example/VolumeViewer.jsx
+++ b/react-example/VolumeViewer.jsx
@@ -34,7 +34,7 @@ export class VolumeViewer extends React.Component {
                     const hmin = aimg.getHistogram(channelIndex).findBinOfPercentile(0.5);
                     const hmax = aimg.getHistogram(channelIndex).findBinOfPercentile(0.983);
                     const lut = new Lut().createFromMinMax(hmin, hmax);
-                    aimg.setLut(channelIndex, lut.lut);
+                    aimg.setLut(channelIndex, lut);
           
                     this.view3D.setVolumeChannelEnabled(aimg, channelIndex, channelIndex < 3);
                     this.view3D.updateActiveChannels(aimg);

--- a/react-example/gui-setup.js
+++ b/react-example/gui-setup.js
@@ -76,7 +76,7 @@ export function showChannelUI(volume, view3D, gui) {
         return function () {
           const [hmin, hmax] = volume.getHistogram(j).findAutoIJBins();
           const lut = new Lut().createFromMinMax(hmin, hmax);
-          volume.setLut(j, lut.lut);
+          volume.setLut(j, lut);
           view3D.updateLuts(volume);
         };
       })(i),
@@ -85,7 +85,7 @@ export function showChannelUI(volume, view3D, gui) {
         return function () {
           const [b, e] = volume.getHistogram(j).findAutoMinMax();
           const lut = new Lut().createFromMinMax(b, e);
-          volume.setLut(j, lut.lut);
+          volume.setLut(j, lut);
           view3D.updateLuts(volume);
         };
       })(i),
@@ -94,7 +94,7 @@ export function showChannelUI(volume, view3D, gui) {
         return function () {
           const [hmin, hmax] = volume.getHistogram(j).findBestFitBins();
           const lut = new Lut().createFromMinMax(hmin, hmax);
-          volume.setLut(j, lut.lut);
+          volume.setLut(j, lut);
           view3D.updateLuts(volume);
         };
       })(i),
@@ -103,7 +103,7 @@ export function showChannelUI(volume, view3D, gui) {
           const hmin = volume.getHistogram(j).findBinOfPercentile(0.5);
           const hmax = volume.getHistogram(j).findBinOfPercentile(0.983);
           const lut = new Lut().createFromMinMax(hmin, hmax);
-          volume.setLut(j, lut.lut);
+          volume.setLut(j, lut);
           view3D.updateLuts(volume);
         };
       })(i),
@@ -207,7 +207,7 @@ export function showChannelUI(volume, view3D, gui) {
             const hwindow = value;
             const hlevel = myState.infoObj.channelGui[j].level;
             const lut = new Lut().createFromWindowLevel(hwindow, hlevel);
-            volume.setLut(j, lut.lut);
+            volume.setLut(j, lut);
             view3D.updateLuts(volume);
           };
         })(i)
@@ -224,7 +224,7 @@ export function showChannelUI(volume, view3D, gui) {
             const hwindow = myState.infoObj.channelGui[j].window;
             const hlevel = value;
             const lut = new Lut().createFromWindowLevel(hwindow, hlevel);
-            volume.setLut(j, lut.lut);
+            volume.setLut(j, lut);
             view3D.updateLuts(volume);
           };
         })(i)

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -1,6 +1,6 @@
 import { DataTexture, RedFormat, UnsignedByteType, RGBAFormat, LinearFilter, NearestFilter } from "three";
 import Histogram from "./Histogram.js";
-import { Lut, LUT_ARRAY_LENGTH, remapLut } from "./Lut.js";
+import { Lut, LUT_ARRAY_LENGTH, remapControlPoints, remapLut } from "./Lut.js";
 
 interface ChannelImageData {
   /** Returns the one-dimensional array containing the data in RGBA order, as integers in the range 0 to 255. */
@@ -18,7 +18,7 @@ export default class Channel {
   public volumeData: Uint8Array;
   public name: string;
   public histogram: Histogram;
-  public lut: Uint8Array;
+  public lut: Lut;
   public colorPalette: Uint8Array;
   public colorPaletteAlpha: number;
   public dims: [number, number, number];
@@ -45,9 +45,8 @@ export default class Channel {
     this.dims = [0, 0, 0];
 
     // intensity remapping lookup table
-    this.lut = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
-    const lut = new Lut().createFromMinMax(0, 255);
-    this.setLut(lut.lut);
+    this.lut = new Lut().createFromMinMax(0, 255);
+
     // per-intensity color labeling (disabled initially)
     this.colorPalette = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
     // store in 0..1 range. 1 means fully colorPalette, 0 means fully lut.
@@ -66,7 +65,7 @@ export default class Channel {
     if (this.colorPaletteAlpha === 1.0) {
       ret.set(this.colorPalette);
     } else if (this.colorPaletteAlpha === 0.0) {
-      ret.set(this.lut);
+      ret.set(this.lut.lut);
       for (let i = 0; i < LUT_ARRAY_LENGTH / 4; ++i) {
         ret[i * 4 + 0] *= rgb[0];
         ret[i * 4 + 1] *= rgb[1];
@@ -96,10 +95,17 @@ export default class Channel {
 
   public setRawDataRange(min: number, max: number): void {
     // remap the lut which was based on rawMin and rawMax to new min and max
-    const newLut = remapLut(this.lut, this.rawMin, this.rawMax, min, max);
+    // If either of the min/max ranges are both zero, then we have undefined behavior and should
+    // not remap the lut.  This situation can happen at first load, for example,
+    // when one channel has arrived but others haven't.
+    if (!(this.rawMin === 0 && this.rawMax === 0) && !(min === 0 && max === 0)) {
+      const newLut = remapLut(this.lut.lut, this.rawMin, this.rawMax, min, max);
+      const newControlPoints = remapControlPoints(this.lut.controlPoints, this.rawMin, this.rawMax, min, max);
+      this.lut.lut = newLut;
+      this.lut.controlPoints = newControlPoints;
+    }
     this.rawMin = min;
     this.rawMax = max;
-    this.lut = newLut;
   }
 
   public getHistogram(): Histogram {
@@ -144,7 +150,7 @@ export default class Channel {
 
     const [hmin, hmax] = this.histogram.findAutoIJBins();
     const lut = new Lut().createFromMinMax(hmin, hmax);
-    this.setLut(lut.lut);
+    this.setLut(lut);
   }
 
   // let's rearrange this.imgData.data into a 3d array.
@@ -247,8 +253,7 @@ export default class Channel {
     this.rebuildDataTexture(this.imgData.data, ax, ay);
   }
 
-  // lut should be an uint8array of 256*4 elements (256 rgba8 values)
-  public setLut(lut: Uint8Array): void {
+  public setLut(lut: Lut): void {
     this.lut = lut;
   }
 

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -99,10 +99,7 @@ export default class Channel {
     // not remap the lut.  This situation can happen at first load, for example,
     // when one channel has arrived but others haven't.
     if (!(this.rawMin === 0 && this.rawMax === 0) && !(min === 0 && max === 0)) {
-      const newLut = remapLut(this.lut.lut, this.rawMin, this.rawMax, min, max);
-      const newControlPoints = remapControlPoints(this.lut.controlPoints, this.rawMin, this.rawMax, min, max);
-      this.lut.lut = newLut;
-      this.lut.controlPoints = newControlPoints;
+      this.lut.remapDomains(this.rawMin, this.rawMax, min, max);
     }
     this.rawMin = min;
     this.rawMax = max;

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -75,15 +75,16 @@ export default class Channel {
       for (let i = 0; i < LUT_ARRAY_LENGTH / 4; ++i) {
         ret[i * 4 + 0] =
           this.colorPalette[i * 4 + 0] * this.colorPaletteAlpha +
-          this.lut[i * 4 + 0] * (1.0 - this.colorPaletteAlpha) * rgb[0];
+          this.lut.lut[i * 4 + 0] * (1.0 - this.colorPaletteAlpha) * rgb[0];
         ret[i * 4 + 1] =
           this.colorPalette[i * 4 + 1] * this.colorPaletteAlpha +
-          this.lut[i * 4 + 1] * (1.0 - this.colorPaletteAlpha) * rgb[1];
+          this.lut.lut[i * 4 + 1] * (1.0 - this.colorPaletteAlpha) * rgb[1];
         ret[i * 4 + 2] =
           this.colorPalette[i * 4 + 2] * this.colorPaletteAlpha +
-          this.lut[i * 4 + 2] * (1.0 - this.colorPaletteAlpha) * rgb[2];
+          this.lut.lut[i * 4 + 2] * (1.0 - this.colorPaletteAlpha) * rgb[2];
         ret[i * 4 + 3] =
-          this.colorPalette[i * 4 + 3] * this.colorPaletteAlpha + this.lut[i * 4 + 3] * (1.0 - this.colorPaletteAlpha);
+          this.colorPalette[i * 4 + 3] * this.colorPaletteAlpha +
+          this.lut.lut[i * 4 + 3] * (1.0 - this.colorPaletteAlpha);
       }
     }
 

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -2,6 +2,7 @@ import { Vector2, Vector3 } from "three";
 
 import Channel from "./Channel.js";
 import Histogram from "./Histogram.js";
+import { Lut } from "./Lut.js";
 import { getColorByChannelIndex } from "./constants/colors.js";
 import { type IVolumeLoader, LoadSpec, type PerChannelCallback } from "./loaders/IVolumeLoader.js";
 import { MAX_ATLAS_EDGE, pickLevelToLoadUnscaled } from "./loaders/VolumeLoaderUtils.js";
@@ -438,7 +439,7 @@ export default class Volume {
    * @param {number} c The channel index
    * @param {Array.<number>} lut The lut as a 256 element array
    */
-  setLut(c: number, lut: Uint8Array): void {
+  setLut(c: number, lut: Lut): void {
     this.channels[c].setLut(lut);
   }
 

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -523,9 +523,35 @@ describe("test remapping control points when raw data range is updated", () => {
       { x: 192, color: [255, 255, 255], opacity: 1.0 },
       { x: 255, color: [255, 255, 255], opacity: 1.0 },
     ];
+    /**
+     * Old CPs:
+     * 255 |           o ------o
+     *     |          /
+     *     |         /
+     *     |        /
+     *   0 | o----o
+     *     +-------------------
+     *       0    64    192    255
+     *       v    v     v      v
+     */
     const cp2 = remapControlPoints(cp, 0, 255, 64, 192);
+    /**
+     * New CPs:
+     * 255 |           o
+     *     |          /
+     *     |         /
+     *     |        /
+     *   0 |       o
+     *     +-------------------
+     *             0    255
+     *             v     v
+     * raw values: 64    192
+     */
+    // intensity range contracted from 0-255 to 64-192
+    // therefore the cps should just outside of 64-192 are gone and
+    // the new cp's capture only the ramp up from 64-192 in the original cp list.
     const positions = cp2.map((cp) => Math.round(cp.x));
-    expect(positions).to.include.members([0, 64, 96, 160, 192, 255]);
+    expect(positions).to.include.members([0, 255]);
   });
   it("remaps the control points correctly when new intensity range expanded", () => {
     const cp: ControlPoint[] = [
@@ -534,8 +560,31 @@ describe("test remapping control points when raw data range is updated", () => {
       { x: 192, color: [255, 255, 255], opacity: 1.0 },
       { x: 255, color: [255, 255, 255], opacity: 1.0 },
     ];
+    /**
+     * Old CPs:
+     * 255 |           o ------o
+     *     |          /
+     *     |         /
+     *     |        /
+     *   0 | o----o
+     *     +-------------------
+     *       0    64    192    255
+     *       v    v     v      v
+     */
     const cp2 = remapControlPoints(cp, 0, 255, -64, 320);
+    /**
+     * New CPs:
+     * 255 |           o ------o
+     *     |          /
+     *     |         /
+     *     |        /
+     *   0 | o----o
+     *     +-------------------
+     *       0    85    170    255
+     *       v    v     v      v
+     *     -64    64    192    320 (abs intensities)
+     */
     const positions = cp2.map((cp) => Math.round(cp.x));
-    expect(positions).to.include.members([0, 32, 225, 255]);
+    expect(positions).to.include.members([0, 85, 170, 255]);
   });
 });

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -70,8 +70,9 @@ function checkChannelDataConstruction(c: Channel, index: number, imgdata: ImageI
   expect(c.imgData.height).to.equal(atlasHeight);
   expect(c.imgData.data).to.be.a("Uint8ClampedArray");
   expect(c.imgData.data.length).to.equal(atlasWidth * atlasHeight);
-  expect(c.lut).to.be.a("Uint8Array");
-  expect(c.lut.length).to.equal(LUT_ARRAY_LENGTH);
+  expect(c.lut).to.be.a("Lut");
+  expect(c.lut.lut).to.be.a("Uint8Array");
+  expect(c.lut.lut.length).to.equal(LUT_ARRAY_LENGTH);
 }
 
 describe("test volume", () => {

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -70,7 +70,6 @@ function checkChannelDataConstruction(c: Channel, index: number, imgdata: ImageI
   expect(c.imgData.height).to.equal(atlasHeight);
   expect(c.imgData.data).to.be.a("Uint8ClampedArray");
   expect(c.imgData.data.length).to.equal(atlasWidth * atlasHeight);
-  expect(c.lut).to.be.a("Lut");
   expect(c.lut.lut).to.be.a("Uint8Array");
   expect(c.lut.lut.length).to.equal(LUT_ARRAY_LENGTH);
 }


### PR DESCRIPTION
Estimated time to review: <15 min.

Following up on a previous refactor PR, we now use the results.  
Channels were previously storing a lookup table as a simple Uint8Array.  Now we have an encapsulated class called Lut. 
Modified Channel to use it, fixed the remapping code to include both ControlPoints and array, and tested the results of the remapping in the test app.   
