### PR TITLE
Two lut enhancements

### DIFF
--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -475,7 +475,8 @@ export function remapControlPoints(
   oldMin: number,
   oldMax: number,
   newMin: number,
-  newMax: number
+  newMax: number,
+  noNudge = false
 ): ControlPoint[] {
   if (controlPoints.length === 0) {
     return controlPoints;
@@ -502,6 +503,10 @@ export function remapControlPoints(
       color: [cp.color[0], cp.color[1], cp.color[2]],
     };
     newControlPoints.push(newCP);
+  }
+
+  if (noNudge) {
+    return newControlPoints;
   }
 
   // Commonly (e.g. in the output of most of the LUT generators above), the first and last control points define a line

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -182,10 +182,10 @@ export class Lut {
         const [first, last] = this.controlPoints;
         if (first.x === 0 && last.x === 255 && first.opacity === 0 && last.opacity === 1) {
           this.#lut = createFullRangeLut();
+          return this.#lut;
         }
-      } else {
-        this.#lut = controlPointsToLut(this.controlPoints);
       }
+      this.#lut = controlPointsToLut(this.controlPoints);
     }
 
     return this.#lut as Uint8Array;

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -191,10 +191,6 @@ export class Lut {
     return this.#lut as Uint8Array;
   }
 
-  set lut(lut: Uint8Array) {
-    this.#lut = lut;
-  }
-
   /**
    * Generate a piecewise linear lookup table that ramps up from 0 to 1 over the b to e domain.
    * If e === b, then we use a step function with f(b) = 0 and f(b + 1) = 1

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -476,7 +476,7 @@ export function remapControlPoints(
   oldMax: number,
   newMin: number,
   newMax: number,
-  noNudge = false
+  nudgeEndPoints = true
 ): ControlPoint[] {
   if (controlPoints.length === 0) {
     return controlPoints;
@@ -505,7 +505,7 @@ export function remapControlPoints(
     newControlPoints.push(newCP);
   }
 
-  return noNudge ? newControlPoints : nudgeRemappedEndControlPoints(newControlPoints, oldFirstX, oldLastX);
+  return nudgeEndPoints ? nudgeRemappedEndControlPoints(newControlPoints, oldFirstX, oldLastX) : newControlPoints;
 }
 
 /**

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -83,20 +83,6 @@ const createFullRangeControlPoints = (opacityMin = 0, opacityMax = 1): [ControlP
   { x: 255, opacity: opacityMax, color: [255, 255, 255] },
 ];
 
-function createFullRangeLut(): Uint8Array {
-  const lut = new Uint8Array(LUT_ARRAY_LENGTH);
-
-  // simple linear mapping for actual range
-  for (let x = 0; x < lut.length / 4; ++x) {
-    lut[x * 4 + 0] = 255;
-    lut[x * 4 + 1] = 255;
-    lut[x * 4 + 2] = 255;
-    lut[x * 4 + 3] = x;
-  }
-
-  return lut;
-}
-
 /**
  * @typedef {Object} Lut Used for rendering.
  * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array
@@ -206,7 +192,17 @@ export class Lut {
 
   // basically, the identity LUT with respect to opacity
   createFullRange(): Lut {
-    this.lut = createFullRangeLut();
+    const lut = new Uint8Array(LUT_ARRAY_LENGTH);
+
+    // simple linear mapping for actual range
+    for (let x = 0; x < lut.length / 4; ++x) {
+      lut[x * 4 + 0] = 255;
+      lut[x * 4 + 1] = 255;
+      lut[x * 4 + 2] = 255;
+      lut[x * 4 + 3] = x;
+    }
+
+    this.lut = lut;
     this.controlPoints = createFullRangeControlPoints();
     return this;
   }

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -191,6 +191,10 @@ export class Lut {
     return this.#lut as Uint8Array;
   }
 
+  set lut(lut: Uint8Array) {
+    this.#lut = lut;
+  }
+
   /**
    * Generate a piecewise linear lookup table that ramps up from 0 to 1 over the b to e domain.
    * If e === b, then we use a step function with f(b) = 0 and f(b + 1) = 1

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -97,70 +97,6 @@ function createFullRangeLut(): Uint8Array {
   return lut;
 }
 
-// @param {Object[]} controlPoints - array of {x:number 0..255, opacity:number 0..1, color:array of 3 numbers 0..255}
-// @return {Uint8Array} array of length 256*4 representing the rgba values of the gradient
-function controlPointsToLut(controlPoints: ControlPoint[]): Uint8Array {
-  const lut = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
-
-  if (controlPoints.length === 0) {
-    return lut;
-  }
-
-  // ensure they are sorted in ascending order of x
-  controlPoints.sort((a, b) => a.x - b.x);
-
-  // special case only one control point.
-  if (controlPoints.length === 1) {
-    const rgba = controlPointToRGBA(controlPoints[0]);
-    // lut was already filled with zeros
-    // copy val from x to 255.
-    const startx = clamp(controlPoints[0].x, 0, 255);
-    for (let x = startx; x < 256; ++x) {
-      lut[x * 4 + 0] = rgba[0];
-      lut[x * 4 + 1] = rgba[1];
-      lut[x * 4 + 2] = rgba[2];
-      lut[x * 4 + 3] = rgba[3];
-    }
-    return lut;
-  }
-
-  let c0 = controlPoints[0];
-  let c1 = controlPoints[1];
-  let color0 = controlPointToRGBA(c0);
-  let color1 = controlPointToRGBA(c1);
-  let lastIndex = 1;
-  let a = 0;
-  for (let i = 0; i < 256; ++i) {
-    // find the two control points that i is between
-    while (i > c1.x) {
-      // advance control points
-      c0 = c1;
-      color0 = color1;
-      lastIndex++;
-      if (lastIndex >= controlPoints.length) {
-        // if the last control point is before 255, then we want to continue its value all the way to 255.
-        c1 = { x: 255, color: c1.color, opacity: c1.opacity };
-      } else {
-        c1 = controlPoints[lastIndex];
-      }
-      color1 = controlPointToRGBA(c1);
-    }
-    // find the lerp amount between the two control points
-    if (c1.x === c0.x) {
-      // use c1
-      a = 1.0;
-    } else {
-      a = (i - c0.x) / (c1.x - c0.x);
-    }
-    lut[i * 4 + 0] = clamp(lerp(color0[0], color1[0], a), 0, 255);
-    lut[i * 4 + 1] = clamp(lerp(color0[1], color1[1], a), 0, 255);
-    lut[i * 4 + 2] = clamp(lerp(color0[2], color1[2], a), 0, 255);
-    lut[i * 4 + 3] = clamp(lerp(color0[3], color1[3], a), 0, 255);
-  }
-
-  return lut;
-}
-
 /**
  * @typedef {Object} Lut Used for rendering.
  * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array
@@ -168,27 +104,13 @@ function controlPointsToLut(controlPoints: ControlPoint[]): Uint8Array {
  * @property {Array.<ControlPoint>} controlPoints
  */
 export class Lut {
+  public lut: Uint8Array;
   public controlPoints: ControlPoint[];
-  #lut: Uint8Array | null;
 
   constructor() {
-    this.#lut = null;
-    this.controlPoints = createFullRangeControlPoints();
-  }
-
-  get lut(): Uint8Array {
-    if (this.#lut === null) {
-      if (this.controlPoints.length === 2) {
-        const [first, last] = this.controlPoints;
-        if (first.x === 0 && last.x === 255 && first.opacity === 0 && last.opacity === 1) {
-          this.#lut = createFullRangeLut();
-        }
-      } else {
-        this.#lut = controlPointsToLut(this.controlPoints);
-      }
-    }
-
-    return this.#lut as Uint8Array;
+    this.lut = new Uint8Array(LUT_ARRAY_LENGTH);
+    this.controlPoints = [];
+    this.createFullRange();
   }
 
   /**
@@ -235,12 +157,12 @@ export class Lut {
 
     // Edge case: b and e are both out of bounds
     if (b < 0 && e < 0) {
-      this.#lut = lut;
+      this.lut = lut;
       this.controlPoints = createFullRangeControlPoints(1, 1);
       return this;
     }
     if (b >= 255 && e >= 255) {
-      this.#lut = lut;
+      this.lut = lut;
       this.controlPoints = createFullRangeControlPoints(0, 0);
       return this;
     }
@@ -277,14 +199,14 @@ export class Lut {
     }
     controlPoints.push({ x: 255, opacity: endVal, color: [255, 255, 255] });
 
-    this.#lut = lut;
+    this.lut = lut;
     this.controlPoints = controlPoints;
     return this;
   }
 
   // basically, the identity LUT with respect to opacity
   createFullRange(): Lut {
-    this.#lut = createFullRangeLut();
+    this.lut = createFullRangeLut();
     this.controlPoints = createFullRangeControlPoints();
     return this;
   }
@@ -302,7 +224,72 @@ export class Lut {
     return this.createFromMinMax(b * 255, e * 255);
   }
 
+  // @param {Object[]} controlPoints - array of {x:number 0..255, opacity:number 0..1, color:array of 3 numbers 0..255}
+  // @return {Uint8Array} array of length 256*4 representing the rgba values of the gradient
   createFromControlPoints(controlPoints: ControlPoint[]): Lut {
+    const lut = new Uint8Array(LUT_ARRAY_LENGTH).fill(0);
+
+    if (controlPoints.length === 0) {
+      this.lut = lut;
+      this.controlPoints = controlPoints;
+      return this;
+    }
+
+    // ensure they are sorted in ascending order of x
+    controlPoints.sort((a, b) => a.x - b.x);
+
+    // special case only one control point.
+    if (controlPoints.length === 1) {
+      const rgba = controlPointToRGBA(controlPoints[0]);
+      // lut was already filled with zeros
+      // copy val from x to 255.
+      const startx = clamp(controlPoints[0].x, 0, 255);
+      for (let x = startx; x < 256; ++x) {
+        lut[x * 4 + 0] = rgba[0];
+        lut[x * 4 + 1] = rgba[1];
+        lut[x * 4 + 2] = rgba[2];
+        lut[x * 4 + 3] = rgba[3];
+      }
+      this.lut = lut;
+      this.controlPoints = controlPoints;
+      return this;
+    }
+
+    let c0 = controlPoints[0];
+    let c1 = controlPoints[1];
+    let color0 = controlPointToRGBA(c0);
+    let color1 = controlPointToRGBA(c1);
+    let lastIndex = 1;
+    let a = 0;
+    for (let i = 0; i < 256; ++i) {
+      // find the two control points that i is between
+      while (i > c1.x) {
+        // advance control points
+        c0 = c1;
+        color0 = color1;
+        lastIndex++;
+        if (lastIndex >= controlPoints.length) {
+          // if the last control point is before 255, then we want to continue its value all the way to 255.
+          c1 = { x: 255, color: c1.color, opacity: c1.opacity };
+        } else {
+          c1 = controlPoints[lastIndex];
+        }
+        color1 = controlPointToRGBA(c1);
+      }
+      // find the lerp amount between the two control points
+      if (c1.x === c0.x) {
+        // use c1
+        a = 1.0;
+      } else {
+        a = (i - c0.x) / (c1.x - c0.x);
+      }
+      lut[i * 4 + 0] = clamp(lerp(color0[0], color1[0], a), 0, 255);
+      lut[i * 4 + 1] = clamp(lerp(color0[1], color1[1], a), 0, 255);
+      lut[i * 4 + 2] = clamp(lerp(color0[2], color1[2], a), 0, 255);
+      lut[i * 4 + 3] = clamp(lerp(color0[3], color1[3], a), 0, 255);
+    }
+
+    this.lut = lut;
     this.controlPoints = controlPoints;
     return this;
   }
@@ -355,7 +342,7 @@ export class Lut {
 
       lutControlPoints.push({ x: 255, opacity: 1, color: [255, 255, 255] });
 
-      this.#lut = lut;
+      this.lut = lut;
       this.controlPoints = lutControlPoints;
       return this;
     } else {
@@ -417,7 +404,7 @@ export class Lut {
       }
     }
 
-    this.#lut = lut;
+    this.lut = lut;
     this.controlPoints = controlPoints;
     return this;
   }
@@ -426,7 +413,7 @@ export class Lut {
   remapDomains(oldMin: number, oldMax: number, newMin: number, newMax: number) {
     // no attempt is made here to ensure that lut and controlPoints are internally consistent.
     // if they start out consistent, they should end up consistent. And vice versa.
-    this.#lut = this.#lut && remapLut(this.#lut, oldMin, oldMax, newMin, newMax);
+    this.lut = remapLut(this.lut, oldMin, oldMax, newMin, newMax);
     this.controlPoints = remapControlPoints(this.controlPoints, oldMin, oldMax, newMin, newMax);
   }
 }

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -83,6 +83,20 @@ const createFullRangeControlPoints = (opacityMin = 0, opacityMax = 1): [ControlP
   { x: 255, opacity: opacityMax, color: [255, 255, 255] },
 ];
 
+function createFullRangeLut(): Uint8Array {
+  const lut = new Uint8Array(LUT_ARRAY_LENGTH);
+
+  // simple linear mapping for actual range
+  for (let x = 0; x < lut.length / 4; ++x) {
+    lut[x * 4 + 0] = 255;
+    lut[x * 4 + 1] = 255;
+    lut[x * 4 + 2] = 255;
+    lut[x * 4 + 3] = x;
+  }
+
+  return lut;
+}
+
 /**
  * @typedef {Object} Lut Used for rendering.
  * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array
@@ -192,17 +206,7 @@ export class Lut {
 
   // basically, the identity LUT with respect to opacity
   createFullRange(): Lut {
-    const lut = new Uint8Array(LUT_ARRAY_LENGTH);
-
-    // simple linear mapping for actual range
-    for (let x = 0; x < lut.length / 4; ++x) {
-      lut[x * 4 + 0] = 255;
-      lut[x * 4 + 1] = 255;
-      lut[x * 4 + 2] = 255;
-      lut[x * 4 + 3] = x;
-    }
-
-    this.lut = lut;
+    this.lut = createFullRangeLut();
     this.controlPoints = createFullRangeControlPoints();
     return this;
   }

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -182,10 +182,10 @@ export class Lut {
         const [first, last] = this.controlPoints;
         if (first.x === 0 && last.x === 255 && first.opacity === 0 && last.opacity === 1) {
           this.#lut = createFullRangeLut();
-          return this.#lut;
         }
+      } else {
+        this.#lut = controlPointsToLut(this.controlPoints);
       }
-      this.#lut = controlPointsToLut(this.controlPoints);
     }
 
     return this.#lut as Uint8Array;

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -505,18 +505,28 @@ export function remapControlPoints(
     newControlPoints.push(newCP);
   }
 
-  if (noNudge) {
-    return newControlPoints;
-  }
+  return noNudge ? newControlPoints : nudgeRemappedEndControlPoints(newControlPoints, oldFirstX, oldLastX);
+}
 
-  // Commonly (e.g. in the output of most of the LUT generators above), the first and last control points define a line
-  // of constant opacity and are just there to connect the function to the ends of the range. Remapping these points
-  // just makes things look weird. We should do our best to keep them in place without losing information.
+/**
+ * Attempts to keep the first and last control points in a remapped list in a sensible place if they were previously on
+ * or outside the edge of the range.
+ *
+ * Commonly (e.g. in the output of nearly all the factory methods in `Lut`), the very first and last control points
+ * just define a line of constant opacity out to the upper/lower edge of the range. Remapping these points naively
+ * means that the range of the transfer function no longer matches the actual range of intensities. This isn't a
+ * problem for producing a lut, but it does make things look weird. If it is possible to do so without losing
+ * information, we should try to keep these points in place.
+ *
+ * In addition to a list of control points, this function requires the x coordinate of the end points _before_
+ * remapping, to determine whether the points used to be at or outside the edges of the range.
+ */
+function nudgeRemappedEndControlPoints(controlPoints: ControlPoint[], oldFirstX: number, oldLastX: number) {
   const EPSILON = 0.0001;
-  const first = newControlPoints[0];
-  const second = newControlPoints[1];
-  const secondLast = newControlPoints[newControlPoints.length - 2];
-  const last = newControlPoints[newControlPoints.length - 1];
+  const first = controlPoints[0];
+  const second = controlPoints[1];
+  const secondLast = controlPoints[controlPoints.length - 2];
+  const last = controlPoints[controlPoints.length - 1];
 
   if (Math.abs(first.opacity - (second?.opacity ?? Infinity)) < EPSILON) {
     if (first.x < 0) {
@@ -538,5 +548,5 @@ export function remapControlPoints(
     }
   }
 
-  return newControlPoints;
+  return controlPoints;
 }

--- a/src/Lut.ts
+++ b/src/Lut.ts
@@ -78,6 +78,11 @@ function controlPointToRGBA(controlPoint) {
   return [controlPoint.color[0], controlPoint.color[1], controlPoint.color[2], Math.floor(controlPoint.opacity * 255)];
 }
 
+const createFullRangeControlPoints = (opacityMin = 0, opacityMax = 1): [ControlPoint, ControlPoint] => [
+  { x: 0, opacity: opacityMin, color: [255, 255, 255] },
+  { x: 255, opacity: opacityMax, color: [255, 255, 255] },
+];
+
 /**
  * @typedef {Object} Lut Used for rendering.
  * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array
@@ -139,18 +144,12 @@ export class Lut {
     // Edge case: b and e are both out of bounds
     if (b < 0 && e < 0) {
       this.lut = lut;
-      this.controlPoints = [
-        { x: 0, opacity: 1, color: [255, 255, 255] },
-        { x: 255, opacity: 1, color: [255, 255, 255] },
-      ];
+      this.controlPoints = createFullRangeControlPoints(1, 1);
       return this;
     }
     if (b >= 255 && e >= 255) {
       this.lut = lut;
-      this.controlPoints = [
-        { x: 0, opacity: 0, color: [255, 255, 255] },
-        { x: 255, opacity: 0, color: [255, 255, 255] },
-      ];
+      this.controlPoints = createFullRangeControlPoints(0, 0);
       return this;
     }
 
@@ -204,10 +203,7 @@ export class Lut {
     }
 
     this.lut = lut;
-    this.controlPoints = [
-      { x: 0, opacity: 0, color: [255, 255, 255] },
-      { x: 255, opacity: 1, color: [255, 255, 255] },
-    ];
+    this.controlPoints = createFullRangeControlPoints();
     return this;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import VolumeCache from "./VolumeCache.js";
 import RequestQueue from "./utils/RequestQueue.js";
 import SubscribableRequestQueue from "./utils/SubscribableRequestQueue.js";
 import Histogram from "./Histogram.js";
-import { Lut } from "./Lut.js";
+import { Lut, remapControlPoints } from "./Lut.js";
 import { ViewportCorner } from "./types.js";
 import { VolumeFileFormat, createVolumeLoader, PrefetchDirection } from "./loaders/index.js";
 import { LoadSpec } from "./loaders/IVolumeLoader.js";
@@ -33,6 +33,7 @@ export type { WorkerLoader } from "./workers/VolumeLoaderContext.js";
 export {
   Histogram,
   Lut,
+  remapControlPoints,
   View3d,
   Volume,
   LoadSpec,

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -516,13 +516,14 @@ describe("test remapping lut when raw data range is updated", () => {
 });
 
 describe("test remapping control points when raw data range is updated", () => {
+  const cp: ControlPoint[] = [
+    { x: 0, color: [255, 255, 255], opacity: 0 },
+    { x: 64, color: [255, 255, 255], opacity: 0 },
+    { x: 192, color: [255, 255, 255], opacity: 1.0 },
+    { x: 255, color: [255, 255, 255], opacity: 1.0 },
+  ];
+
   it("remaps the control points correctly when new intensity range contracted", () => {
-    const cp: ControlPoint[] = [
-      { x: 0, color: [255, 255, 255], opacity: 0 },
-      { x: 64, color: [255, 255, 255], opacity: 0 },
-      { x: 192, color: [255, 255, 255], opacity: 1.0 },
-      { x: 255, color: [255, 255, 255], opacity: 1.0 },
-    ];
     /**
      * Old CPs:
      * 255 |           o ------o
@@ -554,12 +555,6 @@ describe("test remapping control points when raw data range is updated", () => {
     expect(positions).to.include.members([-127, 0, 255, 381]);
   });
   it("remaps the control points correctly when new intensity range expanded", () => {
-    const cp: ControlPoint[] = [
-      { x: 0, color: [255, 255, 255], opacity: 0 },
-      { x: 64, color: [255, 255, 255], opacity: 0 },
-      { x: 192, color: [255, 255, 255], opacity: 1.0 },
-      { x: 255, color: [255, 255, 255], opacity: 1.0 },
-    ];
     /**
      * Old CPs:
      * 255 |           o ------o

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -516,7 +516,7 @@ describe("test remapping lut when raw data range is updated", () => {
 });
 
 describe("test remapping control points when raw data range is updated", () => {
-  const cp: ControlPoint[] = [
+  const createMockCPs = (): ControlPoint[] => [
     { x: 0, color: [255, 255, 255], opacity: 0 },
     { x: 64, color: [255, 255, 255], opacity: 0 },
     { x: 192, color: [255, 255, 255], opacity: 1.0 },
@@ -524,6 +524,7 @@ describe("test remapping control points when raw data range is updated", () => {
   ];
 
   it("remaps the control points correctly when new intensity range contracted", () => {
+    const cp = createMockCPs();
     /**
      * Old CPs:
      * 255 |           o ------o
@@ -555,6 +556,7 @@ describe("test remapping control points when raw data range is updated", () => {
     expect(positions).to.include.members([-127, 0, 255, 381]);
   });
   it("remaps the control points correctly when new intensity range expanded", () => {
+    const cp = createMockCPs();
     /**
      * Old CPs:
      * 255 |           o ------o

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -534,7 +534,7 @@ describe("test remapping control points when raw data range is updated", () => {
      *       0    64    192    255
      *       v    v     v      v
      */
-    const cp2 = remapControlPoints(cp, 0, 255, 64, 192);
+    const cp2 = remapControlPoints(cp, 0, 255, 64, 192, false);
     /**
      * New CPs:
      * 255 |           o
@@ -571,7 +571,7 @@ describe("test remapping control points when raw data range is updated", () => {
      *       0    64    192    255
      *       v    v     v      v
      */
-    const cp2 = remapControlPoints(cp, 0, 255, -64, 320);
+    const cp2 = remapControlPoints(cp, 0, 255, -64, 320, false);
     /**
      * New CPs:
      * 255 |           o ------o


### PR DESCRIPTION
Review time: small-medium (~10-20min)

Implements one and a half small wishlist items related to lut/control point remapping I had while working on allen-cell-animated/website-3d-cell-viewer#294. This causes no breaking changes to the API, so this code should be fine to update into website-3d-cell-viewer without any further changes.

## Change 1: nudge start and end control points when remapping

When control points are remapped, the first and last control points are almost always pushed either outside the 0-255 range, or into the middle of the range so that the control points no longer technically define a function with a domain of 0-255. The lut generator doesn't at all mind generating a lut with points like this, but they make the transfer function editor look sloppy:

| Before remap | After remap (👎) |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/4820a310-6d5a-44b3-b506-4742d8794cd0) | ![image](https://github.com/user-attachments/assets/9df050aa-3226-4593-b398-b75bc63ff88c) |

I added some code to the remapping function that gets a bit smarter about handling these edge points, while still prioritizing preserving information over keeping points within range:

| Before remap | After remap (👍) |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/30e98ba1-b2c9-4046-965f-564ee7c3b849) | ![image](https://github.com/user-attachments/assets/8ab98265-83eb-4562-a0fb-6db59521c346) |

## Change 1.5: don't generate a lut until necessary

I reverted most of this change in favor of just exporting the `remapControlPoints` function that I need, but some of its fingerprints are still on this PR.

Originally, I made changes to `Lut` that allowed its `lut` field to be `null` on construction so that it only needed to fill it in when necessary. This was to allow `Lut` to be used as a simple control point container without incurring the overhead of filling in a `Uint8Array`. This was motivated by the fact that I was having to create and use a `Lut` to manually remap control points in allen-cell-animated/website-3d-cell-viewer#294, but again the simpler solution here is to just export the underlying function.

Again, most of this change is gone now, but the commits are still there and waiting to be re-added if it sounds useful for other reasons.