### PR TITLE
feature: Format timestamp

### DIFF
--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -353,7 +353,7 @@ export class ThreeJsPanel {
     const scaleBarContainerStyle: Partial<CSSStyleDeclaration> = {
       fontFamily: "-apple-system, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif",
       position: "absolute",
-      right: "20px",
+      right: "169px",
       bottom: "20px",
     };
     Object.assign(this.scaleBarContainerElement.style, scaleBarContainerStyle);
@@ -372,6 +372,8 @@ export class ThreeJsPanel {
       lineHeight: "0",
       boxSizing: "border-box",
       paddingRight: "10px",
+      // TODO: Adjust based on width of timestamp
+      marginRight: "40px",
     };
     Object.assign(this.orthoScaleBarElement.style, orthoScaleBarStyle);
     this.scaleBarContainerElement.appendChild(this.orthoScaleBarElement);

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -19,7 +19,7 @@ import TrackballControls from "./TrackballControls.js";
 import Timing from "./Timing.js";
 import scaleBarSVG from "./constants/scaleBarSVG.js";
 import { isOrthographicCamera, ViewportCorner, isTop, isRight } from "./types.js";
-import { formatNumber } from "./utils/num_utils.js";
+import { formatNumber, getTimestamp } from "./utils/num_utils.js";
 
 const DEFAULT_PERSPECTIVE_CAMERA_DISTANCE = 5.0;
 const DEFAULT_PERSPECTIVE_CAMERA_NEAR = 0.001;
@@ -428,7 +428,7 @@ export class ThreeJsPanel {
   }
 
   updateTimestepIndicator(progress: number, total: number, unit: string): void {
-    this.timestepIndicatorElement.innerHTML = `${formatNumber(progress)} / ${formatNumber(total)} ${unit}`;
+    this.timestepIndicatorElement.innerHTML = getTimestamp(progress, total, unit);
   }
 
   setPerspectiveScaleBarColor(color: [number, number, number]): void {

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -39,20 +39,21 @@ export type ImageInfo = Readonly<{
   times: number;
   /** Size of each timestep in temporal units */
   timeScale: number;
-  /** Symbol of temporal unit used by `timeScale`, e.g. "hr"
+  /**
+   * Symbol of temporal unit used by `timeScale`, e.g. "hr".
    *
    * If units match one of the following, the viewer will automatically format
-   * timestamps to a d:hh:mm:ss.sss format, rounding to the nearest integer of the unit specified.
+   * timestamps to a d:hh:mm:ss.sss format, truncated as an integer of the unit specified.
    * See https://ngff.openmicroscopy.org/latest/index.html#axes-md for a list of valid time units.
-   * - "ms", "millisecond" for milliseconds: d:hh:mm:ss.sss
-   * - "s", "sec", "second", or "seconds" for seconds: d:hh:mm:ss
-   * - "m", "min", "minute", or "minutes" for minutes: d:hh:mm
-   * - "h", "hr", "hour", or "hours" for hours: d:hh
-   * - "d", "day", or "days" for days: d
+   * - "ms", "millisecond" for milliseconds: `d:hh:mm:ss.sss`
+   * - "s", "sec", "second", or "seconds" for seconds: `d:hh:mm:ss`
+   * - "m", "min", "minute", or "minutes" for minutes: `d:hh:mm`
+   * - "h", "hr", "hour", or "hours" for hours: `d:hh`
+   * - "d", "day", or "days" for days: `d`
    *
-   * Segments of the timestamp will be omitted if the maximum timestamp value wouldn't include them.
+   * The maximum timestamp value is used to determine the maximum unit shown.
    * For example, if the time unit is in seconds, and the maximum time is 90 seconds, the timestamp
-   * will be formatted as "{m:ss} (m:s)".
+   * will be formatted as "{m:ss} (m:s)", and the day and hour segments will be omitted.
    */
   timeUnit: string;
 

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -39,7 +39,21 @@ export type ImageInfo = Readonly<{
   times: number;
   /** Size of each timestep in temporal units */
   timeScale: number;
-  /** Symbol of temporal unit used by `timeScale`, e.g. "hr" */
+  /** Symbol of temporal unit used by `timeScale`, e.g. "hr"
+   *
+   * If units match one of the following, the viewer will automatically format
+   * timestamps to a d:hh:mm:ss.sss format, rounding to the nearest integer of the unit specified.
+   * See https://ngff.openmicroscopy.org/latest/index.html#axes-md for a list of valid time units.
+   * - "ms", "millisecond" for milliseconds: d:hh:mm:ss.sss
+   * - "s", "sec", "second", or "seconds" for seconds: d:hh:mm:ss
+   * - "m", "min", "minute", or "minutes" for minutes: d:hh:mm
+   * - "h", "hr", "hour", or "hours" for hours: d:hh
+   * - "d", "day", or "days" for days: d
+   *
+   * Segments of the timestamp will be omitted if the maximum timestamp value wouldn't include them.
+   * For example, if the time unit is in seconds, and the maximum time is 90 seconds, the timestamp
+   * will be formatted as "{m:ss} (m:s)".
+   */
   timeUnit: string;
 
   /** Number of scale levels available for this volume */

--- a/src/constants/time.ts
+++ b/src/constants/time.ts
@@ -1,0 +1,23 @@
+export const enum TimeUnit {
+  Millisecond,
+  Second,
+  Minute,
+  Hour,
+  Day,
+}
+
+const recognizedTimeUnits: Record<TimeUnit, Set<string>> = {
+  [TimeUnit.Millisecond]: new Set(["ms", "millisecond", "milliseconds"]),
+  [TimeUnit.Second]: new Set(["s", "sec", "second", "seconds"]),
+  [TimeUnit.Minute]: new Set(["m", "min", "minute", "minutes"]),
+  [TimeUnit.Hour]: new Set(["h", "hr", "hour", "hours"]),
+  [TimeUnit.Day]: new Set(["d", "day", "days"]),
+};
+
+export function parseTimeUnit(unit: string): TimeUnit | undefined {
+  for (const [timeUnit, recognizedUnits] of Object.entries(recognizedTimeUnits)) {
+    if (recognizedUnits.has(unit)) {
+      return timeUnit as unknown as TimeUnit;
+    }
+  }
+}

--- a/src/constants/time.ts
+++ b/src/constants/time.ts
@@ -14,6 +14,17 @@ const recognizedTimeUnits: Record<TimeUnit, Set<string>> = {
   [TimeUnit.DAY]: new Set(["d", "day", "days"]),
 };
 
+/**
+ * Parses an OME-compatible time unit into a TimeUnit enum.
+ * @param unit string unit
+ * @returns
+ * - `TimeUnit.MILLISECOND` if unit is "ms", "millisecond", or "milliseconds"
+ * - `TimeUnit.SECOND` if unit is "s", "sec", "second", or "seconds"
+ * - `TimeUnit.MINUTE` if unit is "m", "min", "minute", or "minutes"
+ * - `TimeUnit.HOUR` if unit is "h", "hr", "hour", or "hours"
+ * - `TimeUnit.DAY` if unit is "d", "day", or "days"
+ * - `undefined` if unit is not recognized
+ */
 export function parseTimeUnit(unit: string): TimeUnit | undefined {
   for (const [timeUnit, recognizedUnits] of Object.entries(recognizedTimeUnits)) {
     if (recognizedUnits.has(unit)) {

--- a/src/constants/time.ts
+++ b/src/constants/time.ts
@@ -1,17 +1,17 @@
 export const enum TimeUnit {
-  Millisecond,
-  Second,
-  Minute,
-  Hour,
-  Day,
+  MILLISECOND,
+  SECOND,
+  MINUTE,
+  HOUR,
+  DAY,
 }
 
 const recognizedTimeUnits: Record<TimeUnit, Set<string>> = {
-  [TimeUnit.Millisecond]: new Set(["ms", "millisecond", "milliseconds"]),
-  [TimeUnit.Second]: new Set(["s", "sec", "second", "seconds"]),
-  [TimeUnit.Minute]: new Set(["m", "min", "minute", "minutes"]),
-  [TimeUnit.Hour]: new Set(["h", "hr", "hour", "hours"]),
-  [TimeUnit.Day]: new Set(["d", "day", "days"]),
+  [TimeUnit.MILLISECOND]: new Set(["ms", "millisecond", "milliseconds"]),
+  [TimeUnit.SECOND]: new Set(["s", "sec", "second", "seconds"]),
+  [TimeUnit.MINUTE]: new Set(["m", "min", "minute", "minutes"]),
+  [TimeUnit.HOUR]: new Set(["h", "hr", "hour", "hours"]),
+  [TimeUnit.DAY]: new Set(["d", "day", "days"]),
 };
 
 export function parseTimeUnit(unit: string): TimeUnit | undefined {

--- a/src/test/num_utils.test.ts
+++ b/src/test/num_utils.test.ts
@@ -93,10 +93,10 @@ describe("num_utils", () => {
     });
 
     it("does not show past three decimals for seconds", () => {
-      expect(getTimestamp(9.9999, 1000, "ms")).to.equal("0.009 / 1.000 s");
+      expect(getTimestamp(9.9, 1000, "ms")).to.equal("0.009 / 1.000 s");
     });
 
-    it("can show only seconds", () => {
+    it("ignores milliseconds when unit is seconds", () => {
       expect(getTimestamp(0, 59, "s")).to.equal("0 / 59 s");
       expect(getTimestamp(0.54, 59, "s")).to.equal("0 / 59 s");
       expect(getTimestamp(12, 59, "s")).to.equal("12 / 59 s");
@@ -138,8 +138,8 @@ describe("num_utils", () => {
       const hoursInMs = 60 * minutesInMs;
       const daysInMs = 24 * hoursInMs;
 
-      let time = 1 * daysInMs + 17 * hoursInMs + 23 * minutesInMs + 45 * secondsInMs + 678;
-      let total = 2 * daysInMs;
+      const time = 1 * daysInMs + 17 * hoursInMs + 23 * minutesInMs + 45 * secondsInMs + 678;
+      const total = 2 * daysInMs;
       expect(getTimestamp(time, total, "ms")).to.equal("1:17:23:45.678 / 2:00:00:00.000 d:h:m:s");
     });
 

--- a/src/test/num_utils.test.ts
+++ b/src/test/num_utils.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
+import { it } from "mocha";
 
-import { formatNumber } from "../utils/num_utils";
+import { formatNumber, getTimestamp } from "../utils/num_utils";
 
 describe("num_utils", () => {
   describe("formatNumber", () => {
@@ -63,6 +64,89 @@ describe("num_utils", () => {
       expect(formatNumber(12345, 5)).to.equal("1.23×10⁴");
       expect(formatNumber(12345, 6)).to.equal("1.235×10⁴");
       expect(formatNumber(12345, 8)).to.equal("1.23450×10⁴");
+    });
+  });
+
+  describe("getTimestamp", () => {
+    it("shows only milliseconds if total time units < 1000 ms", () => {
+      expect(getTimestamp(0, 999, "ms")).to.equal("0 / 999 ms");
+      expect(getTimestamp(41, 999, "ms")).to.equal("41 / 999 ms");
+      expect(getTimestamp(-50, 999, "ms")).to.equal("-50 / 999 ms");
+      expect(getTimestamp(999, 999, "ms")).to.equal("999 / 999 ms");
+    });
+
+    it("ignores decimal places in milliseconds", () => {
+      expect(getTimestamp(0.4, 100, "ms")).to.equal("0 / 100 ms");
+      expect(getTimestamp(9.9, 100, "ms")).to.equal("9 / 100 ms");
+    });
+
+    it("does not convert unrecognized time units", () => {
+      expect(getTimestamp(0, 999, "foo")).to.equal("0 / 999 foo");
+      expect(getTimestamp(41, 999, "bar")).to.equal("41 / 999 bar");
+      expect(getTimestamp(999, 999, "baz")).to.equal("999 / 999 baz");
+    });
+
+    it("shows seconds if total time is > 1000 ms", () => {
+      expect(getTimestamp(0, 1000, "ms")).to.equal("0.000 / 1.000 s");
+      expect(getTimestamp(999, 1000, "ms")).to.equal("0.999 / 1.000 s");
+      expect(getTimestamp(1, 4500, "ms")).to.equal("0.001 / 4.500 s");
+    });
+
+    it("does not show past three decimals for seconds", () => {
+      expect(getTimestamp(9.9999, 1000, "ms")).to.equal("0.009 / 1.000 s");
+    });
+
+    it("can show only seconds", () => {
+      expect(getTimestamp(0, 59, "s")).to.equal("0 / 59 s");
+      expect(getTimestamp(0.54, 59, "s")).to.equal("0 / 59 s");
+      expect(getTimestamp(12, 59, "s")).to.equal("12 / 59 s");
+    });
+
+    it("converts from seconds to minutes", () => {
+      expect(getTimestamp(0, 60, "s")).to.equal("0:00 / 1:00 m:s");
+    });
+
+    it("converts from seconds to other units", () => {
+      const minutesInSec = 60;
+      const hoursInSec = 60 * minutesInSec;
+      const daysInSec = 24 * hoursInSec;
+
+      let time = 1 * hoursInSec + 23 * minutesInSec + 45;
+      let total = 2 * hoursInSec + 30 * minutesInSec + 0;
+      expect(getTimestamp(time, total, "s")).to.equal("1:23:45 / 2:30:00 h:m:s");
+
+      time = 15 * hoursInSec + 0 * minutesInSec + 1;
+      total = 17 * hoursInSec + 0 * minutesInSec + 0;
+      expect(getTimestamp(time, total, "s")).to.equal("15:00:01 / 17:00:00 h:m:s");
+
+      time = 0;
+      total = 23 * hoursInSec + 59 * minutesInSec + 59;
+      expect(getTimestamp(time, total, "s")).to.equal("0:00:00 / 23:59:59 h:m:s");
+
+      time = 1 * daysInSec + 0 * hoursInSec + 0 * minutesInSec + 0;
+      total = 2 * daysInSec + 0 * hoursInSec + 0 * minutesInSec + 0;
+      expect(getTimestamp(time, total, "s")).to.equal("1:00:00:00 / 2:00:00:00 d:h:m:s");
+
+      time = 1 * daysInSec + 23 * hoursInSec + 59 * minutesInSec + 59;
+      total = 2 * daysInSec + 0 * hoursInSec + 0 * minutesInSec + 0;
+      expect(getTimestamp(time, total, "s")).to.equal("1:23:59:59 / 2:00:00:00 d:h:m:s");
+    });
+
+    it("can show full d:hh:mm:ss.sss timestamps", () => {
+      const secondsInMs = 1000;
+      const minutesInMs = 60 * secondsInMs;
+      const hoursInMs = 60 * minutesInMs;
+      const daysInMs = 24 * hoursInMs;
+
+      let time = 1 * daysInMs + 17 * hoursInMs + 23 * minutesInMs + 45 * secondsInMs + 678;
+      let total = 2 * daysInMs;
+      expect(getTimestamp(time, total, "ms")).to.equal("1:17:23:45.678 / 2:00:00:00.000 d:h:m:s");
+    });
+
+    it("ignores smaller units when time defined in hours", () => {
+      expect(getTimestamp(0, 123 * 24, "h")).to.equal("0:00 / 123:00 d:h");
+      expect(getTimestamp(23, 123 * 24, "h")).to.equal("0:23 / 123:00 d:h");
+      expect(getTimestamp(24 + 5, 123 * 24, "h")).to.equal("1:05 / 123:00 d:h");
     });
   });
 });

--- a/src/utils/num_utils.ts
+++ b/src/utils/num_utils.ts
@@ -1,5 +1,3 @@
-import { use } from "chai";
-
 import { parseTimeUnit, TimeUnit } from "../constants/time.js";
 
 export const DEFAULT_SIG_FIGS = 5;

--- a/src/utils/num_utils.ts
+++ b/src/utils/num_utils.ts
@@ -89,15 +89,15 @@ export function formatNumber(value: number, sigFigs = DEFAULT_SIG_FIGS, sciSigFi
 }
 
 export function timeToMilliseconds(time: number, unit: TimeUnit): number {
-  if (unit == TimeUnit.Millisecond) {
+  if (unit == TimeUnit.MILLISECOND) {
     return time;
-  } else if (unit == TimeUnit.Second) {
+  } else if (unit == TimeUnit.SECOND) {
     return time * SECONDS_IN_MS;
-  } else if (unit == TimeUnit.Minute) {
+  } else if (unit == TimeUnit.MINUTE) {
     return time * MINUTES_IN_MS;
-  } else if (unit == TimeUnit.Hour) {
+  } else if (unit == TimeUnit.HOUR) {
     return time * HOURS_IN_MS;
-  } else if (unit == TimeUnit.Day) {
+  } else if (unit == TimeUnit.DAY) {
     return time * DAYS_IN_MS;
   } else {
     throw new Error("Unrecognized time unit");
@@ -189,11 +189,11 @@ export function getTimestamp(time: number, total: number, unit: string): string 
   // Enable each unit based on the total time.
   // Exploit an enum property where TimeUnit.Milliseconds < TimeUnit.Second < TimeUnit.Minute ... etc.
   const options = {
-    useMs: timeUnit == TimeUnit.Millisecond,
-    useSec: timeUnit == TimeUnit.Second || (timeUnit <= TimeUnit.Second && totalMs >= SECONDS_IN_MS),
-    useMin: timeUnit == TimeUnit.Minute || (timeUnit <= TimeUnit.Minute && totalMs >= MINUTES_IN_MS),
-    useHours: timeUnit == TimeUnit.Hour || (timeUnit <= TimeUnit.Hour && totalMs >= HOURS_IN_MS),
-    useDays: timeUnit == TimeUnit.Day || (timeUnit <= TimeUnit.Day && totalMs >= DAYS_IN_MS),
+    useMs: timeUnit == TimeUnit.MILLISECOND,
+    useSec: timeUnit == TimeUnit.SECOND || (timeUnit <= TimeUnit.SECOND && totalMs >= SECONDS_IN_MS),
+    useMin: timeUnit == TimeUnit.MINUTE || (timeUnit <= TimeUnit.MINUTE && totalMs >= MINUTES_IN_MS),
+    useHours: timeUnit == TimeUnit.HOUR || (timeUnit <= TimeUnit.HOUR && totalMs >= HOURS_IN_MS),
+    useDays: timeUnit == TimeUnit.DAY || (timeUnit <= TimeUnit.DAY && totalMs >= DAYS_IN_MS),
   };
 
   const { timestamp, units } = formatTimestamp(timeMs, options);

--- a/src/utils/num_utils.ts
+++ b/src/utils/num_utils.ts
@@ -102,8 +102,12 @@ export function timeToMilliseconds(time: number, unit: TimeUnit): number {
   }
 }
 
-function padConditionally(value: number, pad: number, shouldPad: boolean): string {
-  return shouldPad ? value.toString().padStart(pad, "0") : value.toString();
+/**
+ * Pads the `value` with zeroes to the specified `length` if `shouldPad` is true
+ * and returns the resulting string. Otherwise, returns the string representation of `value`.
+ */
+function padConditionally(value: number, length: number, shouldPad: boolean): string {
+  return shouldPad ? value.toString().padStart(length, "0") : value.toString();
 }
 
 function formatTimestamp(
@@ -134,12 +138,12 @@ function formatTimestamp(
   }
   if (useMin) {
     const minutes = Math.floor((timeMs % HOURS_IN_MS) / MINUTES_IN_MS);
-    digits.push(useHours ? minutes.toString().padStart(2, "0") : minutes.toString());
+    digits.push(padConditionally(minutes, 2, useHours));
     units.push("m");
   }
   if (useSec) {
     const seconds = Math.floor((timeMs % MINUTES_IN_MS) / SECONDS_IN_MS);
-    let secondString = useMin ? seconds.toString().padStart(2, "0") : seconds.toString();
+    let secondString = padConditionally(seconds, 2, useMin);
     units.push("s");
     // If using milliseconds, add as a decimal to the seconds string.
     if (useMs) {
@@ -173,9 +177,6 @@ function formatTimestamp(
  */
 export function getTimestamp(time: number, total: number, unit: string): string {
   const timeUnit = parseTimeUnit(unit);
-  console.log("time", time);
-  console.log("timeUnit", timeUnit);
-  console.log("unit", unit);
 
   if (timeUnit === undefined) {
     return `${formatNumber(time)} / ${formatNumber(total)} ${unit}`;
@@ -184,7 +185,7 @@ export function getTimestamp(time: number, total: number, unit: string): string 
   const timeMs = timeToMilliseconds(time, timeUnit);
   const totalMs = timeToMilliseconds(total, timeUnit);
 
-  // Enable each unit based on the total time.
+  // Toggle each unit based on the total time and the provided timeUnit.
   // Exploit an enum property where TimeUnit.Milliseconds < TimeUnit.Second < TimeUnit.Minute ... etc.
   const options = {
     useMs: timeUnit == TimeUnit.MILLISECOND,

--- a/src/utils/num_utils.ts
+++ b/src/utils/num_utils.ts
@@ -1,4 +1,13 @@
+import { use } from "chai";
+
+import { parseTimeUnit, TimeUnit } from "../constants/time.js";
+
 export const DEFAULT_SIG_FIGS = 5;
+
+const SECONDS_IN_MILLISECONDS = 1000;
+const MINUTES_IN_MILLISECONDS = 1000 * 60;
+const HOURS_IN_MILLISECONDS = 1000 * 60 * 60;
+const DAYS_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
 
 // Adapted from https://gist.github.com/ArneS/2ecfbe4a9d7072ac56c0.
 function digitToUnicodeSupercript(n: number): string {
@@ -77,4 +86,119 @@ export function formatNumber(value: number, sigFigs = DEFAULT_SIG_FIGS, sciSigFi
     const trimmed = trimTrailing(numStr, "0");
     return trimmed.endsWith(".") ? trimmed.slice(0, -1) : trimmed;
   }
+}
+
+export function timeToMilliseconds(time: number, unit: TimeUnit): number {
+  if (unit == TimeUnit.Millisecond) {
+    return time;
+  } else if (unit == TimeUnit.Second) {
+    return time * SECONDS_IN_MILLISECONDS;
+  } else if (unit == TimeUnit.Minute) {
+    return time * MINUTES_IN_MILLISECONDS;
+  } else if (unit == TimeUnit.Hour) {
+    return time * HOURS_IN_MILLISECONDS;
+  } else if (unit == TimeUnit.Day) {
+    return time * DAYS_IN_MILLISECONDS;
+  } else {
+    throw new Error("Unrecognized time unit");
+  }
+}
+
+function padConditionally(value: number, pad: number, shouldPad: boolean): string {
+  return shouldPad ? value.toString().padStart(pad, "0") : value.toString();
+}
+
+function formatTimestamp(
+  timeMs: number,
+  options: {
+    useMs: boolean;
+    useSec: boolean;
+    useMin: boolean;
+    useHours: boolean;
+    useDays: boolean;
+  }
+): { timestamp: string; units: string } {
+  const { useMs, useSec, useMin, useHours, useDays } = options;
+  const digits: string[] = [];
+  const units: string[] = [];
+
+  if (useDays) {
+    const days = Math.floor(timeMs / DAYS_IN_MILLISECONDS);
+    digits.push(days.toString());
+    units.push("d");
+  }
+  if (useHours) {
+    const hours = Math.floor((timeMs % DAYS_IN_MILLISECONDS) / HOURS_IN_MILLISECONDS);
+    // If the previous unit is included, pad the hours to 2 digits so the
+    // timestamp is consistent.
+    digits.push(padConditionally(hours, 2, useDays));
+    units.push("h");
+  }
+  if (useMin) {
+    const minutes = Math.floor((timeMs % HOURS_IN_MILLISECONDS) / MINUTES_IN_MILLISECONDS);
+    digits.push(useHours ? minutes.toString().padStart(2, "0") : minutes.toString());
+    units.push("m");
+  }
+  if (useSec) {
+    const seconds = Math.floor((timeMs % MINUTES_IN_MILLISECONDS) / SECONDS_IN_MILLISECONDS);
+    let secondString = useMin ? seconds.toString().padStart(2, "0") : seconds.toString();
+    units.push("s");
+    // If using milliseconds, add as a decimal to the seconds string.
+    if (useMs) {
+      const milliseconds = timeMs % SECONDS_IN_MILLISECONDS;
+      secondString += "." + milliseconds.toString().padStart(3, "0");
+      units.push("ms");
+    }
+    digits.push(secondString);
+  }
+  return { timestamp: digits.join(":"), units: units.join(":") };
+}
+
+/**
+ * Gets a timestamp formatted as `{time} / {total} {unit}`. If `unit` is a recognized
+ * time unit, the timestamp will be formatted as a `d:hh:mm:ss.ms` string.
+ *
+ * @param time Current time, in specified units.
+ * @param total Total time, in specified units.
+ * @param unit The unit of time.
+ * @returns A formatted timestamp string.
+ * - If `unit` is not recognized, the timestamp will be formatted as `{time} / {total} {unit}`,
+ * where `time` and `total` are formatted with significant digits as needed.
+ * - If `unit` is recognized, the timestamp will be formatted as `d:hh:mm:ss.ms`, specifying
+ * the most significant unit based on the total time, and the least significant unit with
+ * `unit`. See `parseTimeUnit()` for recognized time units.
+ */
+export function getTimestamp(time: number, total: number, unit: string): string {
+  const timeUnit = parseTimeUnit(unit);
+  console.log("time", time);
+  console.log("timeUnit", timeUnit);
+  console.log("unit", unit);
+
+  if (timeUnit === undefined) {
+    return `${formatNumber(time)} / ${formatNumber(total)} ${unit}`;
+  }
+
+  const timeMs = timeToMilliseconds(time, timeUnit);
+  const totalMs = timeToMilliseconds(total, timeUnit);
+
+  console.log("timeMs", timeMs);
+  console.log("totalMs", totalMs);
+
+  // Enable each unit based on the total time.
+  // Exploit an enum property where TimeUnit.Milliseconds < TimeUnit.Second < TimeUnit.Minute ... etc.
+  const options = {
+    useMs: timeUnit == TimeUnit.Millisecond,
+    useSec: timeUnit == TimeUnit.Second || (timeUnit <= TimeUnit.Second && totalMs >= SECONDS_IN_MILLISECONDS),
+    useMin: timeUnit == TimeUnit.Minute || (timeUnit <= TimeUnit.Minute && totalMs >= MINUTES_IN_MILLISECONDS),
+    useHours: timeUnit == TimeUnit.Hour || (timeUnit <= TimeUnit.Hour && totalMs >= HOURS_IN_MILLISECONDS),
+    useDays: timeUnit == TimeUnit.Day || (timeUnit <= TimeUnit.Day && totalMs >= DAYS_IN_MILLISECONDS),
+  };
+  console.log("options", options);
+  console.log("TimeUnit Ms", TimeUnit.Millisecond);
+  console.log("TimeUnit Min", TimeUnit.Minute);
+
+  const { timestamp, units } = formatTimestamp(timeMs, options);
+  const { timestamp: totalTimestamp } = formatTimestamp(totalMs, options);
+
+  return `${timestamp} / ${totalTimestamp} ${units}`;
 }

--- a/src/utils/num_utils.ts
+++ b/src/utils/num_utils.ts
@@ -3,9 +3,9 @@ import { parseTimeUnit, TimeUnit } from "../constants/time.js";
 export const DEFAULT_SIG_FIGS = 5;
 
 const SECONDS_IN_MS = 1000;
-const MINUTES_IN_MS = 1000 * 60;
-const HOURS_IN_MS = 1000 * 60 * 60;
-const DAYS_IN_MS = 1000 * 60 * 60 * 24;
+const MINUTES_IN_MS = SECONDS_IN_MS * 60;
+const HOURS_IN_MS = MINUTES_IN_MS * 60;
+const DAYS_IN_MS = HOURS_IN_MS * 24;
 
 // Adapted from https://gist.github.com/ArneS/2ecfbe4a9d7072ac56c0.
 function digitToUnicodeSupercript(n: number): string {
@@ -86,20 +86,20 @@ export function formatNumber(value: number, sigFigs = DEFAULT_SIG_FIGS, sciSigFi
   }
 }
 
+const timeUnitEnumToMilliseconds = {
+  [TimeUnit.MILLISECOND]: 1,
+  [TimeUnit.SECOND]: SECONDS_IN_MS,
+  [TimeUnit.MINUTE]: MINUTES_IN_MS,
+  [TimeUnit.HOUR]: HOURS_IN_MS,
+  [TimeUnit.DAY]: DAYS_IN_MS,
+};
+
 export function timeToMilliseconds(time: number, unit: TimeUnit): number {
-  if (unit == TimeUnit.MILLISECOND) {
-    return time;
-  } else if (unit == TimeUnit.SECOND) {
-    return time * SECONDS_IN_MS;
-  } else if (unit == TimeUnit.MINUTE) {
-    return time * MINUTES_IN_MS;
-  } else if (unit == TimeUnit.HOUR) {
-    return time * HOURS_IN_MS;
-  } else if (unit == TimeUnit.DAY) {
-    return time * DAYS_IN_MS;
-  } else {
+  const timeUnitMultiplier = timeUnitEnumToMilliseconds[unit];
+  if (timeUnitMultiplier === undefined) {
     throw new Error("Unrecognized time unit");
   }
+  return time * timeUnitMultiplier;
 }
 
 /**


### PR DESCRIPTION
Will close https://github.com/allen-cell-animated/website-3d-cell-viewer/issues/265 ("time in minutes should automatically change to hours/days") once changes are released and merged.

*Estimated review size: medium, 20 minutes*

## Changes
- Changes the timestamp formatter to recognize days, hours, minutes, seconds, or milliseconds, and to format these units into a `d:hh:mm:ss.sss`-style timestamp.
  - All units smaller than the provided unit are dropped.
  - The total timestamp is used to determine the largest time unit to show.

Changes, as seen in 3DVV: 
![image](https://github.com/user-attachments/assets/65a4827f-68b1-4c14-ab45-1cbe96f4c82c)

