### PR TITLE
feature: Camera transform getters + setters

### DIFF
--- a/public/types.ts
+++ b/public/types.ts
@@ -1,3 +1,4 @@
+import { Euler, Vector3 } from "three";
 import { Volume, Light } from "../src";
 import { VolumeFileFormat } from "../src/loaders";
 import { IVolumeLoader } from "../src/loaders/IVolumeLoader";
@@ -98,4 +99,11 @@ interface ChannelGuiOptions {
   colorizeEnabled: boolean;
   colorize: (channelNum: number) => void;
   colorizeAlpha: number;
+}
+
+export interface CameraTransform {
+  position: Vector3;
+  rotation: Euler;
+  up: Vector3;
+  target: Vector3;
 }

--- a/public/types.ts
+++ b/public/types.ts
@@ -1,4 +1,3 @@
-import { Euler, Vector3 } from "three";
 import { Volume, Light } from "../src";
 import { VolumeFileFormat } from "../src/loaders";
 import { IVolumeLoader } from "../src/loaders/IVolumeLoader";
@@ -99,11 +98,4 @@ interface ChannelGuiOptions {
   colorizeEnabled: boolean;
   colorize: (channelNum: number) => void;
   colorizeAlpha: number;
-}
-
-export interface CameraTransform {
-  position: Vector3;
-  rotation: Euler;
-  up: Vector3;
-  target: Vector3;
 }

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -28,12 +28,12 @@ const DEFAULT_PERSPECTIVE_CAMERA_FAR = 20.0;
 
 const DEFAULT_ORTHO_SCALE = 0.5;
 
