### PR TITLE
safer type check for perspective camera

### DIFF
--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -628,7 +628,7 @@ export class ThreeJsPanel {
       up: this.camera.up.toArray(),
       target: this.controls.target.toArray(),
       orthoScale: isOrthographicCamera(this.camera) ? this.controls.scale : undefined,
-      fov: this.camera.type === "PerspectiveCamera" ? this.camera.fov : undefined,
+      fov: isPerspectiveCamera(this.camera) ? this.camera.fov : undefined,
     };
   }
 

--- a/src/ThreeJsPanel.ts
+++ b/src/ThreeJsPanel.ts
@@ -18,7 +18,7 @@ import {
 import TrackballControls from "./TrackballControls.js";
 import Timing from "./Timing.js";
 import scaleBarSVG from "./constants/scaleBarSVG.js";
-import { isOrthographicCamera, ViewportCorner, isTop, isRight } from "./types.js";
+import { isOrthographicCamera, isPerspectiveCamera, ViewportCorner, isTop, isRight } from "./types.js";
 import { constrainToAxis, formatNumber } from "./utils/num_utils.js";
 import { Axis } from "./VolumeRenderSettings.js";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Camera, OrthographicCamera, Vector3 } from "three";
+import { Camera, OrthographicCamera, PerspectiveCamera, Vector3 } from "three";
 
 export interface Bounds {
   bmin: Vector3;
@@ -88,6 +88,9 @@ export interface VolumeDisplayOptions {
 
 export const isOrthographicCamera = (def: Camera): def is OrthographicCamera =>
   def && (def as OrthographicCamera).isOrthographicCamera;
+
+export const isPerspectiveCamera = (def: Camera): def is PerspectiveCamera =>
+  def && (def as PerspectiveCamera).isPerspectiveCamera;
 
 export const enum ViewportCorner {
   TOP_LEFT = "top_left",


### PR DESCRIPTION
time to review: tiny

This change just adds a more robust type check (for whether the camera is in a perspective projection mode), that is in accordance with threejs documentation.  Alternately we could use `!isOrthographicCamera` but why not be even more specific.