### PR TITLE
feat: Added error for zarr files that exceed max atlas size

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
         <option value="zarrIDR2">OME Zarr (IDR 2)</option>
         <option value="zarrVariance">OME Zarr (Variance)</option>
         <option value="zarrNucmorph0">OME Zarr (NucMorph)</option>
+        <option value="zarrFlyBrain">OME Zarr (Fly brain)</option>
         <option value="opencell">OpenCell</option>
         <option value="cfeJson" selected>CFE Json</option>
         <option value="abm">OME TIFF (ABM data)</option>

--- a/public/index.ts
+++ b/public/index.ts
@@ -77,6 +77,10 @@ const TEST_DATA: Record<string, TestDataSpec> = {
     type: VolumeFileFormat.ZARR,
     url: "https://animatedcell-test-data.s3.us-west-2.amazonaws.com/20200323_F01_001/P8-B4.zarr/",
   },
+  zarrFlyBrain: {
+    type: VolumeFileFormat.ZARR,
+    url: "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846152.zarr/",
+  },
   zarrUK: {
     type: VolumeFileFormat.ZARR,
     url: "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr",

--- a/src/loaders/VolumeLoadError.ts
+++ b/src/loaders/VolumeLoadError.ts
@@ -6,6 +6,7 @@ import { NodeNotFoundError, KeyError } from "@zarrita/core";
 export const enum VolumeLoadErrorType {
   UNKNOWN = "unknown",
   NOT_FOUND = "not_found",
+  TOO_LARGE = "too_large",
   LOAD_DATA_FAILED = "load_data_failed",
   INVALID_METADATA = "invalid_metadata",
   INVALID_MULTI_SOURCE_ZARR = "invalid_multi_source_zarr",

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -100,13 +100,10 @@ export function estimateLevelForAtlas(
     return 0;
   }
 
-  // update levelToLoad after we get size info about multiscales
-  let levelToLoad = spatialDimsZYX.length - 1;
   for (let i = 0; i < spatialDimsZYX.length; ++i) {
     // estimate atlas size:
     if (doesSpatialDimensionFitInAtlas(spatialDimsZYX[i], maxAtlasEdge)) {
-      levelToLoad = i;
-      return levelToLoad;
+      return i;
     }
   }
   return undefined;
@@ -140,12 +137,10 @@ export function scaleMultipleDimsToSubregion(subregion: Box3, dims: ZYX[]): ZYX[
  *  This function assumes that `spatialDimsZYX` has already been appropriately scaled to match `loadSpec`'s `subregion`.
  */
 export function pickLevelToLoadUnscaled(loadSpec: LoadSpec, spatialDimsZYX: ZYX[]): number {
-  const optimalLevel = estimateLevelForAtlas(spatialDimsZYX, loadSpec.maxAtlasEdge);
-  let levelToLoad = optimalLevel;
-
-  // Check here for whether optimalLevel is within max atlas size?
-  if (optimalLevel !== undefined) {
-    levelToLoad = Math.max(optimalLevel + (loadSpec.scaleLevelBias ?? 0), loadSpec.multiscaleLevel ?? 0);
+  let levelToLoad = estimateLevelForAtlas(spatialDimsZYX, loadSpec.maxAtlasEdge);
+  // Check here for whether levelToLoad is within max atlas size?
+  if (levelToLoad !== undefined) {
+    levelToLoad = Math.max(levelToLoad + (loadSpec.scaleLevelBias ?? 0), loadSpec.multiscaleLevel ?? 0);
     levelToLoad = Math.max(0, Math.min(spatialDimsZYX.length - 1, levelToLoad));
 
     if (doesSpatialDimensionFitInAtlas(spatialDimsZYX[levelToLoad], loadSpec.maxAtlasEdge)) {

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -164,6 +164,7 @@ export function pickLevelToLoadUnscaled(loadSpec: LoadSpec, spatialDimsZYX: ZYX[
     smallestDims,
     `. Max atlas edge allowed is ${loadSpec.maxAtlasEdge}.`
   );
+  console.log("All available levels: ", spatialDimsZYX);
   throw new VolumeLoadError(`Volume is too large; multiscale level does not fit in preferred memory footprint.`, {
     type: VolumeLoadErrorType.TOO_LARGE,
   });

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -155,13 +155,12 @@ export function pickLevelToLoadUnscaled(loadSpec: LoadSpec, spatialDimsZYX: ZYX[
 
   // Level to load could not be loaded due to atlas size constraints.
   if (levelToLoad === undefined) {
+    // No optimal level exists so choose the smallest level to report out
     levelToLoad = spatialDimsZYX.length - 1;
   }
   const smallestDims = spatialDimsZYX[levelToLoad];
   console.error(
-    `Volume is too large; no multiscale level found that fits in preferred memory footprint. Selected level ${levelToLoad} (optimal ${optimalLevel} + bias ${
-      loadSpec.scaleLevelBias ?? 0
-    }) has dimensions `,
+    `Volume is too large; no multiscale level found that fits in preferred memory footprint. Selected level ${levelToLoad}  has dimensions `,
     smallestDims,
     `. Max atlas edge allowed is ${loadSpec.maxAtlasEdge}.`
   );


### PR DESCRIPTION
Closes #174, handling zarr files that are too large.

*Estimated review size: small, 10 minutes*

## Changes
- Adds a check in VolumeLoaderUtils for Zarr files that exceed our current max atlas dimension (4096x4096), and throws an error if it cannot be loaded.

TODO noted by Dan: For certain datasets, it may be possible to open the Z-slice data but not the 3D data. Should we do parallel checks for both, and switch to 2D mode if it's the only view mode we can support?
TODO: Enforce maximum on the number of channels that can be enabled? 

## Validation
1. Run volume-viewer locally.
2. Switch to the new "Fly Brain" Zarr in the dropdown.
3. Press Ctrl + Alt + 1 to open the developer menu. 
4. Change the maxAtlasEdge to 512. There should be an error message for the 3D view.
5. Switch to Z-slice mode. The error message should disappear and a slice should appear.

