### PR TITLE
fix: Fixes webpack syntax error when running `npm run start`

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,7 +5,7 @@ import CopyWebpackPlugin from "copy-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
 
-import packageJson from "./package.json" with { type: "json" };
+import packageJson from "./package.json" assert { type: "json" };
 
 import { fileURLToPath } from "url";
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -60,7 +60,7 @@ export default {
     extensions: [".js", ".ts"],
     extensionAlias: {
       ".js": [".js", ".ts"],
-    }
+    },
   },
   module: {
     rules: [


### PR DESCRIPTION
Fixes an error I was encountering when running webpack:

```
[webpack-cli] Failed to load 'C:\Users\...\volume-viewer\webpack.dev.js' config
[webpack-cli] SyntaxError: Unexpected token 'with'
```

This replaces the `with` token with a type assertion.

*Estimated review size: tiny, 1 minute*