### PR TITLE
error is now a warning

### DIFF
--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -7,8 +7,8 @@ import {
   VolumeDims,
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
-import { computePackedAtlasDims } from "./VolumeLoaderUtils";
-import { ImageInfo } from "../Volume";
+import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
+import { ImageInfo } from "../Volume.js";
 import { DATARANGE_UINT8 } from "../types.js";
 
 // this is the form in which a 4D numpy array arrives as converted

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -119,7 +119,7 @@ function compareZarrArraySize(
   }
 }
 
-const EPSILON = 0.0000001;
+const EPSILON = 0.00001;
 const aboutEquals = (a: number, b: number): boolean => Math.abs(a - b) < EPSILON;
 
 function scaleTransformsAreEqual(aSrc: ZarrSource, aLevel: number, bSrc: ZarrSource, bLevel: number): boolean {
@@ -168,7 +168,10 @@ export function matchSourceScaleLevels(sources: ZarrSource[]): void {
         // Now we know the arrays are equal, but they may still be invalid to match up because...
         // ...they have different scale transformations
         if (!scaleTransformsAreEqual(smallestSrc, scaleIndexes[smallestIdx], currentSrc, scaleIndexes[currentIdx])) {
-          throw new Error("Incompatible zarr arrays: scale levels of equal size have different scale transformations");
+          // today we are going to treat this as a warning.
+          // For our implementation it is enough that the xyz pixel ranges are the same.
+          // Ideally scale*arraysize=physical size is really the quantity that should be equal, for combining two volume data sets as channels.
+          console.warn("Incompatible zarr arrays: scale transformations are different.");
         }
         // ...they have different numbers of timesteps
         const largestT = smallestSrc.axesTCZYX[0] > -1 ? smallestArr.shape[smallestSrc.axesTCZYX[0]] : 1;

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -171,7 +171,7 @@ export function matchSourceScaleLevels(sources: ZarrSource[]): void {
           // today we are going to treat this as a warning.
           // For our implementation it is enough that the xyz pixel ranges are the same.
           // Ideally scale*arraysize=physical size is really the quantity that should be equal, for combining two volume data sets as channels.
-          console.warn("Incompatible zarr arrays: scale transformations are different.");
+          console.warn("Incompatible zarr arrays: scale levels of equal size have different scale transformations");
         }
         // ...they have different numbers of timesteps
         const largestT = smallestSrc.axesTCZYX[0] > -1 ? smallestArr.shape[smallestSrc.axesTCZYX[0]] : 1;

--- a/src/test/zarr_utils.test.ts
+++ b/src/test/zarr_utils.test.ts
@@ -311,12 +311,12 @@ describe("zarr_utils", () => {
       );
     });
 
-    it("throws an error if two scale levels of the same size have different scale transformations", async () => {
+    it("Does not throw an error if two scale levels of the same size have different scale transformations", async () => {
       const sources = await createMockSources([
         { shapes: [[1, 1, 1, 1, 1]], scales: [[1, 1, 2, 2, 2]] },
         { shapes: [[1, 1, 1, 1, 1]], scales: [[1, 1, 1, 1, 1]] },
       ]);
-      expect(() => matchSourceScaleLevels(sources)).to.throw(
+      expect(() => matchSourceScaleLevels(sources)).to.not.throw(
         "Incompatible zarr arrays: scale levels of equal size have different scale transformations"
       );
     });


### PR DESCRIPTION
Time to review: 5 min

2 key fixes:

1. when matching data from different sources, we will consider the physical scale to be optional in favor of just matching the XYZ array dims.   This is important for our nucmorph deliverable in which they are having trouble applying the correct physical scale metadata to the segmentation zarrs.
2. The RawArrayLoader had some bad imports 
