### PR TITLE
allow lut controlpoints to be out of our 0-255 range; simplify remapping

### DIFF
--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -31,7 +31,7 @@ export default class Channel {
     this.loaded = false;
     this.imgData = { data: new Uint8ClampedArray(), width: 0, height: 0 };
     this.rawMin = 0;
-    this.rawMax = 0;
+    this.rawMax = 255;
 
     // on gpu
     this.dataTexture = new DataTexture(new Uint8Array(), 0, 0);
@@ -101,9 +101,9 @@ export default class Channel {
     // when one channel has arrived but others haven't.
     if (!(this.rawMin === 0 && this.rawMax === 0) && !(min === 0 && max === 0)) {
       this.lut.remapDomains(this.rawMin, this.rawMax, min, max);
+      this.rawMin = min;
+      this.rawMax = max;
     }
-    this.rawMin = min;
-    this.rawMax = max;
   }
 
   public getHistogram(): Histogram {

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -241,8 +241,10 @@ export class Lut {
     // special case only one control point.
     if (controlPoints.length === 1) {
       const rgba = controlPointToRGBA(controlPoints[0]);
+      // lut was already filled with zeros
       // copy val from x to 255.
-      for (let x = controlPoints[0].x; x < 256; ++x) {
+      const startx = clamp(controlPoints[0].x, 0, 255);
+      for (let x = startx; x < 256; ++x) {
         lut[x * 4 + 0] = rgba[0];
         lut[x * 4 + 1] = rgba[1];
         lut[x * 4 + 2] = rgba[2];
@@ -281,10 +283,10 @@ export class Lut {
       } else {
         a = (i - c0.x) / (c1.x - c0.x);
       }
-      lut[i * 4 + 0] = lerp(color0[0], color1[0], a);
-      lut[i * 4 + 1] = lerp(color0[1], color1[1], a);
-      lut[i * 4 + 2] = lerp(color0[2], color1[2], a);
-      lut[i * 4 + 3] = lerp(color0[3], color1[3], a);
+      lut[i * 4 + 0] = clamp(lerp(color0[0], color1[0], a), 0, 255);
+      lut[i * 4 + 1] = clamp(lerp(color0[1], color1[1], a), 0, 255);
+      lut[i * 4 + 2] = clamp(lerp(color0[2], color1[2], a), 0, 255);
+      lut[i * 4 + 3] = clamp(lerp(color0[3], color1[3], a), 0, 255);
     }
 
     this.lut = lut;

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -551,7 +551,7 @@ describe("test remapping control points when raw data range is updated", () => {
     // therefore the cps should just outside of 64-192 are gone and
     // the new cp's capture only the ramp up from 64-192 in the original cp list.
     const positions = cp2.map((cp) => Math.round(cp.x));
-    expect(positions).to.include.members([0, 255]);
+    expect(positions).to.include.members([-127, 0, 255, 381]);
   });
   it("remaps the control points correctly when new intensity range expanded", () => {
     const cp: ControlPoint[] = [
@@ -585,6 +585,6 @@ describe("test remapping control points when raw data range is updated", () => {
      *     -64    64    192    320 (abs intensities)
      */
     const positions = cp2.map((cp) => Math.round(cp.x));
-    expect(positions).to.include.members([0, 85, 170, 255]);
+    expect(positions).to.include.members([43, 85, 170, 212]);
   });
 });


### PR DESCRIPTION
Context:
When playing through time series data, we have to adjust our lookup table to account for intensity ranges changing in the data.  However, the way we were doing it, there was too much clipping at the edges of our accepted 0-255 domain for the control points.  In the case of consecutive remappings, information out of the bounds was being lost by this clipping and things would quickly look terrible - often just going to complete black or complete white.

This PR stops trying to fix up edge cases when we have to remap lookup tables during time series playback.  

Instead the plan is to simply allow control points to be out of range, and build the lut array from the control points, correctly handling the out of range values.

See companion PR in website-3d-cell-viewer to properly take advantage of this. (https://github.com/allen-cell-animated/website-3d-cell-viewer/pull/210)