### PR TITLE
add scale level bias method to `View3d`

### DIFF
--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -242,6 +242,10 @@ export class View3d {
     this.updateTimestepIndicator(volume);
   }
 
+  /**
+   * Nudge the scale level loaded into this volume off the one chosen by the loader.
+   * E.g. a bias of `1` will load 1 scale level lower than "ideal."
+   */
   setScaleLevelBias(volume: Volume, scaleLevelBias: number): void {
     volume.updateRequiredData({ scaleLevelBias });
   }

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -242,6 +242,10 @@ export class View3d {
     this.updateTimestepIndicator(volume);
   }
 
+  setScaleLevelBias(volume: Volume, scaleLevelBias: number): void {
+    volume.updateRequiredData({ scaleLevelBias });
+  }
+
   /**
    * Assign a channel index as a mask channel (will multiply its color against the entire visible volume)
    * @param {Object} volume


### PR DESCRIPTION
Est. review time: tiny (<5min)

Adds the method `setScaleLevelBias` to `View3d`, allowing us to manually nudge the scale level loaded into a volume. This is useful for taking more control of the viewer's scale level selection process from website-3d-cell-viewer, particularly for picking a lower scale level during playback.