### PR TITLE
remove subset adjustment from slice shader

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -603,8 +603,8 @@ function updateZSliceUI(volume: Volume) {
   const zInput = document.getElementById("zValue") as HTMLInputElement;
 
   const totalZSlices = volume.imageInfo.volumeSize.z;
-  zSlider.max = `${totalZSlices}`;
-  zInput.max = `${totalZSlices}`;
+  zSlider.max = `${totalZSlices - 1}`;
+  zInput.max = `${totalZSlices - 1}`;
 
   zInput.value = `${Math.floor(totalZSlices / 2)}`;
   zSlider.value = `${Math.floor(totalZSlices / 2)}`;

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -170,9 +170,13 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
     if (dirtyFlags & SettingsFlags.ROI) {
       // Normalize and set bounds
       const bounds = this.settings.bounds;
+      const { normRegionSize, normRegionOffset } = this.volume;
+      const offsetToCenter = normRegionSize.clone().divideScalar(2).add(normRegionOffset).subScalar(0.5);
+      const bmin = bounds.bmin.clone().sub(offsetToCenter).divide(normRegionSize).clampScalar(-0.5, 0.5);
+      const bmax = bounds.bmax.clone().sub(offsetToCenter).divide(normRegionSize).clampScalar(-0.5, 0.5);
 
-      this.setUniform("AABB_CLIP_MIN", bounds.bmin);
-      this.setUniform("AABB_CLIP_MAX", bounds.bmax);
+      this.setUniform("AABB_CLIP_MIN", bmin);
+      this.setUniform("AABB_CLIP_MAX", bmax);
 
       const sliceInBounds = this.updateSlice();
       if (sliceInBounds) {

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -93,6 +93,7 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
 
   public updateVolumeDimensions(): void {
     const scale = this.volume.normPhysicalSize;
+    this.geometryMesh.position.copy(this.volume.getContentCenter());
     // set scale
     this.geometryMesh.scale.copy(scale);
     this.setUniform("volumeScale", scale);

--- a/src/Atlas2DSlice.ts
+++ b/src/Atlas2DSlice.ts
@@ -105,8 +105,6 @@ export default class Atlas2DSlice implements VolumeRenderImpl {
     this.setUniform("ATLAS_DIMS", atlasTileDims);
     this.setUniform("textureRes", atlasSize);
     this.setUniform("SLICES", volumeSize.z);
-    this.setUniform("SUBSET_SCALE", this.volume.normRegionSize);
-    this.setUniform("SUBSET_OFFSET", this.volume.normRegionOffset);
     if (this.sliceUpdateWaiting) {
       this.updateSlice();
     }

--- a/src/constants/shaders/slice.frag
+++ b/src/constants/shaders/slice.frag
@@ -13,8 +13,6 @@ uniform float maskAlpha;
 uniform vec2 ATLAS_DIMS;
 uniform vec3 AABB_CLIP_MIN;
 uniform vec3 AABB_CLIP_MAX;
-uniform vec3 SUBSET_SCALE;
-uniform vec3 SUBSET_OFFSET;
 uniform sampler2D textureAtlas;
 uniform sampler2D textureAtlasMask;
 uniform int Z_SLICE;
@@ -36,6 +34,7 @@ vec4 sampleAtlas(sampler2D tex, vec4 pos) {
   float bounds = float(pos[0] >= 0.0 && pos[0] <= 1.0 &&
     pos[1] >= 0.0 && pos[1] <= 1.0 &&
     pos[2] >= 0.0 && pos[2] <= 1.0);
+
   float nSlices = float(SLICES);
 
   vec2 loc0 = ((pos.xy - 0.5) * flipVolume.xy + 0.5) / ATLAS_DIMS;
@@ -87,7 +86,6 @@ void main() {
   vec4 pos = vec4(vUv, 
     (SLICES==1.0 && Z_SLICE==0) ? 0.0 : float(Z_SLICE) / (SLICES - 1.0), 
     0.0);
-  pos.xyz = (pos.xyz - SUBSET_OFFSET) / SUBSET_SCALE;
 
   vec4 C;
   C = sampleAtlas(textureAtlas, pos);

--- a/src/constants/volumeSliceShader.ts
+++ b/src/constants/volumeSliceShader.ts
@@ -80,14 +80,6 @@ export const sliceShaderUniforms = () => {
       type: "v3",
       value: new Vector3(0.5, 0.5, 0.5),
     },
-    SUBSET_SCALE: {
-      type: "v3",
-      value: new Vector3(1, 1, 1),
-    },
-    SUBSET_OFFSET: {
-      type: "v3",
-      value: new Vector3(0, 0, 0),
-    },
     inverseModelViewMatrix: {
       type: "m4",
       value: new Matrix4(),


### PR DESCRIPTION
Fixing #223 
This extra adjustment was incurring floating point errors which make the last z slice go out of bounds.
Rather than add a bounds epsilon, I found that removing this code seemed to fix the bug without causing any visual discrepancies.

@frasercl would love your insight as to whether this is totally safe.  I think I tested a variety of files but not sure I know why it was there in the first place.