-export interface CameraTransform {
+export type CameraTransform = {
   position: [number, number, number];
   rotation: [number, number, number];
   up: [number, number, number];
   target: [number, number, number];
-}
+};
 
 export class ThreeJsPanel {
   public containerdiv: HTMLDivElement;
@@ -624,7 +624,7 @@ export class ThreeJsPanel {
 
   setCameraTransform(transform: Partial<CameraTransform>) {
     const currentTransform = this.getCameraTransform();
-    // Fill in any missing properties with current
+    // Fill in any missing properties with current transform
     const newTransform = { ...currentTransform, ...transform };
 
     this.camera.up = new Vector3().fromArray(newTransform.up).normalize();

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -33,6 +33,7 @@ export type CameraTransform = {
   rotation: [number, number, number];
   up: [number, number, number];
   target: [number, number, number];
+  orthoScales: [number, number, number];
 };
 
 export class ThreeJsPanel {
@@ -619,6 +620,7 @@ export class ThreeJsPanel {
       rotation: this.camera.rotation.toArray() as [number, number, number],
       up: this.camera.up.toArray(),
       target: this.controls.target.toArray(),
+      orthoScales: [this.orthoControlsX.scale, this.orthoControlsY.scale, this.orthoControlsZ.scale],
     };
   }
 
@@ -631,6 +633,14 @@ export class ThreeJsPanel {
     this.camera.position.set(...newTransform.position);
     this.camera.setRotationFromEuler(new Euler().fromArray(newTransform.rotation));
     this.controls.target = new Vector3().fromArray(newTransform.target);
+    // Update orthographic cameras
+    const orthoControls = [this.orthoControlsX, this.orthoControlsY, this.orthoControlsZ];
+    const orthoCameras = [this.orthographicCameraX, this.orthographicCameraY, this.orthographicCameraZ];
+    for (let i = 0; i < orthoControls.length; i++) {
+      const scale = newTransform.orthoScales[i];
+      orthoControls[i].scale = scale;
+      orthoCameras[i].zoom = 0.5 / scale;
+    }
   }
 
   render(): void {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -21,6 +21,7 @@ import Timing from "./Timing.js";
 import scaleBarSVG from "./constants/scaleBarSVG.js";
 import { isOrthographicCamera, ViewportCorner, isTop, isRight } from "./types.js";
 import { formatNumber } from "./utils/num_utils.js";
+import { CameraTransform } from "../public/types.js";
 
 const DEFAULT_PERSPECTIVE_CAMERA_DISTANCE = 5.0;
 const DEFAULT_PERSPECTIVE_CAMERA_NEAR = 0.001;
@@ -606,15 +607,16 @@ export class ThreeJsPanel {
     return this.renderer.getContext().canvas.height;
   }
 
-  getCameraTransform(): { position: Vector3; rotation: Euler; up: Vector3 } {
+  getCameraTransform(): CameraTransform {
     return {
       position: this.camera.position.clone(),
       rotation: this.camera.rotation.clone(),
       up: this.camera.up.clone(),
+      target: this.controls.target.clone(),
     };
   }
 
-  setCameraTransform(transform: Partial<{ position: Vector3; rotation: Euler; up: Vector3 }>) {
+  setCameraTransform(transform: Partial<CameraTransform>) {
     const currentTransform = this.getCameraTransform();
     // Fill in any missing properties with current
     const newTransform = { ...currentTransform, ...transform };
@@ -622,6 +624,7 @@ export class ThreeJsPanel {
     const newPos = newTransform.position;
     this.camera.position.set(newPos.x, newPos.y, newPos.z);
     this.camera.setRotationFromEuler(newTransform.rotation);
+    this.controls.target = newTransform.target;
   }
 
   render(): void {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -21,13 +21,19 @@ import Timing from "./Timing.js";
 import scaleBarSVG from "./constants/scaleBarSVG.js";
 import { isOrthographicCamera, ViewportCorner, isTop, isRight } from "./types.js";
 import { formatNumber } from "./utils/num_utils.js";
-import { CameraTransform } from "../public/types.js";
 
 const DEFAULT_PERSPECTIVE_CAMERA_DISTANCE = 5.0;
 const DEFAULT_PERSPECTIVE_CAMERA_NEAR = 0.001;
 const DEFAULT_PERSPECTIVE_CAMERA_FAR = 20.0;
 
 const DEFAULT_ORTHO_SCALE = 0.5;
+
+export type CameraTransform = {
+  position: Vector3;
+  rotation: Euler;
+  up: Vector3;
+  target: Vector3;
+};
 
 export class ThreeJsPanel {
   public containerdiv: HTMLDivElement;

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -640,6 +640,7 @@ export class ThreeJsPanel {
       const scale = newTransform.orthoScales[i];
       orthoControls[i].scale = scale;
       orthoCameras[i].zoom = 0.5 / scale;
+      orthoCameras[i].updateProjectionMatrix();
     }
   }
 

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -28,12 +28,12 @@ const DEFAULT_PERSPECTIVE_CAMERA_FAR = 20.0;
 
 const DEFAULT_ORTHO_SCALE = 0.5;
 
-export type CameraTransform = {
+export interface CameraTransform {
   position: [number, number, number];
   rotation: [number, number, number];
   up: [number, number, number];
   target: [number, number, number];
-};
+}
 
 export class ThreeJsPanel {
   public containerdiv: HTMLDivElement;

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -629,10 +629,10 @@ export class ThreeJsPanel {
     // Fill in any missing properties with current transform
     const newTransform = { ...currentTransform, ...transform };
 
-    this.camera.up = new Vector3().fromArray(newTransform.up).normalize();
-    this.camera.position.set(...newTransform.position);
+    this.camera.up.fromArray(newTransform.up).normalize();
+    this.camera.position.fromArray(newTransform.position);
+    this.controls.target.fromArray(newTransform.target);
     this.camera.setRotationFromEuler(new Euler().fromArray(newTransform.rotation));
-    this.controls.target = new Vector3().fromArray(newTransform.target);
     // Update orthographic cameras
     const orthoControls = [this.orthoControlsX, this.orthoControlsY, this.orthoControlsZ];
     const orthoCameras = [this.orthographicCameraX, this.orthographicCameraY, this.orthographicCameraZ];

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -627,7 +627,7 @@ export class ThreeJsPanel {
       position: this.camera.position.toArray(),
       up: this.camera.up.toArray(),
       target: this.controls.target.toArray(),
-      orthoScale: this.camera.type === "OrthographicCamera" ? this.controls.scale : undefined,
+      orthoScale: isOrthographicCamera(this.camera) ? this.controls.scale : undefined,
       fov: this.camera.type === "PerspectiveCamera" ? this.camera.fov : undefined,
     };
   }

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -19,7 +19,8 @@ import TrackballControls from "./TrackballControls.js";
 import Timing from "./Timing.js";
 import scaleBarSVG from "./constants/scaleBarSVG.js";
 import { isOrthographicCamera, ViewportCorner, isTop, isRight } from "./types.js";
-import { formatNumber } from "./utils/num_utils.js";
+import { constrainToAxis, formatNumber } from "./utils/num_utils.js";
+import { Axis } from "./VolumeRenderSettings.js";
 
 const DEFAULT_PERSPECTIVE_CAMERA_DISTANCE = 5.0;
 const DEFAULT_PERSPECTIVE_CAMERA_NEAR = 0.001;
@@ -58,6 +59,7 @@ export class ThreeJsPanel {
   private orthographicCameraZ: OrthographicCamera;
   private orthoControlsZ: TrackballControls;
   public camera: PerspectiveCamera | OrthographicCamera;
+  private viewMode: Axis;
   public controls: TrackballControls;
   private controlEndHandler?: EventListener<Event, "end", TrackballControls>;
   private controlChangeHandler?: EventListener<Event, "change", TrackballControls>;
@@ -208,6 +210,7 @@ export class ThreeJsPanel {
 
     this.camera = this.perspectiveCamera;
     this.controls = this.perspectiveControls;
+    this.viewMode = Axis.NONE;
 
     this.axisCamera = new OrthographicCamera();
     this.axisHelperScene = new Scene();
@@ -534,23 +537,27 @@ export class ThreeJsPanel {
         this.replaceCamera(this.orthographicCameraX);
         this.replaceControls(this.orthoControlsX);
         this.axisHelperObject.rotation.set(0, Math.PI * 0.5, 0);
+        this.viewMode = Axis.X;
         break;
       case "XZ":
       case "Y":
         this.replaceCamera(this.orthographicCameraY);
         this.replaceControls(this.orthoControlsY);
         this.axisHelperObject.rotation.set(Math.PI * 0.5, 0, 0);
+        this.viewMode = Axis.Y;
         break;
       case "XY":
       case "Z":
         this.replaceCamera(this.orthographicCameraZ);
         this.replaceControls(this.orthoControlsZ);
         this.axisHelperObject.rotation.set(0, 0, 0);
+        this.viewMode = Axis.Z;
         break;
       default:
         this.replaceCamera(this.perspectiveCamera);
         this.replaceControls(this.perspectiveControls);
         this.axisHelperObject.rotation.setFromRotationMatrix(this.camera.matrixWorldInverse);
+        this.viewMode = Axis.NONE;
         break;
     }
     this.updateScaleBarVisibility();
@@ -625,17 +632,27 @@ export class ThreeJsPanel {
     };
   }
 
+  /**
+   * Updates the camera's state, including the position, up vector, target position,
+   * scaling, and FOV. If values are missing from `state`, they will be left unchanged.
+   *
+   * @param state Partial `CameraState` object.
+   *
+   * If an OrthographicCamera is used, the camera's position will be constrained to match
+   * the `target` position along the current view mode.
+   */
   setCameraState(state: Partial<CameraState>) {
     const currentState = this.getCameraState();
     // Fill in any missing properties with current state
     const newState = { ...currentState, ...state };
 
     this.camera.up.fromArray(newState.up).normalize();
-    this.camera.position.fromArray(newState.position);
     this.controls.target.fromArray(newState.target);
+    const constrainedPosition = constrainToAxis(newState.position, newState.target, this.viewMode);
+    this.camera.position.fromArray(constrainedPosition);
 
     // Update fields by camera type
-    if (this.camera.type === "OrthographicCamera") {
+    if (isOrthographicCamera(this.camera)) {
       const scale = newState.orthoScale || DEFAULT_ORTHO_SCALE;
       this.controls.scale = scale;
       this.camera.zoom = 0.5 / scale;

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -659,6 +659,9 @@ export class ThreeJsPanel {
     } else {
       this.camera.fov = newState.fov || this.fov;
     }
+
+    this.controls.update();
+    this.camera.updateProjectionMatrix();
   }
 
   render(): void {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -13,7 +13,6 @@ import {
   NormalBlending,
   WebGLRenderer,
   Scene,
-  Euler,
 } from "three";
 
 import TrackballControls from "./TrackballControls.js";

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -13,6 +13,7 @@ import {
   NormalBlending,
   WebGLRenderer,
   Scene,
+  Euler,
 } from "three";
 
 import TrackballControls from "./TrackballControls.js";
@@ -603,6 +604,24 @@ export class ThreeJsPanel {
 
   getHeight(): number {
     return this.renderer.getContext().canvas.height;
+  }
+
+  getCameraTransform(): { position: Vector3; rotation: Euler; up: Vector3 } {
+    return {
+      position: this.camera.position.clone(),
+      rotation: this.camera.rotation.clone(),
+      up: this.camera.up.clone(),
+    };
+  }
+
+  setCameraTransform(transform: Partial<{ position: Vector3; rotation: Euler; up: Vector3 }>) {
+    const currentTransform = this.getCameraTransform();
+    // Fill in any missing properties with current
+    const newTransform = { ...currentTransform, ...transform };
+    this.camera.up = newTransform.up.normalize();
+    const newPos = newTransform.position;
+    this.camera.position.set(newPos.x, newPos.y, newPos.z);
+    this.camera.setRotationFromEuler(newTransform.rotation);
   }
 
   render(): void {

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -28,13 +28,13 @@ const DEFAULT_PERSPECTIVE_CAMERA_FAR = 20.0;
 
 const DEFAULT_ORTHO_SCALE = 0.5;
 
-export type CameraTransform = {
+export type CameraState = {
   position: [number, number, number];
   up: [number, number, number];
   target: [number, number, number];
-  /** Full vertical FOV in degrees, from bottom to top of the view frustum. */
+  /** Full vertical FOV in degrees, from bottom to top of the view frustum. Defined only for perspective cameras. */
   fov?: number;
-  /** The orthographic scale value used on the camera */
+  /** The scale value for the orthographic camera controls; undefined for perspective cameras. */
   orthoScale?: number;
 };
 
@@ -616,7 +616,7 @@ export class ThreeJsPanel {
     return this.renderer.getContext().canvas.height;
   }
 
-  getCameraTransform(): CameraTransform {
+  getCameraState(): CameraState {
     return {
       position: this.camera.position.toArray(),
       up: this.camera.up.toArray(),
@@ -626,8 +626,8 @@ export class ThreeJsPanel {
     };
   }
 
-  setCameraTransform(transform: Partial<CameraTransform>) {
-    const currentTransform = this.getCameraTransform();
+  setCameraState(transform: Partial<CameraState>) {
+    const currentTransform = this.getCameraState();
     // Fill in any missing properties with current transform
     const newTransform = { ...currentTransform, ...transform };
 

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -626,22 +626,22 @@ export class ThreeJsPanel {
     };
   }
 
-  setCameraState(transform: Partial<CameraState>) {
-    const currentTransform = this.getCameraState();
-    // Fill in any missing properties with current transform
-    const newTransform = { ...currentTransform, ...transform };
+  setCameraState(state: Partial<CameraState>) {
+    const currentState = this.getCameraState();
+    // Fill in any missing properties with current state
+    const newState = { ...currentState, ...state };
 
-    this.camera.up.fromArray(newTransform.up).normalize();
-    this.camera.position.fromArray(newTransform.position);
-    this.controls.target.fromArray(newTransform.target);
+    this.camera.up.fromArray(newState.up).normalize();
+    this.camera.position.fromArray(newState.position);
+    this.controls.target.fromArray(newState.target);
 
-    // Update orthographic cameras
+    // Update fields by camera type
     if (this.camera.type === "OrthographicCamera") {
-      const scale = newTransform.orthoScale || DEFAULT_ORTHO_SCALE;
+      const scale = newState.orthoScale || DEFAULT_ORTHO_SCALE;
       this.controls.scale = scale;
       this.camera.zoom = 0.5 / scale;
     } else {
-      this.camera.fov;
+      this.camera.fov = newState.fov || this.fov;
     }
   }
 

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -29,10 +29,10 @@ const DEFAULT_PERSPECTIVE_CAMERA_FAR = 20.0;
 const DEFAULT_ORTHO_SCALE = 0.5;
 
 export type CameraTransform = {
-  position: Vector3;
-  rotation: Euler;
-  up: Vector3;
-  target: Vector3;
+  position: [number, number, number];
+  rotation: [number, number, number];
+  up: [number, number, number];
+  target: [number, number, number];
 };
 
 export class ThreeJsPanel {
@@ -615,10 +615,10 @@ export class ThreeJsPanel {
 
   getCameraTransform(): CameraTransform {
     return {
-      position: this.camera.position.clone(),
-      rotation: this.camera.rotation.clone(),
-      up: this.camera.up.clone(),
-      target: this.controls.target.clone(),
+      position: this.camera.position.toArray(),
+      rotation: this.camera.rotation.toArray() as [number, number, number],
+      up: this.camera.up.toArray(),
+      target: this.controls.target.toArray(),
     };
   }
 
@@ -626,11 +626,11 @@ export class ThreeJsPanel {
     const currentTransform = this.getCameraTransform();
     // Fill in any missing properties with current
     const newTransform = { ...currentTransform, ...transform };
-    this.camera.up = newTransform.up.normalize();
-    const newPos = newTransform.position;
-    this.camera.position.set(newPos.x, newPos.y, newPos.z);
-    this.camera.setRotationFromEuler(newTransform.rotation);
-    this.controls.target = newTransform.target;
+
+    this.camera.up = new Vector3().fromArray(newTransform.up).normalize();
+    this.camera.position.set(...newTransform.position);
+    this.camera.setRotationFromEuler(new Euler().fromArray(newTransform.rotation));
+    this.controls.target = new Vector3().fromArray(newTransform.target);
   }
 
   render(): void {

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -11,7 +11,7 @@ import {
 } from "three";
 import { Pane } from "tweakpane";
 
-import { CameraTransform, ThreeJsPanel } from "./ThreeJsPanel.js";
+import { CameraState, ThreeJsPanel } from "./ThreeJsPanel.js";
 import lightSettings from "./constants/lights.js";
 import VolumeDrawable from "./VolumeDrawable.js";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
@@ -133,12 +133,12 @@ export class View3d {
     return this.canvas3d.containerdiv;
   }
 
-  getCameraTransform(): CameraTransform {
-    return this.canvas3d.getCameraTransform();
+  getCameraState(): CameraState {
+    return this.canvas3d.getCameraState();
   }
 
-  setCameraTransform(transform: Partial<CameraTransform>) {
-    this.canvas3d.setCameraTransform(transform);
+  setCameraState(transform: Partial<CameraState>) {
+    this.canvas3d.setCameraState(transform);
     this.redraw();
   }
 

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -133,6 +133,15 @@ export class View3d {
     return this.canvas3d.containerdiv;
   }
 
+  getCameraTransform(): { position: Vector3; rotation: Euler; up: Vector3 } {
+    return this.canvas3d.getCameraTransform();
+  }
+
+  setCameraTransform(transform: Partial<{ position: Vector3; rotation: Euler; up: Vector3 }>) {
+    this.canvas3d.setCameraTransform(transform);
+    this.redraw();
+  }
+
   /**
    * Force a redraw.
    */

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -11,7 +11,7 @@ import {
 } from "three";
 import { Pane } from "tweakpane";
 
-import { ThreeJsPanel } from "./ThreeJsPanel.js";
+import { CameraTransform, ThreeJsPanel } from "./ThreeJsPanel.js";
 import lightSettings from "./constants/lights.js";
 import VolumeDrawable from "./VolumeDrawable.js";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
@@ -25,7 +25,6 @@ import {
 } from "./types.js";
 import { Axis } from "./VolumeRenderSettings.js";
 import { PerChannelCallback } from "./loaders/IVolumeLoader.js";
-import { CameraTransform } from "../public/types.js";
 
 // Constants are kept for compatibility reasons.
 export const RENDERMODE_RAYMARCH = RenderMode.RAYMARCH;

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -25,6 +25,7 @@ import {
 } from "./types.js";
 import { Axis } from "./VolumeRenderSettings.js";
 import { PerChannelCallback } from "./loaders/IVolumeLoader.js";
+import { CameraTransform } from "../public/types.js";
 
 // Constants are kept for compatibility reasons.
 export const RENDERMODE_RAYMARCH = RenderMode.RAYMARCH;
@@ -133,11 +134,11 @@ export class View3d {
     return this.canvas3d.containerdiv;
   }
 
-  getCameraTransform(): { position: Vector3; rotation: Euler; up: Vector3 } {
+  getCameraTransform(): CameraTransform {
     return this.canvas3d.getCameraTransform();
   }
 
-  setCameraTransform(transform: Partial<{ position: Vector3; rotation: Euler; up: Vector3 }>) {
+  setCameraTransform(transform: Partial<CameraTransform>) {
     this.canvas3d.setCameraTransform(transform);
     this.redraw();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
 import { TiffLoader } from "./loaders/TiffLoader.js";
 import VolumeLoaderContext from "./workers/VolumeLoaderContext.js";
 import { VolumeLoadError, VolumeLoadErrorType } from "./loaders/VolumeLoadError.js";
-
+import { CameraTransform } from "./ThreeJsPanel.js";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
 
 export type { ImageInfo } from "./Volume.js";
@@ -60,4 +60,5 @@ export {
   RENDERMODE_PATHTRACE,
   RENDERMODE_RAYMARCH,
   SKY_LIGHT,
+  type CameraTransform,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
 import { TiffLoader } from "./loaders/TiffLoader.js";
 import VolumeLoaderContext from "./workers/VolumeLoaderContext.js";
 import { VolumeLoadError, VolumeLoadErrorType } from "./loaders/VolumeLoadError.js";
-import { CameraTransform } from "./ThreeJsPanel.js";
+import { type CameraTransform } from "./ThreeJsPanel.js";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
 
 export type { ImageInfo } from "./Volume.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
 import { TiffLoader } from "./loaders/TiffLoader.js";
 import VolumeLoaderContext from "./workers/VolumeLoaderContext.js";
 import { VolumeLoadError, VolumeLoadErrorType } from "./loaders/VolumeLoadError.js";
-import { type CameraTransform } from "./ThreeJsPanel.js";
+import { type CameraState } from "./ThreeJsPanel.js";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
 
 export type { ImageInfo } from "./Volume.js";
@@ -60,5 +60,5 @@ export {
   RENDERMODE_PATHTRACE,
   RENDERMODE_RAYMARCH,
   SKY_LIGHT,
-  type CameraTransform,
+  type CameraState as CameraTransform,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,5 +60,5 @@ export {
   RENDERMODE_PATHTRACE,
   RENDERMODE_RAYMARCH,
   SKY_LIGHT,
-  type CameraState as CameraTransform,
+  type CameraState,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,5 +60,5 @@ export {
   RENDERMODE_PATHTRACE,
   RENDERMODE_RAYMARCH,
   SKY_LIGHT,
-  CameraTransform,
+  type CameraTransform,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,5 +60,5 @@ export {
   RENDERMODE_PATHTRACE,
   RENDERMODE_RAYMARCH,
   SKY_LIGHT,
-  type CameraTransform,
+  CameraTransform,
 };

--- a/src/test/num_utils.test.ts
+++ b/src/test/num_utils.test.ts
@@ -1,6 +1,8 @@
 import { expect } from "chai";
+import { it } from "mocha";
 
-import { formatNumber } from "../utils/num_utils";
+import { constrainToAxis, formatNumber } from "../utils/num_utils.js";
+import { Axis } from "../VolumeRenderSettings.js";
 
 describe("num_utils", () => {
   describe("formatNumber", () => {
@@ -63,6 +65,24 @@ describe("num_utils", () => {
       expect(formatNumber(12345, 5)).to.equal("1.23×10⁴");
       expect(formatNumber(12345, 6)).to.equal("1.235×10⁴");
       expect(formatNumber(12345, 8)).to.equal("1.23450×10⁴");
+    });
+  });
+
+  describe("constrainToAxis", () => {
+    type Number3 = [number, number, number];
+
+    it("constrains to the X, Y, Z axis", () => {
+      const src: Number3 = [1, 2, 3];
+      const target: Number3 = [4, 5, 6];
+      expect(constrainToAxis(src, target, Axis.X)).to.eql([1, 5, 6]);
+      expect(constrainToAxis(src, target, Axis.Y)).to.eql([4, 2, 6]);
+      expect(constrainToAxis(src, target, Axis.Z)).to.eql([4, 5, 3]);
+    });
+
+    it("does nothing if Axis.None is specified", () => {
+      const src: Number3 = [1, 2, 3];
+      const target: Number3 = [4, 5, 6];
+      expect(constrainToAxis(src, target, Axis.NONE)).to.eql([1, 2, 3]);
     });
   });
 });

--- a/src/utils/num_utils.ts
+++ b/src/utils/num_utils.ts
@@ -1,3 +1,5 @@
+import { Axis } from "../VolumeRenderSettings.js";
+
 export const DEFAULT_SIG_FIGS = 5;
 
 // Adapted from https://gist.github.com/ArneS/2ecfbe4a9d7072ac56c0.
@@ -76,5 +78,34 @@ export function formatNumber(value: number, sigFigs = DEFAULT_SIG_FIGS, sciSigFi
     }
     const trimmed = trimTrailing(numStr, "0");
     return trimmed.endsWith(".") ? trimmed.slice(0, -1) : trimmed;
+  }
+}
+
+/**
+ * Constrains the `src` vector relative to the `target` so it only has freedom along the
+ * specified `axis`. Does nothing if `axis = Axis.NONE`.
+ *
+ * @example
+ * ```
+ *   const src = [1, 2, 3];
+ *   const target = [4, 5, 6];
+ *   const constrained = constrainToAxis(src, target, Axis.X);
+ *   console.log(constrained); // [1, 5, 6]
+ * ```
+ */
+export function constrainToAxis(
+  src: [number, number, number],
+  target: [number, number, number],
+  axis: Axis
+): [number, number, number] {
+  switch (axis) {
+    case Axis.X:
+      return [src[0], target[1], target[2]];
+    case Axis.Y:
+      return [target[0], src[1], target[2]];
+    case Axis.Z:
+      return [target[0], target[1], src[2]];
+    default:
+      return [...src];
   }
 }


### PR DESCRIPTION
Adds methods for getting and setting the camera transform on the View3D; this helps with the implementation of https://github.com/allen-cell-animated/website-3d-cell-viewer/issues/283, saving/loading camera position from the URL.

*Estimated review size: small, 5-10 minutes*

## Changes
- Added a new exported type, `CameraTransform`, which contains the position, rotation, up vector, and target position of the camera + camera controller.
- Adds getters and setters for the camera transform from the `ThreeJsPanel`, which are exposed via the `View3d`.
  - Note that all data is passed via arrays, so clients of `View3d` don't have to import ThreeJs directly.
 