### PR TITLE
optimize data arriving at viewer's main thread

### DIFF
--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -242,9 +242,10 @@ export default class Channel {
       tileoffset = tilex * x + tiley * y * atlasrow;
       for (let j = 0; j < y; ++j) {
         tilerowoffset = j * atlasrow;
-        for (let k = 0; k < x; ++k) {
-          volimgdata[tileoffset + tilerowoffset + k] = this.volumeData[i * (x * y) + j * x + k];
-        }
+        volimgdata.set(
+          this.volumeData.subarray(i * (x * y) + j * x, i * (x * y) + j * x + x),
+          tileoffset + tilerowoffset
+        );
       }
     }
 

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -166,7 +166,8 @@ export default class Channel {
     let tilex = 0,
       tiley = 0,
       tileoffset = 0,
-      tilerowoffset = 0;
+      tilerowoffset = 0,
+      destOffset = 0;
     for (let i = 0; i < z; ++i) {
       // tile offset
       tilex = i % numXtiles;
@@ -174,9 +175,10 @@ export default class Channel {
       tileoffset = tilex * x + tiley * y * atlasrow;
       for (let j = 0; j < y; ++j) {
         tilerowoffset = j * atlasrow;
+        destOffset = i * (x * y) + j * x;
         this.volumeData.set(
           volimgdata.subarray(tileoffset + tilerowoffset, tileoffset + tilerowoffset + x),
-          i * (x * y) + j * x
+          destOffset
         );
       }
     }
@@ -235,7 +237,8 @@ export default class Channel {
     let tilex = 0,
       tiley = 0,
       tileoffset = 0,
-      tilerowoffset = 0;
+      tilerowoffset = 0,
+      sourceOffset = 0;
     for (let i = 0; i < z; ++i) {
       // tile offset
       tilex = i % numXtiles;
@@ -243,10 +246,8 @@ export default class Channel {
       tileoffset = tilex * x + tiley * y * atlasrow;
       for (let j = 0; j < y; ++j) {
         tilerowoffset = j * atlasrow;
-        volimgdata.set(
-          this.volumeData.subarray(i * (x * y) + j * x, i * (x * y) + j * x + x),
-          tileoffset + tilerowoffset
-        );
+        sourceOffset = i * (x * y) + j * x;
+        volimgdata.set(this.volumeData.subarray(sourceOffset, sourceOffset + x), tileoffset + tilerowoffset);
       }
     }
 

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -174,9 +174,10 @@ export default class Channel {
       tileoffset = tilex * x + tiley * y * atlasrow;
       for (let j = 0; j < y; ++j) {
         tilerowoffset = j * atlasrow;
-        for (let k = 0; k < x; ++k) {
-          this.volumeData[i * (x * y) + j * x + k] = volimgdata[tileoffset + tilerowoffset + k];
-        }
+        this.volumeData.set(
+          volimgdata.subarray(tileoffset + tilerowoffset, tileoffset + tilerowoffset + x),
+          i * (x * y) + j * x
+        );
       }
     }
   }


### PR DESCRIPTION
Estimated time to review:  10 min or less.

One of the most expensive operations when playing through time series is shuffling data around when it arrives at the viewer.
The following two profiles show 30 seconds of ome-zarr playback of one of our nucmorph colonies, playing in our testbed viewer.
In the following profile: `packToAtlas` is pretty expensive.

Before:
<img width="514" alt="DevTools - localhost9021 2024-04-09 13-15-37" src="https://github.com/allen-cell-animated/volume-viewer/assets/2193409/8cae07aa-3c95-4ec2-ae87-ad5ba2b11072">

Turns out packToAtlas is iterating pixel by pixel over the data and reorganizing it into a different buffer. 
At the innermost part of the loop, we could actually do this with a block-wise array copy rather than iterating one pixel at a time.  
After this optimization, the profile shows packToAtlas consisting of a much smaller time slice!

After:
<img width="525" alt="DevTools - localhost9021 2024-04-09 13-18-03" src="https://github.com/allen-cell-animated/volume-viewer/assets/2193409/cca66ece-f905-42d0-99ea-5b620222f8f6">

(You may notice that now `onChannelLoaded` is starting to dominate the time spent.  However, that computation is nearly entirely eliminated by #203 .)
