### PR TITLE
Fix/update-isosurfaces

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -698,11 +698,7 @@ function showChannelUI(volume: Volume) {
     f.add(myState.channelGui[i], "isosurface").onChange(
       (function (j) {
         return function (value) {
-          if (value) {
-            view3D.createIsosurface(volume, j, myState.channelGui[j].isovalue, 1.0);
-          } else {
-            view3D.clearIsosurface(volume, j);
-          }
+          view3D.setVolumeChannelOptions(volume, j, { isosurfaceEnabled: value });
         };
       })(i)
     );
@@ -713,7 +709,7 @@ function showChannelUI(volume: Volume) {
       .onChange(
         (function (j) {
           return function (value) {
-            view3D.updateIsosurface(volume, j, value);
+            view3D.setVolumeChannelOptions(volume, j, { isovalue: value });
           };
         })(i)
       );

--- a/src/MeshVolume.ts
+++ b/src/MeshVolume.ts
@@ -79,17 +79,6 @@ export default class MeshVolume {
     return this.meshPivot;
   }
 
-  onChannelData(batch: number[]): void {
-    for (let j = 0; j < batch.length; ++j) {
-      const idx = batch[j];
-      // if an isosurface was created before the channel data arrived, we need to re-calculate it now.
-      if (this.meshrep[idx]) {
-        const isovalue = this.getIsovalue(idx);
-        this.updateIsovalue(idx, isovalue === undefined ? 127 : isovalue);
-      }
-    }
-  }
-
   setScale(scale: Vector3, position = new Vector3(0, 0, 0)): void {
     this.scale = scale;
 

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -292,25 +292,6 @@ export class View3d {
   }
 
   /**
-   * If an isosurface is not already created, then create one.  Otherwise change the isovalue of the existing isosurface.
-   * @param {Object} volume
-   * @param {number} channel
-   * @param {number} isovalue isovalue
-   * @param {number=} alpha Opacity
-   */
-  createIsosurface(volume: Volume, channel: number, isovalue: number, alpha: number): void {
-    if (!this.image) {
-      return;
-    }
-    if (this.image.hasIsosurface(channel)) {
-      this.image.updateIsovalue(channel, isovalue);
-    } else {
-      this.image.createIsosurface(channel, isovalue, alpha, alpha < 0.95);
-    }
-    this.redraw();
-  }
-
-  /**
    * Is an isosurface already created for this channel?
    * @param {Object} volume
    * @param {number} channel
@@ -318,41 +299,6 @@ export class View3d {
    */
   hasIsosurface(volume: Volume, channel: number): boolean {
     return this.image?.hasIsosurface(channel) || false;
-  }
-
-  /**
-   * If an isosurface exists, update its isovalue and regenerate the surface. Otherwise do nothing.
-   * @param {Object} volume
-   * @param {number} channel
-   * @param {number} isovalue
-   */
-  updateIsosurface(volume: Volume, channel: number, isovalue: number): void {
-    if (!this.image || !this.image.hasIsosurface(channel)) {
-      return;
-    }
-    this.image.updateIsovalue(channel, isovalue);
-    this.redraw();
-  }
-
-  /**
-   * Set opacity for isosurface
-   * @param {Object} volume
-   * @param {number} channel
-   * @param {number} opacity Opacity
-   */
-  updateOpacity(volume: Volume, channel: number, opacity: number): void {
-    this.image?.updateOpacity(channel, opacity);
-    this.redraw();
-  }
-
-  /**
-   * If an isosurface exists for this channel, hide it now
-   * @param {Object} volume
-   * @param {number} channel
-   */
-  clearIsosurface(volume: Volume, channel: number): void {
-    this.image?.destroyIsosurface(channel);
-    this.redraw();
   }
 
   /**

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -171,15 +171,9 @@ export default class VolumeDrawable {
           this.destroyIsosurface(channelIndex);
         } else if (!hasIso && options.isosurfaceEnabled) {
           // 127 is half of the intensity range 0..255
-          let isovalue = 127;
-          if (options.isovalue !== undefined) {
-            isovalue = options.isovalue;
-          }
+          const isovalue = options.isovalue ?? 127;
           // 1.0 is fully opaque
-          let isosurfaceOpacity = 1.0;
-          if (options.isosurfaceOpacity !== undefined) {
-            isosurfaceOpacity = options.isosurfaceOpacity;
-          }
+          const isosurfaceOpacity = options.isosurfaceOpacity ?? 1.0;
           this.createIsosurface(channelIndex, isovalue, isosurfaceOpacity, isosurfaceOpacity < 1.0);
         }
         this.updateChannelDataRequired(channelIndex);

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -470,11 +470,16 @@ export default class VolumeDrawable {
   }
 
   onChannelLoaded(batch: number[]): void {
-    this.meshVolume.onChannelData(batch);
-
     for (let j = 0; j < batch.length; ++j) {
       const idx = batch[j];
-      this.setChannelOptions(idx, this.channelOptions[idx]);
+      const channelOptions = this.channelOptions[idx];
+      // TODO: this is a relatively crude way to ensure that channel settings are synced up when volume data is loaded.
+      //    Can we instead audit which settings updated by `setChannelOptions` actually need to be reset on load?
+      this.setChannelOptions(idx, channelOptions);
+      if (channelOptions.isosurfaceEnabled) {
+        this.destroyIsosurface(idx);
+        this.createIsosurface(idx, channelOptions.isovalue, channelOptions.isosurfaceOpacity);
+      }
     }
 
     // let the outside world have a chance

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -169,12 +169,9 @@ export default class VolumeDrawable {
       if (hasIso !== options.isosurfaceEnabled) {
         if (hasIso && !options.isosurfaceEnabled) {
           this.destroyIsosurface(channelIndex);
-        } else if (!hasIso && options.isosurfaceEnabled) {
-          // 127 is half of the intensity range 0..255
-          const isovalue = options.isovalue ?? 127;
-          // 1.0 is fully opaque
-          const isosurfaceOpacity = options.isosurfaceOpacity ?? 1.0;
-          this.createIsosurface(channelIndex, isovalue, isosurfaceOpacity, isosurfaceOpacity < 1.0);
+        } else if (!hasIso && options.isosurfaceEnabled && this.volume.channels[channelIndex].loaded) {
+          const { isovalue, isosurfaceOpacity } = options;
+          this.createIsosurface(channelIndex, isovalue, isosurfaceOpacity);
         }
         this.updateChannelDataRequired(channelIndex);
       } else if (options.isosurfaceEnabled) {
@@ -412,8 +409,14 @@ export default class VolumeDrawable {
     return this.meshVolume.hasIsosurface(channel);
   }
 
-  // If an isosurface is not already created, then create one.  Otherwise do nothing.
-  createIsosurface(channel: number, value: number, alpha: number, transp: boolean): void {
+  /**
+   * If an isosurface is not already created, then create one.  Otherwise do nothing.
+   * @param {number} channel The channel to create an isosurface for
+   * @param {number} value The isovalue to use for the isosurface. Default: 127 (middle of 0-255 range)
+   * @param {number} alpha The opacity of the isosurface. Default: 1.0 (opaque)
+   * @param {boolean} transp Whether the isosurface should be transparent. Determined from `alpha` if not provided.
+   */
+  createIsosurface(channel: number, value = 127, alpha = 1.0, transp = alpha < 1.0): void {
     this.meshVolume.createIsosurface(channel, this.channelColors[channel], value, alpha, transp);
   }
 

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -179,7 +179,7 @@ export default class VolumeDrawable {
           this.updateIsovalue(channelIndex, options.isovalue);
         }
         if (options.isosurfaceOpacity !== undefined) {
-          this.updateOpacity(channelIndex, options.isosurfaceOpacity);
+          this.updateIsosurfaceOpacity(channelIndex, options.isosurfaceOpacity);
         }
       }
     } else {
@@ -187,7 +187,7 @@ export default class VolumeDrawable {
         this.updateIsovalue(channelIndex, options.isovalue);
       }
       if (options.isosurfaceOpacity !== undefined) {
-        this.updateOpacity(channelIndex, options.isosurfaceOpacity);
+        this.updateIsosurfaceOpacity(channelIndex, options.isosurfaceOpacity);
       }
     }
   }
