### PR TITLE
allow differing numbers of time steps

### DIFF
--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -316,9 +316,10 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       times = shapeLv[t];
       for (let i = 0; i < this.sources.length; i++) {
         const shape = this.sources[i].scaleLevels[levelToLoad].shape;
-        if (shape[t] < times) {
-          console.warn("The number of time points is not consistent across sources: ", shape[t], times);
-          times = shape[t];
+        const tindex = this.sources[i].axesTCZYX[0];
+        if (shape[tindex] < times) {
+          console.warn("The number of time points is not consistent across sources: ", shape[tindex], times);
+          times = shape[tindex];
         }
       }
     }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -309,7 +309,19 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     const cLast = sourceLast.axesTCZYX[1];
     const lastHasC = cLast > -1;
     const numChannels = sourceLast.channelOffset + (lastHasC ? sourceLast.scaleLevels[levelToLoad].shape[cLast] : 1);
-    const times = hasT ? shapeLv[t] : 1;
+    // we need to make sure that the corresponding matched shapes
+    // use the min size of T
+    let times = 1;
+    if (hasT) {
+      times = shapeLv[t];
+      for (let i = 0; i < this.sources.length; i++) {
+        const shape = this.sources[i].scaleLevels[levelToLoad].shape;
+        if (shape[t] < times) {
+          console.warn("The number of time points is not consistent across sources: ", shape[t], times);
+          times = shape[t];
+        }
+      }
+    }
 
     if (!this.maxExtent) {
       this.maxExtent = loadSpec.subregion.clone();

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -177,11 +177,9 @@ export function matchSourceScaleLevels(sources: ZarrSource[]): void {
         const largestT = smallestSrc.axesTCZYX[0] > -1 ? smallestArr.shape[smallestSrc.axesTCZYX[0]] : 1;
         const currentT = currentSrc.axesTCZYX[0] > -1 ? currentArr.shape[currentSrc.axesTCZYX[0]] : 1;
         if (largestT !== currentT) {
-          console.warn(
-            "Incompatible zarr arrays: different numbers of timesteps: ",
-            smallestArr.shape,
-            currentArr.shape
-          );
+          // we also treat this as a warning.
+          // In OmeZarrLoader we will take the minimum T size of all sources
+          console.warn(`Incompatible zarr arrays: different numbers of timesteps: ${largestT} vs ${currentT}`);
         }
       } else {
         allEqual = false;

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -177,7 +177,11 @@ export function matchSourceScaleLevels(sources: ZarrSource[]): void {
         const largestT = smallestSrc.axesTCZYX[0] > -1 ? smallestArr.shape[smallestSrc.axesTCZYX[0]] : 1;
         const currentT = currentSrc.axesTCZYX[0] > -1 ? currentArr.shape[currentSrc.axesTCZYX[0]] : 1;
         if (largestT !== currentT) {
-          throw new Error("Incompatible zarr arrays: different numbers of timesteps");
+          console.warn(
+            "Incompatible zarr arrays: different numbers of timesteps: ",
+            smallestArr.shape,
+            currentArr.shape
+          );
         }
       } else {
         allEqual = false;

--- a/src/test/zarr_utils.test.ts
+++ b/src/test/zarr_utils.test.ts
@@ -321,9 +321,9 @@ describe("zarr_utils", () => {
       );
     });
 
-    it("throws an error if two scale levels of the same size have a different number of timesteps", async () => {
+    it("Does not throw an error if two scale levels of the same size have a different number of timesteps", async () => {
       const sources = await createMockSources([{ shapes: [[1, 1, 1, 1, 1]] }, { shapes: [[2, 1, 1, 1, 1]] }]);
-      expect(() => matchSourceScaleLevels(sources)).to.throw(
+      expect(() => matchSourceScaleLevels(sources)).to.not.throw(
         "Incompatible zarr arrays: different numbers of timesteps"
       );
     });


### PR DESCRIPTION
resolves #208 

The use case is that our segmentations have fewer t samples than the raw images.  We would like to just warn in the console and quietly display as if the time sequence had the min of the two times.