### PR TITLE
multi-source ome zarr dimension matching:  loosen one more level comparison criterion

### DIFF
--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -163,7 +163,12 @@ export function matchSourceScaleLevels(sources: ZarrSource[]): void {
       if (!ordering) {
         // Arrays are equal, or they are uncomparable
         if (ordering === undefined) {
-          throw new Error("Incompatible zarr arrays: pixel dimensions are mismatched");
+          // We don't need to Error on this at this time.
+          // This just means that the dimensions aren't all changing in the same direction.
+          // We can just skip this as a failed check and continue.
+          console.warn("Incompatible zarr arrays: pixel dimensions are mismatched");
+          allEqual = false;
+          continue;
         }
         // Now we know the arrays are equal, but they may still be invalid to match up because...
         // ...they have different scale transformations

--- a/src/test/zarr_utils.test.ts
+++ b/src/test/zarr_utils.test.ts
@@ -304,9 +304,9 @@ describe("zarr_utils", () => {
       expectSourcesEqual(testSources, refSources);
     });
 
-    it("throws an error if the size of two scale levels are mismatched", async () => {
+    it("Does not throw an error if the size of two scale levels are mismatched", async () => {
       const sources = await createMockSources([{ shapes: [[1, 1, 2, 1, 1]] }, { shapes: [[1, 1, 1, 2, 1]] }]);
-      expect(() => matchSourceScaleLevels(sources)).to.throw(
+      expect(() => matchSourceScaleLevels(sources)).to.not.throw(
         "Incompatible zarr arrays: pixel dimensions are mismatched"
       );
     });


### PR DESCRIPTION
When we are combining zarr channels from two different data sources, we have this loop that tries to find matching array sizes ("shape") among the multiresolution levels of the two zarr sources.

When shapes differ by increasing one dimension but decreasing others, we return an undefined sort value.  This is fine but it also means the levels are unmatched.  We don't need to crash on this - we know the combination is not a match and can continue iterating. 