@@ -392,7 +392,7 @@ export default class VolumeDrawable {
   }
 
   // If an isosurface exists, update its isovalue and regenerate the surface. Otherwise do nothing.
-  updateIsovalue(channel: number, value: number): void {
+  private updateIsovalue(channel: number, value: number): void {
     this.meshVolume.updateIsovalue(channel, value);
   }
 
@@ -400,13 +400,13 @@ export default class VolumeDrawable {
     return this.meshVolume.getIsovalue(channel);
   }
 
-  // Set opacity for isosurface
-  updateOpacity(channel: number, value: number): void {
-    this.meshVolume.updateOpacity(channel, value);
-  }
-
   hasIsosurface(channel: number): boolean {
     return this.meshVolume.hasIsosurface(channel);
+  }
+
+  /** Set opacity for isosurface */
+  private updateIsosurfaceOpacity(channel: number, value: number): void {
+    this.meshVolume.updateOpacity(channel, value);
   }
 
   /**
@@ -416,12 +416,12 @@ export default class VolumeDrawable {
    * @param {number} alpha The opacity of the isosurface. Default: 1.0 (opaque)
    * @param {boolean} transp Whether the isosurface should be transparent. Determined from `alpha` if not provided.
    */
-  createIsosurface(channel: number, value = 127, alpha = 1.0, transp = alpha < 1.0): void {
+  private createIsosurface(channel: number, value = 127, alpha = 1.0, transp = alpha < 1.0): void {
     this.meshVolume.createIsosurface(channel, this.channelColors[channel], value, alpha, transp);
   }
 
   // If an isosurface exists for this channel, destroy it now. Don't just hide it - assume we can free up some resources.
-  destroyIsosurface(channel: number): void {
+  private destroyIsosurface(channel: number): void {
     this.meshVolume.destroyIsosurface(channel);
   }
 
@@ -478,9 +478,7 @@ export default class VolumeDrawable {
     }
 
     // let the outside world have a chance
-    if (this.onChannelDataReadyCallback) {
-      this.onChannelDataReadyCallback();
-    }
+    this.onChannelDataReadyCallback?.();
   }
 
   onChannelAdded(newChannelIndex: number): void {


### PR DESCRIPTION
Closes allen-cell-animated/website-3d-cell-viewer#189, resolving two related problems with isosurfaces:

1. The visibility of a channel's isosurface doesn't count towards its being "required" to load. I.e., if a channel is disabled in the volume but its isosurface is enabled, the channel is still marked as "not required" and its data will not be reloaded when some event requires it (time change, switch to single-slice mode, etc.).
2. Even while a channel is considered "required," isosurfaces aren't regenerated when new data is loaded, notably while playing through time.

While working on this change, I discovered that the viewer exposed two distinct code paths for changing isosurface settings. One was a set of basically stateless methods (`createIsosurface`, `updateIsosurface`, etc.) and the other was via the newer `setChannelOptions`. The example app in this repo uses the first method, while website-3d-cell-viewer uses the second. Since for a number of reasons we now prefer to use a single state-updating method in cases like this, I removed the first code path and updated the test app. So now I get to submit everyone's favorite kind of pull request: one with a net negative effect on the size of the codebase!