### PR TITLE
Fix/chunks span multiple channels

### DIFF
--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -383,9 +383,9 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     });
 
     // for physicalPixelSize, we use the scale of the first level
-    const scale5d = this.getScale(0);
+    const scale5d: TCZYX<number> = this.getScale(0);
     // assume that ImageInfo wants the timeScale of level 0
-    const timeScale = hasT ? scale5d[t] : 1;
+    const timeScale = hasT ? scale5d[0] : 1;
 
     const imgdata: ImageInfo = {
       name: source0.omeroMetadata?.name || "Volume",
@@ -395,7 +395,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       volumeSize: pxSizeLv,
       subregionSize: pxSizeLv.clone(),
       subregionOffset: new Vector3(0, 0, 0),
-      physicalPixelSize: new Vector3(scale5d[x], scale5d[y], hasZ ? scale5d[z] : Math.min(scale5d[x], scale5d[y])),
+      physicalPixelSize: new Vector3(scale5d[4], scale5d[3], hasZ ? scale5d[2] : Math.min(scale5d[4], scale5d[3])),
       spatialUnit,
 
       numChannels,

--- a/src/loaders/VolumeLoadError.ts
+++ b/src/loaders/VolumeLoadError.ts
@@ -41,6 +41,7 @@ export function wrapVolumeLoadError<T>(
     if (e instanceof VolumeLoadError) {
       throw e;
     }
+    console.log(`Error loading volume data: ${e}`);
     throw new VolumeLoadError(message, { type, cause: e });
   };
 }

--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -106,17 +106,18 @@ describe("SubscribableRequestQueue", () => {
       expect(result2).to.equal("bar");
     });
 
-    it("rejects and reissues a request when one subscriber queues the same key twice", async () => {
+    it("alows a subscriber to queue the same key twice", async () => {
       const queue = new SubscribableRequestQueue();
       const id = queue.addSubscriber();
 
       const promise1 = queue.addRequest("test", id, () => delay(TIMEOUT, "foo"));
       const promise2 = queue.addRequest("test", id, () => delay(TIMEOUT, "bar"));
       expect(queue.hasRequest("test")).to.be.true;
-      expect(await isRejected(promise1)).to.be.true;
-
+      expect(promise1).to.not.equal(promise2);
       const result2 = await promise2;
       expect(result2).to.equal("foo");
+      const result1 = await promise1;
+      expect(result1).to.equal("foo");
     });
 
     it("passes request rejections to all subscribers", async () => {

--- a/src/test/SubscribableRequestQueue.test.ts
+++ b/src/test/SubscribableRequestQueue.test.ts
@@ -106,7 +106,7 @@ describe("SubscribableRequestQueue", () => {
       expect(result2).to.equal("bar");
     });
 
-    it("alows a subscriber to queue the same key twice", async () => {
+    it("allows a subscriber to queue the same key twice", async () => {
       const queue = new SubscribableRequestQueue();
       const id = queue.addSubscriber();
 

--- a/src/utils/SubscribableRequestQueue.ts
+++ b/src/utils/SubscribableRequestQueue.ts
@@ -106,10 +106,6 @@ export default class SubscribableRequestQueue {
     if (!subscriber) {
       throw new Error(`SubscribableRequestQueue: subscriber id ${subscriberId} has been removed`);
     }
-    const existingRequest = subscriber.get(key);
-    if (existingRequest) {
-      this.rejectSubscription(key, existingRequest, "SubscribableRequestQueue: request re-queued while running");
-    }
 
     // Create promise and add to list of requests
     return new Promise<T>((resolve, reject) => {


### PR DESCRIPTION
fixes #246 
The main issue was re-queueing on SubscribableRequestQueue because the viewer wants to organize things by Channel as a high level way of fetching data.  Because of this it is possible to request the same chunk several times at once.

There's also a small bug fix for indexing into the scale values.