### PR TITLE
Tweakpane fixes

### DIFF
--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -55,8 +55,7 @@ export class View3d {
   private reflectedLight: DirectionalLight;
   private fillLight: DirectionalLight;
 
-  private tweakpane: Pane;
-  private tweakpaneOpen: boolean;
+  private tweakpane: Pane | null;
 
   /**
    * @param {Object} options Optional options.
@@ -86,8 +85,7 @@ export class View3d {
     this.fillLight = new DirectionalLight();
     this.buildScene();
 
-    this.tweakpane = this.setupGui(this.canvas3d.containerdiv);
-    this.tweakpaneOpen = false;
+    this.tweakpane = null;
     window.addEventListener("keydown", this.handleKeydown);
   }
 
@@ -220,8 +218,8 @@ export class View3d {
   onVolumeData(volume: Volume, channels: number[]): void {
     this.image?.updateScale();
     this.image?.onChannelLoaded(channels);
-    if (volume.isLoaded()) {
-      this.tweakpane = this.setupGui(this.canvas3d.containerdiv);
+    if (volume.isLoaded() && this.tweakpane) {
+      this.tweakpane.refresh();
     }
   }
 
@@ -902,8 +900,12 @@ export class View3d {
   handleKeydown = (event: KeyboardEvent): void => {
     // control-option-1 (mac) or ctrl-alt-1 (windows)
     if (event.code === "Digit1" && event.altKey && event.ctrlKey) {
-      this.tweakpaneOpen = !this.tweakpaneOpen;
-      this.tweakpane.element.style.display = this.tweakpaneOpen ? "block" : "none";
+      if (this.tweakpane) {
+        this.tweakpane.dispose();
+        this.tweakpane = null;
+      } else {
+        this.tweakpane = this.setupGui(this.canvas3d.containerdiv);
+      }
     }
   };
 
@@ -912,16 +914,11 @@ export class View3d {
   }
 
   private setupGui(container: HTMLElement): Pane {
-    if (this.tweakpane) {
-      this.canvas3d.containerdiv.removeChild(this.tweakpane.element);
-    }
-
     const pane = new Pane({ title: "Advanced Settings", container });
     const paneStyle: Partial<CSSStyleDeclaration> = {
       position: "absolute",
       top: "0",
       right: "0",
-      display: "none",
     };
     Object.assign(pane.element.style, paneStyle);
 


### PR DESCRIPTION
Review time: really little (5-10min)

Resolves #143 and resolves #156: use tweakpane more responsibly.

### How tweakpane is used currently:

- The user may press Ctrl+Alt+1 to open the tweakpane. Internally, the tweakpane element already existed (built on construction of `View3d`), and this action just reveals it with CSS.
- On every data load, the tweakpane is fully rebuilt.

### How tweakpane is used after this PR:

- The tweakpane does not exist before it is opened - it is (re)built whenever the user toggles it to visible, and destroyed when they toggle to invisible.
- On every data load, we call the pane's `refresh` method.
- We destroy the tweakpane with its own `dispose` method, rather than just unmounting it in the DOM.

I believe the original strategy of rebuilding the tweakpane on data loads was to anticipate when objects were replaced and rebind everything to new objects. But that seems to be pretty rare - it should currently just happen on switching to an entirely new volume (though other, deeper objects we could bind controls to in the future, e.g. `Channel` or `MeshVolume`, may be recreated more frequently and cause confusion). Hopefully a user who knows to open the tweakpane can deal with reopening it when a desync occurs. I'd still be grateful for a bit of extra testing here though. In particular, @toloudis I'm seeing different and better numbers in the heap profiler with this change versus the current state, but I'd be interested in a bit of verification since you did the tests that prompted #143 in the first place.