### PR TITLE
Propagate load errors

### DIFF
--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -46,7 +46,7 @@ export class View3d {
   private exposure: number;
   private volumeRenderMode: RenderMode.PATHTRACE | RenderMode.RAYMARCH;
   private renderUpdateListener?: (iteration: number) => void;
-  private loadErrorHandler?: (volume: Volume, error: Error) => void;
+  private loadErrorHandler?: (volume: Volume, error: unknown) => void;
   private image?: VolumeDrawable;
 
   private lights: Light[];
@@ -228,11 +228,11 @@ export class View3d {
     this.image?.onChannelAdded(newChannelIndex);
   }
 
-  onVolumeLoadError(volume: Volume, error: Error): void {
+  onVolumeLoadError(volume: Volume, error: unknown): void {
     this.loadErrorHandler?.(volume, error);
   }
 
-  setLoadErrorHandler(handler: ((volume: Volume, error: Error) => void) | undefined): void {
+  setLoadErrorHandler(handler: ((volume: Volume, error: unknown) => void) | undefined): void {
     this.loadErrorHandler = handler;
   }
 

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -46,6 +46,7 @@ export class View3d {
   private exposure: number;
   private volumeRenderMode: RenderMode.PATHTRACE | RenderMode.RAYMARCH;
   private renderUpdateListener?: (iteration: number) => void;
+  private loadErrorHandler?: (volume: Volume, error: Error) => void;
   private image?: VolumeDrawable;
 
   private lights: Light[];
@@ -225,6 +226,14 @@ export class View3d {
   // do fixups for when the volume has had a new empty channel added.
   onVolumeChannelAdded(volume: Volume, newChannelIndex: number): void {
     this.image?.onChannelAdded(newChannelIndex);
+  }
+
+  onVolumeLoadError(volume: Volume, error: Error): void {
+    this.loadErrorHandler?.(volume, error);
+  }
+
+  setLoadErrorHandler(handler: ((volume: Volume, error: Error) => void) | undefined): void {
+    this.loadErrorHandler = handler;
   }
 
   setTime(volume: Volume, time: number, onChannelLoaded?: PerChannelCallback): void {

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -84,6 +84,7 @@ export const getDefaultImageInfo = (): ImageInfo => ({
 interface VolumeDataObserver {
   onVolumeData: (vol: Volume, batch: number[]) => void;
   onVolumeChannelAdded: (vol: Volume, idx: number) => void;
+  onVolumeLoadError: (vol: Volume, error: Error) => void;
 }
 
 /**

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -287,7 +287,7 @@ export default class Volume {
     }
 
     if (shouldReload) {
-      await this.loadNewData(onChannelLoaded);
+      this.loadNewData(onChannelLoaded);
     }
   }
 

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -286,7 +286,7 @@ export default class Volume {
     }
 
     if (shouldReload) {
-      this.loadNewData(onChannelLoaded);
+      await this.loadNewData(onChannelLoaded);
     }
   }
 
@@ -294,13 +294,13 @@ export default class Volume {
    * Loads new data as specified in `this.loadSpecRequired`. Clones `loadSpecRequired` into `loadSpec` to indicate
    * that the data that *must* be loaded is now the data that *has* been loaded.
    */
-  private loadNewData(onChannelLoaded?: PerChannelCallback): void {
+  private loadNewData(onChannelLoaded?: PerChannelCallback): Promise<void> | undefined {
     this.setUnloaded();
     this.loadSpec = {
       ...this.loadSpecRequired,
       subregion: this.loadSpecRequired.subregion.clone(),
     };
-    this.loader?.loadVolumeData(this, undefined, onChannelLoaded);
+    return this.loader?.loadVolumeData(this, undefined, onChannelLoaded);
   }
 
   // we calculate the physical size of the volume (voxels*pixel_size)

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,9 @@ import {
 } from "./loaders/RawArrayLoader.js";
 import { TiffLoader } from "./loaders/TiffLoader.js";
 import VolumeLoaderContext from "./workers/VolumeLoaderContext.js";
+import { VolumeLoadError, type VolumeLoadErrorType } from "./loaders/VolumeLoadError.js";
 
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
-import { VolumeLoadError, VolumeLoadErrorType } from "./loaders/VolumeLoadError.js";
 
 export type { ImageInfo } from "./Volume.js";
 export type { ControlPoint } from "./Lut.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { TiffLoader } from "./loaders/TiffLoader.js";
 import VolumeLoaderContext from "./workers/VolumeLoaderContext.js";
 
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
+import { VolumeLoadError, VolumeLoadErrorType } from "./loaders/VolumeLoadError.js";
 
 export type { ImageInfo } from "./Volume.js";
 export type { ControlPoint } from "./Lut.js";
@@ -48,6 +49,8 @@ export {
   type RawArrayLoaderOptions,
   TiffLoader,
   VolumeLoaderContext,
+  VolumeLoadError,
+  type VolumeLoadErrorType,
   VolumeFileFormat,
   createVolumeLoader,
   Channel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {
 } from "./loaders/RawArrayLoader.js";
 import { TiffLoader } from "./loaders/TiffLoader.js";
 import VolumeLoaderContext from "./workers/VolumeLoaderContext.js";
-import { VolumeLoadError, type VolumeLoadErrorType } from "./loaders/VolumeLoadError.js";
+import { VolumeLoadError, VolumeLoadErrorType } from "./loaders/VolumeLoadError.js";
 
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
 
@@ -50,7 +50,7 @@ export {
   TiffLoader,
   VolumeLoaderContext,
   VolumeLoadError,
-  type VolumeLoadErrorType,
+  VolumeLoadErrorType,
   VolumeFileFormat,
   createVolumeLoader,
   Channel,

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -81,14 +81,17 @@ export interface IVolumeLoader {
 
   /**
    * Begin loading a volume's data, as specified in its `LoadSpec`.
-   * Pass a callback to respond when this request loads a new channel. This callback will execute after the
-   * one assigned in `createVolume`, if any.
+   *
+   * Pass a callback to respond when this request loads a new channel. This callback will execute after the one
+   * assigned in `createVolume`, if any.
+   *
+   * The returned `Promise` resolves once all channels load, or rejects with any error that occurs during loading.
    */
   // TODO make this return a promise that resolves when loading is done?
   // TODO this is not cancellable in the sense that any async requests initiated here are not stored
   // in a way that they can be interrupted.
   // TODO explicitly passing a `LoadSpec` is now rarely useful. Remove?
-  loadVolumeData(volume: Volume, loadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): void;
+  loadVolumeData(volume: Volume, loadSpec?: LoadSpec, onChannelLoaded?: PerChannelCallback): Promise<void>;
 
   /** Change which directions to prioritize when prefetching. Currently only implemented on `OMEZarrLoader`. */
   setPrefetchPriority(directions: PrefetchDirection[]): void;
@@ -120,16 +123,21 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
   /**
    * Begins loading per-channel data for the volume specified by `imageInfo` and `loadSpec`.
    *
-   * Returns a promise that resolves to reflect any modifications to `imageInfo` and/or `loadSpec` that need to be made
-   * based on this load. Actual loaded channel data is passed to `onData` as it is loaded. Depending on the format,
-   * the returned array may be in simple 3d dimension order or reflect a 2d atlas. If the latter, the dimensions of the
-   * atlas are passed as the third argument to `onData`.
+   * This function accepts two required callbacks. The first, `onUpdateVolumeMetadata`, should be called at most once
+   * to modify the `Volume`'s `imageInfo` and/or `loadSpec` properties based on changes made by this load. Actual
+   * loaded channel data is passed to `onData` as it is loaded.
+   *
+   * Depending on the loader, the array passed to `onData` may be in simple 3d dimension order or reflect a 2d atlas.
+   * If the latter, the dimensions of the atlas are passed as the third argument to `onData`.
+   *
+   * The returned promise should resolve when all data has been loaded, or reject if any error occurs while loading.
    */
   abstract loadRawChannelData(
     imageInfo: ImageInfo,
     loadSpec: LoadSpec,
+    onUpdateVolumeMetadata: (imageInfo?: ImageInfo, loadSpec?: LoadSpec) => void,
     onData: RawChannelDataCallback
-  ): Promise<Partial<LoadedVolumeInfo>>;
+  ): Promise<void>;
 
   setPrefetchPriority(_directions: PrefetchDirection[]): void {
     // no-op by default
@@ -153,6 +161,14 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
     loadSpecOverride?: LoadSpec,
     onChannelLoaded?: PerChannelCallback
   ): Promise<void> {
+    const onUpdateMetadata = (imageInfo?: ImageInfo, loadSpec?: LoadSpec): void => {
+      if (imageInfo) {
+        volume.imageInfo = imageInfo;
+        volume.updateDimensions();
+      }
+      volume.loadSpec = { ...loadSpec, ...spec };
+    };
+
     const onChannelData: RawChannelDataCallback = (channelIndices, dataArrays, ranges, atlasDims) => {
       for (let i = 0; i < channelIndices.length; i++) {
         const channelIndex = channelIndices[i];
@@ -168,12 +184,6 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
     };
 
     const spec = { ...loadSpecOverride, ...volume.loadSpec };
-    const { imageInfo, loadSpec } = await this.loadRawChannelData(volume.imageInfo, spec, onChannelData);
-
-    if (imageInfo) {
-      volume.imageInfo = imageInfo;
-      volume.updateDimensions();
-    }
-    volume.loadSpec = { ...loadSpec, ...spec };
+    return this.loadRawChannelData(volume.imageInfo, spec, onUpdateMetadata, onChannelData);
   }
 }

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -578,6 +578,10 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
         )
       );
 
+      if (result?.data === undefined) {
+        return;
+      }
+
       const converted = convertChannel(result.data);
       if (syncChannels) {
         resultChannelData.push(converted[0]);

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -530,16 +530,18 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     };
   }
 
-  loadRawChannelData(
+  async loadRawChannelData(
     imageInfo: ImageInfo,
     loadSpec: LoadSpec,
+    onUpdateMetadata: (imageInfo: ImageInfo) => void,
     onData: RawChannelDataCallback
-  ): Promise<{ imageInfo: ImageInfo }> {
+  ): Promise<void> {
     // This seemingly useless line keeps a stable local copy of `syncChannels` which the async closures below capture
     // so that changes to `this.syncChannels` don't affect the behavior of loads in progress.
     const syncChannels = this.syncChannels;
 
     const updatedImageInfo = this.updateImageInfoForLoad(imageInfo, loadSpec);
+    onUpdateMetadata(updatedImageInfo);
     const { numChannels, multiscaleLevel } = updatedImageInfo;
     const channelIndexes = loadSpec.channels ?? Array.from({ length: numChannels }, (_, i) => i);
 
@@ -594,13 +596,12 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
 
     this.beginPrefetch(keys, multiscaleLevel);
 
-    Promise.all(channelPromises).then(() => {
-      if (syncChannels) {
-        onData(resultChannelIndices, resultChannelData, resultChannelRanges);
-      }
-      this.requestQueue.removeSubscriber(subscriber, CHUNK_REQUEST_CANCEL_REASON);
-    });
-    return Promise.resolve({ imageInfo: updatedImageInfo });
+    await Promise.all(channelPromises);
+
+    if (syncChannels) {
+      onData(resultChannelIndices, resultChannelData, resultChannelRanges);
+    }
+    this.requestQueue.removeSubscriber(subscriber, CHUNK_REQUEST_CANCEL_REASON);
   }
 }
 

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -61,8 +61,9 @@ class OpenCellLoader extends ThreadableVolumeLoader {
   loadRawChannelData(
     imageInfo: ImageInfo,
     _loadSpec: LoadSpec,
+    _onUpdateMetadata: () => void,
     onData: RawChannelDataCallback
-  ): Promise<Record<string, never>> {
+  ): Promise<void> {
     // HQTILE or LQTILE
     // make a json metadata dict for the two channels:
     const urls = [
@@ -79,8 +80,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     const w = imageInfo.atlasTileDims.x * imageInfo.volumeSize.x;
     const h = imageInfo.atlasTileDims.y * imageInfo.volumeSize.y;
     // all data coming from this loader is natively 8-bit
-    JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, data) => onData(ch, data, [DATARANGE_UINT8], [w, h]));
-    return Promise.resolve({});
+    return JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, data) => onData(ch, data, [DATARANGE_UINT8], [w, h]));
   }
 }
 

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -107,12 +107,21 @@ class RawArrayLoader extends ThreadableVolumeLoader {
     return { imageInfo: convertImageInfo(this.jsonInfo), loadSpec };
   }
 
-  async loadRawChannelData(
+  loadRawChannelData(
     imageInfo: ImageInfo,
     loadSpec: LoadSpec,
+    onUpdateMetadata: (imageInfo: undefined, loadSpec: LoadSpec) => void,
     onData: RawChannelDataCallback
-  ): Promise<{ loadSpec?: LoadSpec }> {
+  ): Promise<void> {
     const requestedChannels = loadSpec.channels;
+
+    const adjustedLoadSpec = {
+      ...loadSpec,
+      // `subregion` and `multiscaleLevel` are unused by this loader
+      subregion: new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1)),
+      multiscaleLevel: 0,
+    };
+    onUpdateMetadata(undefined, adjustedLoadSpec);
 
     for (let chindex = 0; chindex < imageInfo.numChannels; ++chindex) {
       if (requestedChannels && requestedChannels.length > 0 && !requestedChannels.includes(chindex)) {
@@ -124,13 +133,7 @@ class RawArrayLoader extends ThreadableVolumeLoader {
       onData([chindex], [channelData], [DATARANGE_UINT8]);
     }
 
-    const adjustedLoadSpec = {
-      ...loadSpec,
-      // `subregion` and `multiscaleLevel` are unused by this loader
-      subregion: new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1)),
-      multiscaleLevel: 0,
-    };
-    return { loadSpec: adjustedLoadSpec };
+    return Promise.resolve();
   }
 }
 

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -11,6 +11,7 @@ import {
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
 import { VolumeLoadError, VolumeLoadErrorType, wrapVolumeLoadError } from "./VolumeLoadError.js";
 import type { ImageInfo } from "../Volume.js";
+import { ErrorObject, deserializeError } from "serialize-error";
 
 function prepareXML(xml: string): string {
   // trim trailing unicode zeros?
@@ -46,6 +47,24 @@ class OMEDims {
   pixelsizez = 1;
   channelnames: string[] = [];
 }
+
+export type TiffWorkerParams = {
+  channel: number;
+  tilesizex: number;
+  tilesizey: number;
+  sizec: number;
+  sizez: number;
+  dimensionOrder: string;
+  bytesPerSample: number;
+  url: string;
+};
+
+export type TiffLoadResult = {
+  isError: false;
+  data: Uint8Array;
+  channel: number;
+  range: [number, number];
+};
 
 function getAttributeOrError(el: Element, attr: string): string {
   const val = el.getAttribute(attr);
@@ -182,34 +201,43 @@ class TiffLoader extends ThreadableVolumeLoader {
   ): Promise<void> {
     const dims = await this.loadOmeDims();
 
+    const channelProms: Promise<void>[] = [];
     // do each channel on a worker?
     for (let channel = 0; channel < imageInfo.numChannels; ++channel) {
-      const params = {
-        channel: channel,
-        // these are target xy sizes for the in-memory volume data
-        // they may or may not be the same size as original xy sizes
-        tilesizex: imageInfo.volumeSize.x,
-        tilesizey: imageInfo.volumeSize.y,
-        sizec: imageInfo.numChannels,
-        sizez: imageInfo.volumeSize.z,
-        dimensionOrder: dims.dimensionorder,
-        bytesPerSample: getBytesPerSample(dims.pixeltype),
-        url: this.url,
-      };
-      const worker = new Worker(new URL("../workers/FetchTiffWorker", import.meta.url));
-      worker.onmessage = (e) => {
-        const u8 = e.data.data;
-        const channel = e.data.channel;
-        const range = e.data.range;
-        onData([channel], [u8], [range]);
-        worker.terminate();
-      };
-      // TODO propagate original errors with serialize-error
-      worker.onerror = (e) => {
-        alert("Error: Line " + e.lineno + " in " + e.filename + ": " + e.message);
-      };
-      worker.postMessage(params);
+      const thisChannelProm = new Promise<void>((resolve, reject) => {
+        const params: TiffWorkerParams = {
+          channel: channel,
+          // these are target xy sizes for the in-memory volume data
+          // they may or may not be the same size as original xy sizes
+          tilesizex: imageInfo.volumeSize.x,
+          tilesizey: imageInfo.volumeSize.y,
+          sizec: imageInfo.numChannels,
+          sizez: imageInfo.volumeSize.z,
+          dimensionOrder: dims.dimensionorder,
+          bytesPerSample: getBytesPerSample(dims.pixeltype),
+          url: this.url,
+        };
+
+        const worker = new Worker(new URL("../workers/FetchTiffWorker", import.meta.url));
+        worker.onmessage = (e: MessageEvent<TiffLoadResult | { isError: true; error: ErrorObject }>) => {
+          if (e.data.isError) {
+            reject(deserializeError(e.data.error));
+            return;
+          }
+          const { data, channel, range } = e.data;
+          onData([channel], [data], [range]);
+          worker.terminate();
+          resolve();
+        };
+
+        worker.postMessage(params);
+      });
+
+      channelProms.push(thisChannelProm);
     }
+
+    // waiting for all channels to load allows errors to propagate to the caller via this promise
+    await Promise.all(channelProms);
   }
 }
 

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -1,5 +1,6 @@
 import { fromUrl } from "geotiff";
 import { Vector3 } from "three";
+import { ErrorObject, deserializeError } from "serialize-error";
 
 import {
   ThreadableVolumeLoader,
@@ -11,7 +12,6 @@ import {
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
 import { VolumeLoadError, VolumeLoadErrorType, wrapVolumeLoadError } from "./VolumeLoadError.js";
 import type { ImageInfo } from "../Volume.js";
-import { ErrorObject, deserializeError } from "serialize-error";
 
 function prepareXML(xml: string): string {
   // trim trailing unicode zeros?

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -177,8 +177,9 @@ class TiffLoader extends ThreadableVolumeLoader {
   async loadRawChannelData(
     imageInfo: ImageInfo,
     _loadSpec: LoadSpec,
+    _onUpdateMetadata: () => void,
     onData: RawChannelDataCallback
-  ): Promise<Record<string, never>> {
+  ): Promise<void> {
     const dims = await this.loadOmeDims();
 
     // do each channel on a worker?
@@ -203,13 +204,12 @@ class TiffLoader extends ThreadableVolumeLoader {
         onData([channel], [u8], [range]);
         worker.terminate();
       };
+      // TODO propagate original errors with serialize-error
       worker.onerror = (e) => {
         alert("Error: Line " + e.lineno + " in " + e.filename + ": " + e.message);
       };
       worker.postMessage(params);
     }
-
-    return {};
   }
 }
 

--- a/src/workers/FetchTiffWorker.ts
+++ b/src/workers/FetchTiffWorker.ts
@@ -1,7 +1,8 @@
 import { fromUrl } from "geotiff";
 import { serializeError } from "serialize-error";
-import type { TiffLoadResult, TiffWorkerParams } from "../loaders/TiffLoader";
-import { VolumeLoadError, VolumeLoadErrorType } from "../loaders/VolumeLoadError";
+
+import type { TiffLoadResult, TiffWorkerParams } from "../loaders/TiffLoader.js";
+import { VolumeLoadError, VolumeLoadErrorType } from "../loaders/VolumeLoadError.js";
 
 type TypedArray =
   | Uint8Array

--- a/src/workers/FetchTiffWorker.ts
+++ b/src/workers/FetchTiffWorker.ts
@@ -1,6 +1,7 @@
 import { fromUrl } from "geotiff";
 import { serializeError } from "serialize-error";
 import type { TiffLoadResult, TiffWorkerParams } from "../loaders/TiffLoader";
+import { VolumeLoadError, VolumeLoadErrorType } from "../loaders/VolumeLoadError";
 
 type TypedArray =
   | Uint8Array
@@ -92,9 +93,11 @@ async function loadTiffChannel(e: MessageEvent<TiffWorkerParams>): Promise<TiffL
     // deposit in full channel array in the right place
     const offset = zslice * tilesizex * tilesizey;
     if (arrayresult.BYTES_PER_ELEMENT > 4) {
-      console.log("byte size not supported yet");
+      throw new VolumeLoadError("byte size not supported yet", { type: VolumeLoadErrorType.INVALID_METADATA });
     } else if (arrayresult.BYTES_PER_ELEMENT !== bytesPerSample) {
-      console.log("tiff bytes per element mismatch with OME metadata");
+      throw new VolumeLoadError("tiff bytes per element mismatch with OME metadata", {
+        type: VolumeLoadErrorType.INVALID_METADATA,
+      });
     } else {
       u8.set(new Uint8Array(arrayresult.buffer), offset * arrayresult.BYTES_PER_ELEMENT);
     }

--- a/src/workers/FetchTiffWorker.ts
+++ b/src/workers/FetchTiffWorker.ts
@@ -94,7 +94,9 @@ async function loadTiffChannel(e: MessageEvent<TiffWorkerParams>): Promise<TiffL
     // deposit in full channel array in the right place
     const offset = zslice * tilesizex * tilesizey;
     if (arrayresult.BYTES_PER_ELEMENT > 4) {
-      throw new VolumeLoadError("byte size not supported yet", { type: VolumeLoadErrorType.INVALID_METADATA });
+      throw new VolumeLoadError("byte size not supported yet: " + arrayresult.BYTES_PER_ELEMENT, {
+        type: VolumeLoadErrorType.INVALID_METADATA,
+      });
     } else if (arrayresult.BYTES_PER_ELEMENT !== bytesPerSample) {
       throw new VolumeLoadError("tiff bytes per element mismatch with OME metadata", {
         type: VolumeLoadErrorType.INVALID_METADATA,

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -22,6 +22,12 @@ export const enum WorkerResponseResult {
   EVENT,
 }
 
+/** The kind of events that can occur when loading - updates to metadata, or new channel data */
+export const enum WorkerEventType {
+  METADATA_UPDATE,
+  CHANNEL_LOAD,
+}
+
 /** All messages to/from a worker carry a `msgId`, a `type`, and a `payload` (whose type is determined by `type`). */
 type WorkerMsgBase<T extends WorkerMsgType, P> = {
   msgId: number;
@@ -58,13 +64,14 @@ export type WorkerResponsePayload<T extends WorkerMsgType> = {
   [WorkerMsgType.CREATE_LOADER]: boolean;
   [WorkerMsgType.CREATE_VOLUME]: LoadedVolumeInfo;
   [WorkerMsgType.LOAD_DIMS]: VolumeDims[];
-  [WorkerMsgType.LOAD_VOLUME_DATA]: Partial<LoadedVolumeInfo>;
+  [WorkerMsgType.LOAD_VOLUME_DATA]: void;
   [WorkerMsgType.SET_PREFETCH_PRIORITY_DIRECTIONS]: void;
   [WorkerMsgType.SYNCHRONIZE_MULTICHANNEL_LOADING]: void;
 }[T];
 
-/** Currently the only event a loader can produce is a `ChannelLoadEvent` when a batch of channels loads. */
+/** Event for when a batch of channel data loads. */
 export type ChannelLoadEvent = {
+  eventType: WorkerEventType.CHANNEL_LOAD;
   loaderId: number;
   loadId: number;
   channelIndex: number[];
@@ -73,10 +80,19 @@ export type ChannelLoadEvent = {
   atlasDims?: [number, number];
 };
 
+/** Event for when metadata updates. */
+export type MetadataUpdateEvent = {
+  eventType: WorkerEventType.METADATA_UPDATE;
+  loaderId: number;
+  loadId: number;
+  imageInfo?: ImageInfo;
+  loadSpec?: LoadSpec;
+};
+
 /** All valid types of worker requests, with some `WorkerMsgType` and a matching payload type. */
 export type WorkerRequest<T extends WorkerMsgType> = WorkerMsgBase<T, WorkerRequestPayload<T>>;
 /** All valid types of worker responses: `SUCCESS` with a matching payload, `ERROR` with a message, or an `EVENT`. */
 export type WorkerResponse<T extends WorkerMsgType> =
   | ({ responseResult: WorkerResponseResult.SUCCESS } & WorkerMsgBase<T, WorkerResponsePayload<T>>)
   | ({ responseResult: WorkerResponseResult.ERROR } & WorkerMsgBase<T, ErrorObject>)
-  | ({ responseResult: WorkerResponseResult.EVENT } & ChannelLoadEvent);
+  | ({ responseResult: WorkerResponseResult.EVENT } & (ChannelLoadEvent | MetadataUpdateEvent));

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -22,9 +22,11 @@ export const enum WorkerResponseResult {
   EVENT,
 }
 
-/** The kind of events that can occur when loading - updates to metadata, or new channel data */
+/** The kind of events that can occur when loading */
 export const enum WorkerEventType {
+  /** Fired to update a `Volume`'s `imageInfo` and/or `loadSpec` based on loaded data (time, channels, region, etc.) */
   METADATA_UPDATE,
+  /** Fired when data for a channel (or batch of channels) is loaded */
   CHANNEL_LOAD,
 }
 


### PR DESCRIPTION
Review time: moderate (~30min)

#210 introduced a new `VolumeLoadError` type to let us rigorously express any errors that might happen while loading volume data. But due to multiple problems with the way volume loading works, not all of those errors were actually possible to catch. This PR makes changes to ensure that, no matter where errors happen, a client package (i.e. website-3d-cell-viewer) always has a way to learn about it.

## Problem 1: Callbacks

When a loader loads volume data (as opposed to metadata), we generally make simultaneous requests for every individual channel (or batch of channels) in a volume. Internally, this looks like firing off an async closure for every (batch of) channels we're trying to load and then immediately returning, relying on a callback to get channel data back once it's loaded. Trouble is, those closures end up basically floating in space with no connection back to the original call that initiated them.

To resolve this, I changed the signature of `loadVolumeData` to return a `Promise<void>` which represents the load operation in progress, and which therefore must only resolve when all requested channels have loaded. Assuming that promise is implemented sensibly, if one of those channel loads errors, that error should result in the promise rejecting, letting anyone `await`-ing the promise catch that error.

Implementing this required a moderate rework to the way `ThreadableVolumeLoader` works, and therefore to the interface between `VolumeLoadWorker` and the main thread (via `VolumeLoaderContext`).

## Problem 2: Implicit loading

Even if every error generated by a loader can be caught, not every call to the loader is accessible to the client: many (most now) are made implicitly on a change to some other setting - time, region, scale level, etc. I added the ability to set a load error handler on `View3d` to capture errors on these implicit loads. This handler gets attached to a `Volume` via the pre-existing `VolumeDataObserver` path.