### PR TITLE
Feature/redundant imageinfo fields

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -161,7 +161,6 @@ const myState: State = {
   flipZ: 1,
 
   channelFolderNames: [],
-  //infoObj: getDefaultImageInfo(),
   channelGui: [],
 
   currentImageStore: "",
@@ -631,7 +630,6 @@ function showChannelUI(volume: Volume) {
     }
   }
 
-  //myState.infoObj = volume.imageInfo;
   const nChannels = volume.imageInfo.numChannels;
   const channelNames = volume.imageInfo.channelNames;
 

--- a/public/index.ts
+++ b/public/index.ts
@@ -3,7 +3,7 @@ import GUI from "lil-gui";
 
 import {
   CreateLoaderOptions,
-  ImageInfo2,
+  ImageInfo,
   IVolumeLoader,
   LoadSpec,
   Lut,
@@ -865,7 +865,7 @@ function showChannelUI(volume: Volume) {
   }
 }
 
-function loadImageData(jsonData: ImageInfo2, volumeData: Uint8Array[]) {
+function loadImageData(jsonData: ImageInfo, volumeData: Uint8Array[]) {
   const vol = new Volume(jsonData);
   myState.volume = vol;
 

--- a/public/index.ts
+++ b/public/index.ts
@@ -22,7 +22,6 @@ import {
 // special loader really just for this demo app but lives with the other loaders
 import { OpenCellLoader } from "../src/loaders/OpenCellLoader";
 import { State, TestDataSpec } from "./types";
-import { getDefaultImageInfo } from "../src/Volume";
 import VolumeLoaderContext from "../src/workers/VolumeLoaderContext";
 import { DATARANGE_UINT8 } from "../src/types";
 import { RawArrayLoaderOptions } from "../src/loaders/RawArrayLoader";

--- a/public/index.ts
+++ b/public/index.ts
@@ -3,7 +3,7 @@ import GUI from "lil-gui";
 
 import {
   CreateLoaderOptions,
-  ImageInfo,
+  ImageInfo2,
   IVolumeLoader,
   LoadSpec,
   Lut,
@@ -162,7 +162,7 @@ const myState: State = {
   flipZ: 1,
 
   channelFolderNames: [],
-  infoObj: getDefaultImageInfo(),
+  //infoObj: getDefaultImageInfo(),
   channelGui: [],
 
   currentImageStore: "",
@@ -600,7 +600,8 @@ function updateTimeUI() {
 function updateChannelUI(vol: Volume, channelIndex: number) {
   const channel = vol.channels[channelIndex];
 
-  const folder = gui.folders.find((f) => f._title === "Channel " + myState.infoObj.channelNames[channelIndex]);
+  const channelNames = vol.imageInfo.channelNames;
+  const folder = gui.folders.find((f) => f._title === "Channel " + channelNames[channelIndex]);
   if (!folder) {
     return;
   }
@@ -631,12 +632,14 @@ function showChannelUI(volume: Volume) {
     }
   }
 
-  myState.infoObj = volume.imageInfo;
+  //myState.infoObj = volume.imageInfo;
+  const nChannels = volume.imageInfo.numChannels;
+  const channelNames = volume.imageInfo.channelNames;
 
   myState.channelGui = [];
 
   myState.channelFolderNames = [];
-  for (let i = 0; i < myState.infoObj.numChannels; ++i) {
+  for (let i = 0; i < nChannels; ++i) {
     myState.channelGui.push({
       colorD: volume.channelColorsDefault[i],
       colorS: [0, 0, 0],
@@ -709,11 +712,11 @@ function showChannelUI(volume: Volume) {
       })(i),
       colorizeAlpha: 0.0,
     });
-    const f = gui.addFolder("Channel " + myState.infoObj.channelNames[i]);
+    const f = gui.addFolder("Channel " + channelNames[i]);
     if (i > 0) {
       f.close();
     }
-    myState.channelFolderNames.push("Channel " + myState.infoObj.channelNames[i]);
+    myState.channelFolderNames.push("Channel " + channelNames[i]);
     f.add(myState.channelGui[i], "enabled").onChange(
       (function (j) {
         return function (value) {
@@ -863,7 +866,7 @@ function showChannelUI(volume: Volume) {
   }
 }
 
-function loadImageData(jsonData: ImageInfo, volumeData: Uint8Array[]) {
+function loadImageData(jsonData: ImageInfo2, volumeData: Uint8Array[]) {
   const vol = new Volume(jsonData);
   myState.volume = vol;
 

--- a/public/types.ts
+++ b/public/types.ts
@@ -1,7 +1,6 @@
 import { Volume, Light } from "../src";
 import { VolumeFileFormat } from "../src/loaders";
 import { IVolumeLoader } from "../src/loaders/IVolumeLoader";
-import { ImageInfo } from "../src/Volume";
 
 export interface TestDataSpec {
   type: VolumeFileFormat | "opencell" | "procedural";

--- a/public/types.ts
+++ b/public/types.ts
@@ -73,7 +73,7 @@ export interface State {
   flipZ: -1 | 1;
 
   channelFolderNames: string[];
-  infoObj: ImageInfo;
+  //infoObj: ImageInfo;
   channelGui: ChannelGuiOptions[];
 
   currentImageStore: string;

--- a/public/types.ts
+++ b/public/types.ts
@@ -72,7 +72,6 @@ export interface State {
   flipZ: -1 | 1;
 
   channelFolderNames: string[];
-  //infoObj: ImageInfo;
   channelGui: ChannelGuiOptions[];
 
   currentImageStore: string;

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -22,7 +22,10 @@ export type ImageInfo2 = Readonly<{
   /** Symbol of physical spatial unit used by `pixelSize` */
   //spatialUnit: string;
 
-  /** Number of channels in the image, accounting for convergence of multiple sources */
+  /** Number of channels in the image, accounting for convergence of multiple sources.
+   * Because of multiple sources, which is not accounted for in ImageInfo2,
+   * that this could be different than the number of channels in the multiscaleLevelDims.
+   */
   combinedNumChannels: number;
   /** The names of each channel */
   channelNames: string[];
@@ -54,7 +57,6 @@ export type ImageInfo2 = Readonly<{
   /** Number of scale levels available for this volume */
   //numMultiscaleLevels: number;
   /** Dimensions of each scale level, at original size, from the first data source */
-  // TODO THIS DATA IS SOMEWHAT REDUNDANT WITH SOME OF THE OTHER FIELDS IN HERE
   multiscaleLevelDims: VolumeDims2[];
 
   /** The scale level from which this image was loaded, between `0` and `numMultiscaleLevels-1` */

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -1,4 +1,4 @@
-import { type VolumeDims2, volumeSize, physicalPixelSize } from "./VolumeDims.js";
+import { type VolumeDims, volumeSize, physicalPixelSize } from "./VolumeDims.js";
 import { Vector3, Vector2 } from "three";
 
 export type ImageInfo = Readonly<{
@@ -58,7 +58,7 @@ export type ImageInfo = Readonly<{
   /** Number of scale levels available for this volume */
   //numMultiscaleLevels: number;
   /** Dimensions of each scale level, at original size, from the first data source */
-  multiscaleLevelDims: VolumeDims2[];
+  multiscaleLevelDims: VolumeDims[];
 
   /** The scale level from which this image was loaded, between `0` and `numMultiscaleLevels-1` */
   multiscaleLevel: number;
@@ -107,7 +107,7 @@ export class CImageInfo {
     this.imageInfo = imageInfo || defaultImageInfo();
   }
 
-  get currentLevelDims(): VolumeDims2 {
+  get currentLevelDims(): VolumeDims {
     return this.imageInfo.multiscaleLevelDims[this.imageInfo.multiscaleLevel];
   }
 

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -4,23 +4,15 @@ import { Vector3, Vector2 } from "three";
 export type ImageInfo = Readonly<{
   name: string;
 
-  /** XYZ size of the *original* (level 0) volume, in pixels */
-  //originalSize: Vector3;
   /**
    * XY dimensions of the texture atlas used by `RayMarchedAtlasVolume` and `Atlas2DSlice`, in number of z-slice
    * tiles (not pixels). Chosen by the loader to lay out the 3D volume in the squarest possible 2D texture atlas.
    */
   atlasTileDims: [number, number];
-  /** Size of the volume (current level), in pixels */
-  //volumeSize: Vector3;
   /** Size of the currently loaded subregion, in pixels, in XYZ order */
   subregionSize: [number, number, number];
   /** Offset of the loaded subregion into the total volume, in pixels, in XYZ order */
   subregionOffset: [number, number, number];
-  /** Size of a single *original* (not downsampled) pixel, in spatial units */
-  //physicalPixelSize: Vector3;
-  /** Symbol of physical spatial unit used by `pixelSize` */
-  //spatialUnit: string;
 
   /** Number of channels in the image, accounting for convergence of multiple sources.
    * Because of multiple sources, which is not accounted for in ImageInfo,
@@ -33,30 +25,6 @@ export type ImageInfo = Readonly<{
   /** Optional overrides to default channel colors, in 0-255 range, RGB order */
   channelColors?: [number, number, number][];
 
-  /** Number of timesteps in the time series, or 1 if the image is not a time series */
-  //times: number;
-  /** Size of each timestep in temporal units */
-  //timeScale: number;
-  /**
-   * Symbol of temporal unit used by `timeScale`, e.g. "hr".
-   *
-   * If units match one of the following, the viewer will automatically format
-   * timestamps to a d:hh:mm:ss.sss format, truncated as an integer of the unit specified.
-   * See https://ngff.openmicroscopy.org/latest/index.html#axes-md for a list of valid time units.
-   * - "ms", "millisecond" for milliseconds: `d:hh:mm:ss.sss`
-   * - "s", "sec", "second", or "seconds" for seconds: `d:hh:mm:ss`
-   * - "m", "min", "minute", or "minutes" for minutes: `d:hh:mm`
-   * - "h", "hr", "hour", or "hours" for hours: `d:hh`
-   * - "d", "day", or "days" for days: `d`
-   *
-   * The maximum timestamp value is used to determine the maximum unit shown.
-   * For example, if the time unit is in seconds, and the maximum time is 90 seconds, the timestamp
-   * will be formatted as "{m:ss} (m:s)", and the day and hour segments will be omitted.
-   */
-  //timeUnit: string;
-
-  /** Number of scale levels available for this volume */
-  //numMultiscaleLevels: number;
   /** Dimensions of each scale level, at original size, from the first data source */
   multiscaleLevelDims: VolumeDims[];
 
@@ -114,8 +82,6 @@ export class CImageInfo {
   /** Number of channels in the image */
   get numChannels(): number {
     return this.imageInfo.combinedNumChannels;
-    // // 1 is C
-    // return this.currentLevelDims.shape[1];
   }
 
   /** XYZ size of the *original* (not downsampled) volume, in pixels */
@@ -150,22 +116,7 @@ export class CImageInfo {
     return this.currentLevelDims.spacing[0];
   }
 
-  /**
-   * Symbol of temporal unit used by `timeScale`, e.g. "hr".
-   *
-   * If units match one of the following, the viewer will automatically format
-   * timestamps to a d:hh:mm:ss.sss format, truncated as an integer of the unit specified.
-   * See https://ngff.openmicroscopy.org/latest/index.html#axes-md for a list of valid time units.
-   * - "ms", "millisecond" for milliseconds: `d:hh:mm:ss.sss`
-   * - "s", "sec", "second", or "seconds" for seconds: `d:hh:mm:ss`
-   * - "m", "min", "minute", or "minutes" for minutes: `d:hh:mm`
-   * - "h", "hr", "hour", or "hours" for hours: `d:hh`
-   * - "d", "day", or "days" for days: `d`
-   *
-   * The maximum timestamp value is used to determine the maximum unit shown.
-   * For example, if the time unit is in seconds, and the maximum time is 90 seconds, the timestamp
-   * will be formatted as "{m:ss} (m:s)", and the day and hour segments will be omitted.
-   */
+  /** Symbol of physical time unit used by `timeScale` */
   get timeUnit(): string {
     return this.currentLevelDims.timeUnit;
   }

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -1,7 +1,7 @@
 import { type VolumeDims2, volumeSize, physicalPixelSize } from "./VolumeDims.js";
 import { Vector3, Vector2 } from "three";
 
-export type ImageInfo2 = Readonly<{
+export type ImageInfo = Readonly<{
   name: string;
 
   /** XYZ size of the *original* (level 0) volume, in pixels */
@@ -74,7 +74,7 @@ export type ImageInfo2 = Readonly<{
   userData?: Record<string, unknown>;
 }>;
 
-export function defaultImageInfo(): ImageInfo2 {
+export function defaultImageInfo(): ImageInfo {
   return {
     name: "",
     atlasTileDims: [1, 1],
@@ -101,9 +101,9 @@ export function defaultImageInfo(): ImageInfo2 {
 }
 
 export class CImageInfo {
-  imageInfo: ImageInfo2;
+  imageInfo: ImageInfo;
 
-  constructor(imageInfo?: ImageInfo2) {
+  constructor(imageInfo?: ImageInfo) {
     this.imageInfo = imageInfo || defaultImageInfo();
   }
 
@@ -215,7 +215,7 @@ export class CImageInfo {
   }
 }
 
-export function computeAtlasSize(imageInfo: ImageInfo2): [number, number] {
+export function computeAtlasSize(imageInfo: ImageInfo): [number, number] {
   const { atlasTileDims } = imageInfo;
   const volDims = imageInfo.multiscaleLevelDims[imageInfo.multiscaleLevel];
   // TCZYX: 4 = x, 3 = y

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -1,0 +1,104 @@
+import type { VolumeDims } from "./VolumeDims";
+
+export type ImageInfo2 = Readonly<{
+  name: string;
+
+  /** XYZ size of the *original* (level 0) volume, in pixels */
+  //originalSize: Vector3;
+  /**
+   * XY dimensions of the texture atlas used by `RayMarchedAtlasVolume` and `Atlas2DSlice`, in number of z-slice
+   * tiles (not pixels). Chosen by the loader to lay out the 3D volume in the squarest possible 2D texture atlas.
+   */
+  atlasTileDims: [number, number];
+  /** Size of the volume (current level), in pixels */
+  //volumeSize: Vector3;
+  /** Size of the currently loaded subregion, in pixels */
+  subregionSize: [number, number, number];
+  /** Offset of the loaded subregion into the total volume, in pixels */
+  subregionOffset: [number, number, number];
+  /** Size of a single *original* (not downsampled) pixel, in spatial units */
+  //physicalPixelSize: Vector3;
+  /** Symbol of physical spatial unit used by `pixelSize` */
+  //spatialUnit: string;
+
+  /** Number of channels in the image, accounting for convergence of multiple sources */
+  combinedNumChannels: number;
+  /** The names of each channel */
+  channelNames: string[];
+  /** Optional overrides to default channel colors, in 0-255 range */
+  channelColors?: [number, number, number][];
+
+  /** Number of timesteps in the time series, or 1 if the image is not a time series */
+  //times: number;
+  /** Size of each timestep in temporal units */
+  //timeScale: number;
+  /**
+   * Symbol of temporal unit used by `timeScale`, e.g. "hr".
+   *
+   * If units match one of the following, the viewer will automatically format
+   * timestamps to a d:hh:mm:ss.sss format, truncated as an integer of the unit specified.
+   * See https://ngff.openmicroscopy.org/latest/index.html#axes-md for a list of valid time units.
+   * - "ms", "millisecond" for milliseconds: `d:hh:mm:ss.sss`
+   * - "s", "sec", "second", or "seconds" for seconds: `d:hh:mm:ss`
+   * - "m", "min", "minute", or "minutes" for minutes: `d:hh:mm`
+   * - "h", "hr", "hour", or "hours" for hours: `d:hh`
+   * - "d", "day", or "days" for days: `d`
+   *
+   * The maximum timestamp value is used to determine the maximum unit shown.
+   * For example, if the time unit is in seconds, and the maximum time is 90 seconds, the timestamp
+   * will be formatted as "{m:ss} (m:s)", and the day and hour segments will be omitted.
+   */
+  //timeUnit: string;
+
+  /** Number of scale levels available for this volume */
+  //numMultiscaleLevels: number;
+  /** Dimensions of each scale level, at original size, from the first data source */
+  // TODO THIS DATA IS SOMEWHAT REDUNDANT WITH SOME OF THE OTHER FIELDS IN HERE
+  multiscaleLevelDims: VolumeDims[];
+
+  /** The scale level from which this image was loaded, between `0` and `numMultiscaleLevels-1` */
+  multiscaleLevel: number;
+
+  transform: {
+    /** Translation of the volume from the center of space, in volume voxels */
+    translation: [number, number, number];
+    /** Rotation of the volume in Euler angles, applied in XYZ order */
+    rotation: [number, number, number];
+  };
+
+  /** Arbitrary additional metadata not captured by other `ImageInfo` properties */
+  userData?: Record<string, unknown>;
+}>;
+
+export function defaultImageInfo(): ImageInfo2 {
+  return {
+    name: "",
+    atlasTileDims: [1, 1],
+    subregionSize: [1, 1, 1],
+    subregionOffset: [0, 0, 0],
+    combinedNumChannels: 1,
+    channelNames: ["0"],
+    channelColors: [[255, 255, 255]],
+    multiscaleLevel: 0,
+    multiscaleLevelDims: [
+      {
+        shape: [1, 1, 1, 1, 1],
+        spacing: [1, 1, 1, 1, 1],
+        spaceUnit: "",
+        timeUnit: "",
+        dataType: "uint8",
+      },
+    ],
+    transform: {
+      translation: [0, 0, 0],
+      rotation: [0, 0, 0],
+    },
+  };
+}
+
+export class CImageInfo {
+  imageInfo: ImageInfo2;
+  constructor(imageInfo?: ImageInfo2) {
+    this.imageInfo = imageInfo || defaultImageInfo();
+  }
+}

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -25,6 +25,7 @@ export type ImageInfo2 = Readonly<{
   /** Number of channels in the image, accounting for convergence of multiple sources.
    * Because of multiple sources, which is not accounted for in ImageInfo2,
    * that this could be different than the number of channels in the multiscaleLevelDims.
+   * NOTE Currently there is one ImageInfo2 per Volume, not per source.
    */
   combinedNumChannels: number;
   /** The names of each channel */
@@ -111,10 +112,10 @@ export class CImageInfo {
   }
 
   /** Number of channels in the image */
-  // TODO FIXME use combinedNumChannels?????
   get numChannels(): number {
-    // 1 is C
-    return this.currentLevelDims.shape[1];
+    return this.imageInfo.combinedNumChannels;
+    // // 1 is C
+    // return this.currentLevelDims.shape[1];
   }
 
   /** XYZ size of the *original* (not downsampled) volume, in pixels */

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -25,7 +25,7 @@ export type ImageInfo = Readonly<{
   /** Number of channels in the image, accounting for convergence of multiple sources.
    * Because of multiple sources, which is not accounted for in ImageInfo,
    * that this could be different than the number of channels in the multiscaleLevelDims.
-   * NOTE Currently there is one ImageInfo2 per Volume, not per source.
+   * NOTE Currently there is one ImageInfo per Volume, not per source.
    */
   combinedNumChannels: number;
   /** The names of each channel */

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -1,4 +1,4 @@
-import { type VolumeDims2, volumeSize, physicalPixelSize } from "./VolumeDims";
+import { type VolumeDims2, volumeSize, physicalPixelSize } from "./VolumeDims.js";
 import { Vector3, Vector2 } from "three";
 
 export type ImageInfo2 = Readonly<{

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -1,4 +1,5 @@
-import type { VolumeDims } from "./VolumeDims";
+import { type VolumeDims2, volumeSize, physicalPixelSize } from "./VolumeDims";
+import { Vector3 } from "three";
 
 export type ImageInfo2 = Readonly<{
   name: string;
@@ -54,7 +55,7 @@ export type ImageInfo2 = Readonly<{
   //numMultiscaleLevels: number;
   /** Dimensions of each scale level, at original size, from the first data source */
   // TODO THIS DATA IS SOMEWHAT REDUNDANT WITH SOME OF THE OTHER FIELDS IN HERE
-  multiscaleLevelDims: VolumeDims[];
+  multiscaleLevelDims: VolumeDims2[];
 
   /** The scale level from which this image was loaded, between `0` and `numMultiscaleLevels-1` */
   multiscaleLevel: number;
@@ -100,5 +101,36 @@ export class CImageInfo {
   imageInfo: ImageInfo2;
   constructor(imageInfo?: ImageInfo2) {
     this.imageInfo = imageInfo || defaultImageInfo();
+  }
+
+  get currentLevelDims(): VolumeDims2 {
+    return this.imageInfo.multiscaleLevelDims[this.imageInfo.multiscaleLevel];
+  }
+  get numChannels(): number {
+    return this.currentLevelDims.sizeC;
+  }
+  get originalSize(): Vector3 {
+    return volumeSize(this.imageInfo.multiscaleLevelDims[0]);
+  }
+  get volumeSize(): Vector3 {
+    return volumeSize(this.currentLevelDims);
+  }
+  get physicalPixelSize(): Vector3 {
+    return physicalPixelSize(this.currentLevelDims);
+  }
+  get spatialUnit(): string {
+    return this.currentLevelDims.spaceUnit;
+  }
+  get times(): number {
+    return this.currentLevelDims.sizeT;
+  }
+  get timeScale(): number {
+    return this.currentLevelDims.timeScale;
+  }
+  get timeUnit(): string {
+    return this.currentLevelDims.timeUnit;
+  }
+  get numMultiscaleLevels(): number {
+    return this.imageInfo.multiscaleLevelDims.length;
   }
 }

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -107,7 +107,8 @@ export class CImageInfo {
     return this.imageInfo.multiscaleLevelDims[this.imageInfo.multiscaleLevel];
   }
   get numChannels(): number {
-    return this.currentLevelDims.sizeC;
+    // 1 is C
+    return this.currentLevelDims.shape[1];
   }
   get originalSize(): Vector3 {
     return volumeSize(this.imageInfo.multiscaleLevelDims[0]);
@@ -122,10 +123,12 @@ export class CImageInfo {
     return this.currentLevelDims.spaceUnit;
   }
   get times(): number {
-    return this.currentLevelDims.sizeT;
+    // 0 is T
+    return this.currentLevelDims.shape[0];
   }
   get timeScale(): number {
-    return this.currentLevelDims.timeScale;
+    // 0 is T
+    return this.currentLevelDims.spacing[0];
   }
   get timeUnit(): string {
     return this.currentLevelDims.timeUnit;

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -23,7 +23,7 @@ export type ImageInfo = Readonly<{
   //spatialUnit: string;
 
   /** Number of channels in the image, accounting for convergence of multiple sources.
-   * Because of multiple sources, which is not accounted for in ImageInfo2,
+   * Because of multiple sources, which is not accounted for in ImageInfo,
    * that this could be different than the number of channels in the multiscaleLevelDims.
    * NOTE Currently there is one ImageInfo2 per Volume, not per source.
    */

--- a/src/ImageInfo.ts
+++ b/src/ImageInfo.ts
@@ -107,55 +107,103 @@ export class CImageInfo {
   get currentLevelDims(): VolumeDims2 {
     return this.imageInfo.multiscaleLevelDims[this.imageInfo.multiscaleLevel];
   }
+
+  /** Number of channels in the image */
+  // TODO FIXME use combinedNumChannels?????
   get numChannels(): number {
     // 1 is C
     return this.currentLevelDims.shape[1];
   }
+
+  /** XYZ size of the *original* (not downsampled) volume, in pixels */
   get originalSize(): Vector3 {
     return volumeSize(this.imageInfo.multiscaleLevelDims[0]);
   }
+
+  /** Size of the volume, in pixels */
   get volumeSize(): Vector3 {
     return volumeSize(this.currentLevelDims);
   }
+
+  /** Size of a single *original* (not downsampled) pixel, in spatial units */
   get physicalPixelSize(): Vector3 {
-    return physicalPixelSize(this.currentLevelDims);
+    return physicalPixelSize(this.imageInfo.multiscaleLevelDims[0]);
   }
+
+  /** Symbol of physical spatial unit used by `physicalPixelSize` */
   get spatialUnit(): string {
-    return this.currentLevelDims.spaceUnit;
+    return this.imageInfo.multiscaleLevelDims[0].spaceUnit;
   }
+
+  /** Number of timesteps in the time series, or 1 if the image is not a time series */
   get times(): number {
     // 0 is T
     return this.currentLevelDims.shape[0];
   }
+
+  /** Size of each timestep in temporal units */
   get timeScale(): number {
     // 0 is T
     return this.currentLevelDims.spacing[0];
   }
+
+  /**
+   * Symbol of temporal unit used by `timeScale`, e.g. "hr".
+   *
+   * If units match one of the following, the viewer will automatically format
+   * timestamps to a d:hh:mm:ss.sss format, truncated as an integer of the unit specified.
+   * See https://ngff.openmicroscopy.org/latest/index.html#axes-md for a list of valid time units.
+   * - "ms", "millisecond" for milliseconds: `d:hh:mm:ss.sss`
+   * - "s", "sec", "second", or "seconds" for seconds: `d:hh:mm:ss`
+   * - "m", "min", "minute", or "minutes" for minutes: `d:hh:mm`
+   * - "h", "hr", "hour", or "hours" for hours: `d:hh`
+   * - "d", "day", or "days" for days: `d`
+   *
+   * The maximum timestamp value is used to determine the maximum unit shown.
+   * For example, if the time unit is in seconds, and the maximum time is 90 seconds, the timestamp
+   * will be formatted as "{m:ss} (m:s)", and the day and hour segments will be omitted.
+   */
   get timeUnit(): string {
     return this.currentLevelDims.timeUnit;
   }
+
+  /** Number of scale levels available for this volume */
   get numMultiscaleLevels(): number {
     return this.imageInfo.multiscaleLevelDims.length;
   }
 
+  /** The names of each channel */
   get channelNames(): string[] {
     return this.imageInfo.channelNames;
   }
+
+  /** Optional overrides to default channel colors, in 0-255 range */
   get channelColors(): [number, number, number][] | undefined {
     return this.imageInfo.channelColors;
   }
+
+  /** Size of the currently loaded subregion, in pixels */
   get subregionSize(): Vector3 {
     return new Vector3(...this.imageInfo.subregionSize);
   }
+
+  /** Offset of the loaded subregion into the total volume, in pixels */
   get subregionOffset(): Vector3 {
     return new Vector3(...this.imageInfo.subregionOffset);
   }
+
   get multiscaleLevel(): number {
     return this.imageInfo.multiscaleLevel;
   }
+
+  /**
+   * XY dimensions of the texture atlas used by `RayMarchedAtlasVolume` and `Atlas2DSlice`, in number of z-slice
+   * tiles (not pixels). Chosen by the loader to lay out the 3D volume in the squarest possible 2D texture atlas.
+   */
   get atlasTileDims(): Vector2 {
     return new Vector2(...this.imageInfo.atlasTileDims);
   }
+
   get transform(): { translation: Vector3; rotation: Vector3 } {
     return {
       translation: new Vector3(...this.imageInfo.transform.translation),
@@ -168,5 +216,5 @@ export function computeAtlasSize(imageInfo: ImageInfo2): [number, number] {
   const { atlasTileDims } = imageInfo;
   const volDims = imageInfo.multiscaleLevelDims[imageInfo.multiscaleLevel];
   // TCZYX: 4 = x, 3 = y
-  return [atlasTileDims[0] * volDims[4], atlasTileDims[1] * volDims[3]];
+  return [atlasTileDims[0] * volDims.shape[4], atlasTileDims[1] * volDims.shape[3]];
 }

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -180,6 +180,7 @@ export default class Volume {
   public channelNames: string[];
   public channelColorsDefault: [number, number, number][];
 
+  // The maximum of the measurements of 3 axes in physical units (pixels*physicalSize)
   public physicalScale: number;
   public physicalPixelSize: Vector3;
   public physicalSize: Vector3;
@@ -547,7 +548,7 @@ export default class Volume {
    * @return {Array.<number>} the xyz translation in normalized volume units
    */
   voxelsToWorldSpace(xyz: [number, number, number]): [number, number, number] {
-    // ASSUME: translation is in original image voxels.
+    // ASSUME: xyz is in original image voxels, compatible with physicalPixelSize.
     // account for pixel_size and normalized scaling in the threejs volume representation we're using
     const m = 1.0 / Math.max(this.physicalSize.x, Math.max(this.physicalSize.y, this.physicalSize.z));
     return new Vector3().fromArray(xyz).multiply(this.physicalPixelSize).multiplyScalar(m).toArray();

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -19,7 +19,7 @@ interface VolumeDataObserver {
 /**
  * A renderable multichannel volume image with 8-bits per channel intensity values.
  * @class
- * @param {ImageInfo2} imageInfo
+ * @param {ImageInfo} imageInfo
  */
 export default class Volume {
   public imageInfo: CImageInfo;

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -4,10 +4,11 @@ import Channel from "./Channel.js";
 import Histogram from "./Histogram.js";
 import { Lut } from "./Lut.js";
 import { getColorByChannelIndex } from "./constants/colors.js";
-import { type IVolumeLoader, LoadSpec, type PerChannelCallback, VolumeDims } from "./loaders/IVolumeLoader.js";
+import { type IVolumeLoader, LoadSpec, type PerChannelCallback } from "./loaders/IVolumeLoader.js";
 import { MAX_ATLAS_EDGE, pickLevelToLoadUnscaled } from "./loaders/VolumeLoaderUtils.js";
 import type { NumberType, TypedArray } from "./types.js";
 import { type ImageInfo, CImageInfo, defaultImageInfo } from "./ImageInfo.js";
+import { VolumeDims } from "./VolumeDims.js";
 
 interface VolumeDataObserver {
   onVolumeData: (vol: Volume, batch: number[]) => void;

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -25,8 +25,9 @@ export default class Volume {
   public imageInfo: CImageInfo;
   public loadSpec: Required<LoadSpec>;
   public loader?: IVolumeLoader;
-  // `LoadSpec` representing the minimum data required to display what's in the viewer (subregion, channels, etc.).
-  // Used to intelligently issue load requests whenever required by a state change. Modify with `updateRequiredData`.
+  /** `LoadSpec` representing the minimum data required to display what's in the viewer (subregion, channels, etc.).
+   * Used to intelligently issue load requests whenever required by a state change. Modify with `updateRequiredData`.
+   */
   public loadSpecRequired: Required<LoadSpec>;
   public channelLoadCallback?: PerChannelCallback;
   public imageMetadata: Record<string, unknown>;
@@ -37,13 +38,13 @@ export default class Volume {
   public channelNames: string[];
   public channelColorsDefault: [number, number, number][];
 
-  // The maximum of the measurements of 3 axes in physical units (pixels*physicalSize)
+  /** The maximum of the measurements of 3 axes in physical units (pixels*physicalSize) */
   public physicalScale: number;
-  // The physical size of a voxel in the original level 0 volume
+  /** The physical size of a voxel in the original level 0 volume */
   public physicalPixelSize: Vector3;
-  // The physical dims of the whole volume (not accounting for subregion)
+  /** The physical dims of the whole volume (not accounting for subregion) */
   public physicalSize: Vector3;
-  // Normalized physical size of the whole volume (not accounting for subregion)
+  /** Normalized physical size of the whole volume (not accounting for subregion) */
   public normPhysicalSize: Vector3;
   public normRegionSize: Vector3;
   public normRegionOffset: Vector3;

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -1,4 +1,4 @@
-import { Vector2, Vector3 } from "three";
+import { Vector3 } from "three";
 
 import Channel from "./Channel.js";
 import Histogram from "./Histogram.js";
@@ -9,107 +9,6 @@ import { MAX_ATLAS_EDGE, pickLevelToLoadUnscaled } from "./loaders/VolumeLoaderU
 import type { NumberType, TypedArray } from "./types.js";
 import { type ImageInfo2, CImageInfo, defaultImageInfo } from "./ImageInfo.js";
 
-export type ImageInfo = Readonly<{
-  name: string;
-
-  /** XYZ size of the *original* (not downsampled) volume, in pixels */
-  originalSize: Vector3;
-  /**
-   * XY dimensions of the texture atlas used by `RayMarchedAtlasVolume` and `Atlas2DSlice`, in number of z-slice
-   * tiles (not pixels). Chosen by the loader to lay out the 3D volume in the squarest possible 2D texture atlas.
-   */
-  atlasTileDims: Vector2;
-  /** Size of the volume, in pixels */
-  volumeSize: Vector3;
-  /** Size of the currently loaded subregion, in pixels */
-  subregionSize: Vector3;
-  /** Offset of the loaded subregion into the total volume, in pixels */
-  subregionOffset: Vector3;
-  /** Size of a single *original* (not downsampled) pixel, in spatial units */
-  physicalPixelSize: Vector3;
-  /** Symbol of physical spatial unit used by `pixelSize` */
-  spatialUnit: string;
-
-  /** Number of channels in the image */
-  numChannels: number;
-  /** The names of each channel */
-  channelNames: string[];
-  /** Optional overrides to default channel colors, in 0-255 range */
-  channelColors?: [number, number, number][];
-
-  /** Number of timesteps in the time series, or 1 if the image is not a time series */
-  times: number;
-  /** Size of each timestep in temporal units */
-  timeScale: number;
-  /**
-   * Symbol of temporal unit used by `timeScale`, e.g. "hr".
-   *
-   * If units match one of the following, the viewer will automatically format
-   * timestamps to a d:hh:mm:ss.sss format, truncated as an integer of the unit specified.
-   * See https://ngff.openmicroscopy.org/latest/index.html#axes-md for a list of valid time units.
-   * - "ms", "millisecond" for milliseconds: `d:hh:mm:ss.sss`
-   * - "s", "sec", "second", or "seconds" for seconds: `d:hh:mm:ss`
-   * - "m", "min", "minute", or "minutes" for minutes: `d:hh:mm`
-   * - "h", "hr", "hour", or "hours" for hours: `d:hh`
-   * - "d", "day", or "days" for days: `d`
-   *
-   * The maximum timestamp value is used to determine the maximum unit shown.
-   * For example, if the time unit is in seconds, and the maximum time is 90 seconds, the timestamp
-   * will be formatted as "{m:ss} (m:s)", and the day and hour segments will be omitted.
-   */
-  timeUnit: string;
-
-  /** Number of scale levels available for this volume */
-  numMultiscaleLevels: number;
-  /** Dimensions of each scale level, at original size, from the first data source */
-  // TODO THIS DATA IS SOMEWHAT REDUNDANT WITH SOME OF THE OTHER FIELDS IN HERE
-  multiscaleLevelDims: VolumeDims[];
-  /** The scale level from which this image was loaded, between `0` and `numMultiscaleLevels-1` */
-  multiscaleLevel: number;
-
-  transform: {
-    /** Translation of the volume from the center of space, in volume voxels */
-    translation: Vector3;
-    /** Rotation of the volume in Euler angles, applied in XYZ order */
-    rotation: Vector3;
-  };
-
-  /** Arbitrary additional metadata not captured by other `ImageInfo` properties */
-  userData?: Record<string, unknown>;
-}>;
-
-export const getDefaultImageInfo = (): ImageInfo => ({
-  name: "",
-  originalSize: new Vector3(1, 1, 1),
-  atlasTileDims: new Vector2(1, 1),
-  volumeSize: new Vector3(1, 1, 1),
-  subregionSize: new Vector3(1, 1, 1),
-  subregionOffset: new Vector3(0, 0, 0),
-  physicalPixelSize: new Vector3(1, 1, 1),
-  spatialUnit: "",
-  numChannels: 0,
-  channelNames: [],
-  channelColors: [],
-  times: 1,
-  timeScale: 1,
-  timeUnit: "",
-  numMultiscaleLevels: 1,
-  multiscaleLevel: 0,
-  multiscaleLevelDims: [
-    {
-      shape: [1, 1, 1, 1, 1],
-      spacing: [1, 1, 1, 1, 1],
-      spaceUnit: "",
-      timeUnit: "",
-      dataType: "uint8",
-    },
-  ],
-  transform: {
-    translation: new Vector3(0, 0, 0),
-    rotation: new Vector3(0, 0, 0),
-  },
-});
-
 interface VolumeDataObserver {
   onVolumeData: (vol: Volume, batch: number[]) => void;
   onVolumeChannelAdded: (vol: Volume, idx: number) => void;
@@ -117,52 +16,9 @@ interface VolumeDataObserver {
 }
 
 /**
- * Provide dimensions of the volume data, including dimensions for texture atlas data in which the volume z slices
- * are tiled across a single large 2d image plane.
- * @typedef {Object} ImageInfo
- * @property {string} name Base name of image
- * @property {string} [version] Schema version preferably in semver format.
- * @property {Vector2} originalSize XY size of the *original* (not downsampled) volume, in pixels
- * @property {Vector2} atlasDims Number of rows and columns of z-slice tiles (not pixels) in the texture atlas
- * @property {Vector3} volumeSize Size of the volume, in pixels
- * @property {Vector3} regionSize Size of the currently loaded subregion, in pixels
- * @property {Vector3} regionOffset Offset of the loaded subregion into the total volume, in pixels
- * @property {Vector3} pixelSize Size of a single *original* (not downsampled) pixel, in spatial units
- * @property {string} spatialUnit Symbol of physical spatial unit used by `pixelSize`
- * @property {number} numChannels Number of channels
- * @property {Array.<string>} channelNames Names of each of the channels to be rendered, in order. Unique identifier expected
- * @property {Array.<Array.<number>>} [channelColors] Colors of each of the channels to be rendered, as an ordered list of [r, g, b] arrays
- * @property {number} times Number of times (default = 1)
- * @property {number} timeScale Size of each time step in `timeUnit` units
- * @property {number} timeUnit Unit symbol for `timeScale` (e.g. min)
- * @property {Object} transform translation and rotation as arrays of 3 numbers. Translation is in voxels (to be multiplied by pixel_size values). Rotation is Euler angles in radians, appled in XYZ order.
- * @property {Object} userData Arbitrary metadata not covered by above properties
- * @example const imgdata = {
-  "name": "AICS-10_5_5",
-  "version": "0.0.0",
-  originalSize: new Vector2(306, 494),
-  atlasDims: new Vector2(10, 7),
-  volumeSize: new Vector3(204, 292, 65),
-  regionSize: new Vector3(204, 292, 65),
-  regionOffset: new Vector3(0, 0, 0),
-  pixelSize: new Vector3(0.065, 0.065, 0.29),
-  spatialUnit: "μm",
-  "numChannels": 9,
-  "channelNames": ["DRAQ5", "EGFP", "Hoechst 33258", "TL Brightfield", "SEG_STRUCT", "SEG_Memb", "SEG_DNA", "CON_Memb", "CON_DNA"],
-  "times": 5,
-  "timeScale": 1,
-  "timeUnit": "hr",
-  "transform": {
-    "translation": new Vector3(5, 5, 1),
-    "rotation": new Vector3(0, 3.14159, 1.57),
-  },
-  };
- */
-
-/**
  * A renderable multichannel volume image with 8-bits per channel intensity values.
  * @class
- * @param {ImageInfo} imageInfo
+ * @param {ImageInfo2} imageInfo
  */
 export default class Volume {
   public imageInfo: CImageInfo;

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -182,8 +182,11 @@ export default class Volume {
 
   // The maximum of the measurements of 3 axes in physical units (pixels*physicalSize)
   public physicalScale: number;
+  // The physical size of a voxel in the original level 0 volume
   public physicalPixelSize: Vector3;
+  // The physical dims of the whole volume (not accounting for subregion)
   public physicalSize: Vector3;
+  // Normalized physical size of the whole volume (not accounting for subregion)
   public normPhysicalSize: Vector3;
   public normRegionSize: Vector3;
   public normRegionOffset: Vector3;
@@ -548,7 +551,7 @@ export default class Volume {
    * @return {Array.<number>} the xyz translation in normalized volume units
    */
   voxelsToWorldSpace(xyz: [number, number, number]): [number, number, number] {
-    // ASSUME: xyz is in original image voxels, compatible with physicalPixelSize.
+    // ASSUME: xyz is in original (level 0) image voxels, compatible with physicalPixelSize.
     // account for pixel_size and normalized scaling in the threejs volume representation we're using
     const m = 1.0 / Math.max(this.physicalSize.x, Math.max(this.physicalSize.y, this.physicalSize.z));
     return new Vector3().fromArray(xyz).multiply(this.physicalPixelSize).multiplyScalar(m).toArray();

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -8,7 +8,7 @@ import { type IVolumeLoader, LoadSpec, type PerChannelCallback } from "./loaders
 import { MAX_ATLAS_EDGE, pickLevelToLoadUnscaled } from "./loaders/VolumeLoaderUtils.js";
 import type { NumberType, TypedArray } from "./types.js";
 import { type ImageInfo, CImageInfo, defaultImageInfo } from "./ImageInfo.js";
-import { VolumeDims } from "./VolumeDims.js";
+import type { VolumeDims } from "./VolumeDims.js";
 
 interface VolumeDataObserver {
   onVolumeData: (vol: Volume, batch: number[]) => void;

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -7,6 +7,7 @@ import { getColorByChannelIndex } from "./constants/colors.js";
 import { type IVolumeLoader, LoadSpec, type PerChannelCallback, VolumeDims } from "./loaders/IVolumeLoader.js";
 import { MAX_ATLAS_EDGE, pickLevelToLoadUnscaled } from "./loaders/VolumeLoaderUtils.js";
 import type { NumberType, TypedArray } from "./types.js";
+import { type ImageInfo2, CImageInfo, defaultImageInfo } from "./ImageInfo.js";
 
 export type ImageInfo = Readonly<{
   name: string;
@@ -164,7 +165,7 @@ interface VolumeDataObserver {
  * @param {ImageInfo} imageInfo
  */
 export default class Volume {
-  public imageInfo: ImageInfo;
+  public imageInfo: CImageInfo;
   public loadSpec: Required<LoadSpec>;
   public loader?: IVolumeLoader;
   // `LoadSpec` representing the minimum data required to display what's in the viewer (subregion, channels, etc.).
@@ -191,14 +192,11 @@ export default class Volume {
   private volumeDataObservers: VolumeDataObserver[];
   private loaded: boolean;
 
-  constructor(
-    imageInfo: ImageInfo = getDefaultImageInfo(),
-    loadSpec: LoadSpec = new LoadSpec(),
-    loader?: IVolumeLoader
-  ) {
+  constructor(imageInfo: ImageInfo2 = defaultImageInfo(), loadSpec: LoadSpec = new LoadSpec(), loader?: IVolumeLoader) {
     this.loaded = false;
-    this.imageInfo = imageInfo;
-    this.name = this.imageInfo.name;
+    this.imageInfo = new CImageInfo(imageInfo);
+    // TODO: use getter?
+    this.name = imageInfo.name;
     this.loadSpec = {
       // Fill in defaults for optional properties
       multiscaleLevel: 0,

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -8,38 +8,38 @@ import { type IVolumeLoader, LoadSpec, type PerChannelCallback, VolumeDims } fro
 import { MAX_ATLAS_EDGE, pickLevelToLoadUnscaled } from "./loaders/VolumeLoaderUtils.js";
 import type { NumberType, TypedArray } from "./types.js";
 
-export type ImageInfo = Readonly<{
-  name: string;
+export class ImageInfo {
+  readonly name: string = "";
 
-  /** XYZ size of the *original* (not downsampled) volume, in pixels */
-  originalSize: Vector3;
+  /** XYZ size of the *original* (level 0) volume, in pixels */
+  //originalSize: Vector3;
   /**
    * XY dimensions of the texture atlas used by `RayMarchedAtlasVolume` and `Atlas2DSlice`, in number of z-slice
    * tiles (not pixels). Chosen by the loader to lay out the 3D volume in the squarest possible 2D texture atlas.
    */
-  atlasTileDims: Vector2;
-  /** Size of the volume, in pixels */
-  volumeSize: Vector3;
+  readonly atlasTileDims: Vector2 = new Vector2(1, 1);
+  /** Size of the volume (current level), in pixels */
+  //volumeSize: Vector3;
   /** Size of the currently loaded subregion, in pixels */
-  subregionSize: Vector3;
+  readonly subregionSize: Vector3 = new Vector3(1, 1, 1);
   /** Offset of the loaded subregion into the total volume, in pixels */
-  subregionOffset: Vector3;
+  readonly subregionOffset: Vector3 = new Vector3(0, 0, 0);
   /** Size of a single *original* (not downsampled) pixel, in spatial units */
-  physicalPixelSize: Vector3;
+  //physicalPixelSize: Vector3;
   /** Symbol of physical spatial unit used by `pixelSize` */
-  spatialUnit: string;
+  //spatialUnit: string;
 
   /** Number of channels in the image */
-  numChannels: number;
+  //numChannels: number;
   /** The names of each channel */
-  channelNames: string[];
+  readonly channelNames: string[] = [];
   /** Optional overrides to default channel colors, in 0-255 range */
-  channelColors?: [number, number, number][];
+  readonly channelColors?: [number, number, number][] = [];
 
   /** Number of timesteps in the time series, or 1 if the image is not a time series */
-  times: number;
+  //times: number;
   /** Size of each timestep in temporal units */
-  timeScale: number;
+  //timeScale: number;
   /**
    * Symbol of temporal unit used by `timeScale`, e.g. "hr".
    *
@@ -56,58 +56,68 @@ export type ImageInfo = Readonly<{
    * For example, if the time unit is in seconds, and the maximum time is 90 seconds, the timestamp
    * will be formatted as "{m:ss} (m:s)", and the day and hour segments will be omitted.
    */
-  timeUnit: string;
+  //timeUnit: string;
 
   /** Number of scale levels available for this volume */
-  numMultiscaleLevels: number;
+  //numMultiscaleLevels: number;
   /** Dimensions of each scale level, at original size, from the first data source */
   // TODO THIS DATA IS SOMEWHAT REDUNDANT WITH SOME OF THE OTHER FIELDS IN HERE
-  multiscaleLevelDims: VolumeDims[];
-  /** The scale level from which this image was loaded, between `0` and `numMultiscaleLevels-1` */
-  multiscaleLevel: number;
-
-  transform: {
-    /** Translation of the volume from the center of space, in volume voxels */
-    translation: Vector3;
-    /** Rotation of the volume in Euler angles, applied in XYZ order */
-    rotation: Vector3;
-  };
-
-  /** Arbitrary additional metadata not captured by other `ImageInfo` properties */
-  userData?: Record<string, unknown>;
-}>;
-
-export const getDefaultImageInfo = (): ImageInfo => ({
-  name: "",
-  originalSize: new Vector3(1, 1, 1),
-  atlasTileDims: new Vector2(1, 1),
-  volumeSize: new Vector3(1, 1, 1),
-  subregionSize: new Vector3(1, 1, 1),
-  subregionOffset: new Vector3(0, 0, 0),
-  physicalPixelSize: new Vector3(1, 1, 1),
-  spatialUnit: "",
-  numChannels: 0,
-  channelNames: [],
-  channelColors: [],
-  times: 1,
-  timeScale: 1,
-  timeUnit: "",
-  numMultiscaleLevels: 1,
-  multiscaleLevel: 0,
-  multiscaleLevelDims: [
-    {
+  readonly multiscaleLevelDims: VolumeDims[] = [
+    new VolumeDims({
       shape: [1, 1, 1, 1, 1],
       spacing: [1, 1, 1, 1, 1],
       spaceUnit: "",
       timeUnit: "",
       dataType: "uint8",
-    },
-  ],
-  transform: {
-    translation: new Vector3(0, 0, 0),
-    rotation: new Vector3(0, 0, 0),
-  },
-});
+    }),
+  ];
+
+  /** The scale level from which this image was loaded, between `0` and `numMultiscaleLevels-1` */
+  readonly multiscaleLevel: number = 0;
+
+  readonly transform: {
+    /** Translation of the volume from the center of space, in volume voxels */
+    translation: Vector3;
+    /** Rotation of the volume in Euler angles, applied in XYZ order */
+    rotation: Vector3;
+  } = { translation: new Vector3(0, 0, 0), rotation: new Vector3(0, 0, 0) };
+
+  /** Arbitrary additional metadata not captured by other `ImageInfo` properties */
+  readonly userData?: Record<string, unknown>;
+
+  get currentLevelDims(): VolumeDims {
+    return this.multiscaleLevelDims[this.multiscaleLevel];
+  }
+  get numChannels(): number {
+    return this.currentLevelDims.sizeC;
+  }
+  get originalSize(): Vector3 {
+    return this.multiscaleLevelDims[0].volumeSize;
+  }
+  get volumeSize(): Vector3 {
+    return this.currentLevelDims.volumeSize;
+  }
+  get physicalPixelSize(): Vector3 {
+    return this.currentLevelDims.physicalPixelSize;
+  }
+  get spatialUnit(): string {
+    return this.currentLevelDims.spaceUnit;
+  }
+  get times(): number {
+    return this.currentLevelDims.sizeT;
+  }
+  get timeScale(): number {
+    return this.currentLevelDims.timeScale;
+  }
+  get timeUnit(): string {
+    return this.currentLevelDims.timeUnit;
+  }
+  get numMultiscaleLevels(): number {
+    return this.multiscaleLevelDims.length;
+  }
+}
+
+export const getDefaultImageInfo = (): ImageInfo => new ImageInfo();
 
 interface VolumeDataObserver {
   onVolumeData: (vol: Volume, batch: number[]) => void;
@@ -350,6 +360,7 @@ export default class Volume {
 
   // we calculate the physical size of the volume (voxels*pixel_size)
   // and then normalize to the max physical dimension
+  // NOTE: This function MUST be called to set up some important dimensional info
   setVoxelSize(size: Vector3): void {
     // only set the data if it is > 0.  zero is not an allowed value.
     size.x = size.x > 0 ? size.x : 1.0;

--- a/src/Volume.ts
+++ b/src/Volume.ts
@@ -7,7 +7,7 @@ import { getColorByChannelIndex } from "./constants/colors.js";
 import { type IVolumeLoader, LoadSpec, type PerChannelCallback, VolumeDims } from "./loaders/IVolumeLoader.js";
 import { MAX_ATLAS_EDGE, pickLevelToLoadUnscaled } from "./loaders/VolumeLoaderUtils.js";
 import type { NumberType, TypedArray } from "./types.js";
-import { type ImageInfo2, CImageInfo, defaultImageInfo } from "./ImageInfo.js";
+import { type ImageInfo, CImageInfo, defaultImageInfo } from "./ImageInfo.js";
 
 interface VolumeDataObserver {
   onVolumeData: (vol: Volume, batch: number[]) => void;
@@ -52,7 +52,7 @@ export default class Volume {
   private volumeDataObservers: VolumeDataObserver[];
   private loaded: boolean;
 
-  constructor(imageInfo: ImageInfo2 = defaultImageInfo(), loadSpec: LoadSpec = new LoadSpec(), loader?: IVolumeLoader) {
+  constructor(imageInfo: ImageInfo = defaultImageInfo(), loadSpec: LoadSpec = new LoadSpec(), loader?: IVolumeLoader) {
     this.loaded = false;
     this.imageInfo = new CImageInfo(imageInfo);
     // TODO: use getter?

--- a/src/VolumeDims.ts
+++ b/src/VolumeDims.ts
@@ -1,7 +1,7 @@
 import { type NumberType } from "./types.js";
 import { Vector3 } from "three";
 
-export type VolumeDims2 = {
+export type VolumeDims = {
   // shape: [t, c, z, y, x]
   shape: [number, number, number, number, number];
   // spacing: [t, c, z, y, x]; generally expect 1 for non-spatial dimensions
@@ -27,7 +27,7 @@ export type VolumeDims2 = {
   dataType: NumberType;
 };
 
-export function defaultVolumeDims(): VolumeDims2 {
+export function defaultVolumeDims(): VolumeDims {
   return {
     shape: [0, 0, 0, 0, 0],
     spacing: [1, 1, 1, 1, 1],
@@ -37,17 +37,17 @@ export function defaultVolumeDims(): VolumeDims2 {
   };
 }
 
-export function volumeSize(volumeDims: VolumeDims2): Vector3 {
+export function volumeSize(volumeDims: VolumeDims): Vector3 {
   return new Vector3(volumeDims.shape[4], volumeDims.shape[3], volumeDims.shape[2]);
 }
 
-export function physicalPixelSize(volumeDims: VolumeDims2): Vector3 {
+export function physicalPixelSize(volumeDims: VolumeDims): Vector3 {
   return new Vector3(volumeDims.spacing[4], volumeDims.spacing[3], volumeDims.spacing[2]);
 }
 
 export class CVolumeDims {
-  volumeDims: VolumeDims2;
-  constructor(volumeDims?: VolumeDims2) {
+  volumeDims: VolumeDims;
+  constructor(volumeDims?: VolumeDims) {
     this.volumeDims = volumeDims || defaultVolumeDims();
   }
 

--- a/src/VolumeDims.ts
+++ b/src/VolumeDims.ts
@@ -44,37 +44,3 @@ export function volumeSize(volumeDims: VolumeDims): Vector3 {
 export function physicalPixelSize(volumeDims: VolumeDims): Vector3 {
   return new Vector3(volumeDims.spacing[4], volumeDims.spacing[3], volumeDims.spacing[2]);
 }
-
-export class CVolumeDims {
-  volumeDims: VolumeDims;
-  constructor(volumeDims?: VolumeDims) {
-    this.volumeDims = volumeDims || defaultVolumeDims();
-  }
-
-  get sizeC(): number {
-    return this.volumeDims.shape[1];
-  }
-  get sizeT(): number {
-    return this.volumeDims.shape[0];
-  }
-  get sizeZ(): number {
-    return this.volumeDims.shape[2];
-  }
-  get sizeY(): number {
-    return this.volumeDims.shape[3];
-  }
-  get sizeX(): number {
-    return this.volumeDims.shape[4];
-  }
-  // returns XYZ order
-  get physicalPixelSize(): Vector3 {
-    return physicalPixelSize(this.volumeDims);
-  }
-  get timeScale(): number {
-    return this.volumeDims.spacing[0];
-  }
-  // returns XYZ order
-  get volumeSize(): Vector3 {
-    return volumeSize(this.volumeDims);
-  }
-}

--- a/src/VolumeDims.ts
+++ b/src/VolumeDims.ts
@@ -7,6 +7,22 @@ export type VolumeDims2 = {
   // spacing: [t, c, z, y, x]; generally expect 1 for non-spatial dimensions
   spacing: [number, number, number, number, number];
   spaceUnit: string;
+  /**
+   * Symbol of temporal unit used by `spacing[0]`, e.g. "hr".
+   *
+   * If units match one of the following, the viewer will automatically format
+   * timestamps to a d:hh:mm:ss.sss format, truncated as an integer of the unit specified.
+   * See https://ngff.openmicroscopy.org/latest/index.html#axes-md for a list of valid time units.
+   * - "ms", "millisecond" for milliseconds: `d:hh:mm:ss.sss`
+   * - "s", "sec", "second", or "seconds" for seconds: `d:hh:mm:ss`
+   * - "m", "min", "minute", or "minutes" for minutes: `d:hh:mm`
+   * - "h", "hr", "hour", or "hours" for hours: `d:hh`
+   * - "d", "day", or "days" for days: `d`
+   *
+   * The maximum timestamp value is used to determine the maximum unit shown.
+   * For example, if the time unit is in seconds, and the maximum time is 90 seconds, the timestamp
+   * will be formatted as "{m:ss} (m:s)", and the day and hour segments will be omitted.
+   */
   timeUnit: string;
   dataType: NumberType;
 };

--- a/src/VolumeDims.ts
+++ b/src/VolumeDims.ts
@@ -1,0 +1,28 @@
+import { type NumberType } from "./types.js";
+
+export type VolumeDims2 = {
+  // shape: [t, c, z, y, x]
+  shape: [number, number, number, number, number];
+  // spacing: [t, c, z, y, x]; generally expect 1 for non-spatial dimensions
+  spacing: [number, number, number, number, number];
+  spaceUnit: string;
+  timeUnit: string;
+  dataType: NumberType;
+};
+
+export function defaultVolumeDims(): VolumeDims2 {
+  return {
+    shape: [0, 0, 0, 0, 0],
+    spacing: [1, 1, 1, 1, 1],
+    spaceUnit: "μm",
+    timeUnit: "s",
+    dataType: "uint8",
+  };
+}
+
+export class CVolumeDims {
+  volumeDims: VolumeDims2;
+  constructor(volumeDims?: VolumeDims2) {
+    this.volumeDims = volumeDims || defaultVolumeDims();
+  }
+}

--- a/src/VolumeDims.ts
+++ b/src/VolumeDims.ts
@@ -1,4 +1,5 @@
 import { type NumberType } from "./types.js";
+import { Vector3 } from "three";
 
 export type VolumeDims2 = {
   // shape: [t, c, z, y, x]
@@ -20,9 +21,44 @@ export function defaultVolumeDims(): VolumeDims2 {
   };
 }
 
+export function volumeSize(volumeDims: VolumeDims2): Vector3 {
+  return new Vector3(volumeDims.shape[4], volumeDims.shape[3], volumeDims.shape[2]);
+}
+
+export function physicalPixelSize(volumeDims: VolumeDims2): Vector3 {
+  return new Vector3(volumeDims.spacing[4], volumeDims.spacing[3], volumeDims.spacing[2]);
+}
+
 export class CVolumeDims {
   volumeDims: VolumeDims2;
   constructor(volumeDims?: VolumeDims2) {
     this.volumeDims = volumeDims || defaultVolumeDims();
+  }
+
+  get sizeC(): number {
+    return this.volumeDims.shape[1];
+  }
+  get sizeT(): number {
+    return this.volumeDims.shape[0];
+  }
+  get sizeZ(): number {
+    return this.volumeDims.shape[2];
+  }
+  get sizeY(): number {
+    return this.volumeDims.shape[3];
+  }
+  get sizeX(): number {
+    return this.volumeDims.shape[4];
+  }
+  // returns XYZ order
+  get physicalPixelSize(): Vector3 {
+    return physicalPixelSize(this.volumeDims);
+  }
+  get timeScale(): number {
+    return this.volumeDims.spacing[0];
+  }
+  // returns XYZ order
+  get volumeSize(): Vector3 {
+    return volumeSize(this.volumeDims);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,6 @@ import { VolumeLoadError, VolumeLoadErrorType } from "./loaders/VolumeLoadError.
 import { type CameraState } from "./ThreeJsPanel.js";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
 
-export type { ImageInfo } from "./Volume.js";
 export type { ImageInfo2 } from "./ImageInfo.js";
 export type { ControlPoint } from "./Lut.js";
 export type { CreateLoaderOptions } from "./loaders/index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { type CameraState } from "./ThreeJsPanel.js";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
 
 export type { ImageInfo } from "./Volume.js";
+export type { ImageInfo2 } from "./ImageInfo.js";
 export type { ControlPoint } from "./Lut.js";
 export type { CreateLoaderOptions } from "./loaders/index.js";
 export type { IVolumeLoader, PerChannelCallback } from "./loaders/IVolumeLoader.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import { VolumeLoadError, VolumeLoadErrorType } from "./loaders/VolumeLoadError.
 import { type CameraState } from "./ThreeJsPanel.js";
 import { Light, AREA_LIGHT, SKY_LIGHT } from "./Light.js";
 
-export type { ImageInfo2 } from "./ImageInfo.js";
+export type { ImageInfo } from "./ImageInfo.js";
 export type { ControlPoint } from "./Lut.js";
 export type { CreateLoaderOptions } from "./loaders/index.js";
 export type { IVolumeLoader, PerChannelCallback } from "./loaders/IVolumeLoader.js";

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -1,6 +1,6 @@
 import { Box3, Vector3 } from "three";
 
-import Volume, { ImageInfo } from "../Volume.js";
+import Volume from "../Volume.js";
 import { CImageInfo, ImageInfo2 } from "../ImageInfo.js";
 import { TypedArray, NumberType } from "../types.js";
 import { buildDefaultMetadata } from "./VolumeLoaderUtils.js";

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -1,6 +1,7 @@
 import { Box3, Vector3 } from "three";
 
 import Volume from "../Volume.js";
+import { VolumeDims } from "../VolumeDims.js";
 import { CImageInfo, ImageInfo } from "../ImageInfo.js";
 import { TypedArray, NumberType } from "../types.js";
 import { buildDefaultMetadata } from "./VolumeLoaderUtils.js";
@@ -31,17 +32,6 @@ export class LoadSpec {
 export function loadSpecToString(spec: LoadSpec): string {
   const { min, max } = spec.subregion;
   return `${spec.multiscaleLevel}:${spec.time}:x(${min.x},${max.x}):y(${min.y},${max.y}):z(${min.z},${max.z})`;
-}
-
-export class VolumeDims {
-  // shape: [t, c, z, y, x]
-  shape: number[] = [0, 0, 0, 0, 0];
-  // spacing: [t, c, z, y, x]; generally expect 1 for non-spatial dimensions
-  spacing: number[] = [1, 1, 1, 1, 1];
-  spaceUnit = "μm";
-  timeUnit = "s";
-  // TODO make this an enum?
-  dataType = "uint8";
 }
 
 export type LoadedVolumeInfo = {

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -1,8 +1,8 @@
 import { Box3, Vector3 } from "three";
 
 import Volume from "../Volume.js";
-import { VolumeDims } from "../VolumeDims.js";
-import { CImageInfo, ImageInfo } from "../ImageInfo.js";
+import type { VolumeDims } from "../VolumeDims.js";
+import { CImageInfo, type ImageInfo } from "../ImageInfo.js";
 import { TypedArray, NumberType } from "../types.js";
 import { buildDefaultMetadata } from "./VolumeLoaderUtils.js";
 import { PrefetchDirection } from "./zarr_utils/types.js";

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -1,7 +1,7 @@
 import { Box3, Vector3 } from "three";
 
 import Volume from "../Volume.js";
-import { CImageInfo, ImageInfo2 } from "../ImageInfo.js";
+import { CImageInfo, ImageInfo } from "../ImageInfo.js";
 import { TypedArray, NumberType } from "../types.js";
 import { buildDefaultMetadata } from "./VolumeLoaderUtils.js";
 import { PrefetchDirection } from "./zarr_utils/types.js";
@@ -45,7 +45,7 @@ export class VolumeDims {
 }
 
 export type LoadedVolumeInfo = {
-  imageInfo: ImageInfo2;
+  imageInfo: ImageInfo;
   loadSpec: LoadSpec;
 };
 
@@ -143,9 +143,9 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
    * The returned promise should resolve when all data has been loaded, or reject if any error occurs while loading.
    */
   abstract loadRawChannelData(
-    imageInfo: ImageInfo2,
+    imageInfo: ImageInfo,
     loadSpec: LoadSpec,
-    onUpdateVolumeMetadata: (imageInfo?: ImageInfo2, loadSpec?: LoadSpec) => void,
+    onUpdateVolumeMetadata: (imageInfo?: ImageInfo, loadSpec?: LoadSpec) => void,
     onData: RawChannelDataCallback
   ): Promise<void>;
 
@@ -175,7 +175,7 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
     loadSpecOverride?: LoadSpec,
     onChannelLoaded?: PerChannelCallback
   ): Promise<void> {
-    const onUpdateMetadata = (imageInfo?: ImageInfo2, loadSpec?: LoadSpec): void => {
+    const onUpdateMetadata = (imageInfo?: ImageInfo, loadSpec?: LoadSpec): void => {
       if (imageInfo) {
         volume.imageInfo = new CImageInfo(imageInfo);
         volume.updateDimensions();

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -1,6 +1,7 @@
 import { Box3, Vector3 } from "three";
 
 import Volume, { ImageInfo } from "../Volume.js";
+import { CImageInfo, ImageInfo2 } from "../ImageInfo.js";
 import { TypedArray, NumberType } from "../types.js";
 import { buildDefaultMetadata } from "./VolumeLoaderUtils.js";
 import { PrefetchDirection } from "./zarr_utils/types.js";
@@ -44,7 +45,7 @@ export class VolumeDims {
 }
 
 export type LoadedVolumeInfo = {
-  imageInfo: ImageInfo;
+  imageInfo: ImageInfo2;
   loadSpec: LoadSpec;
 };
 
@@ -142,9 +143,9 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
    * The returned promise should resolve when all data has been loaded, or reject if any error occurs while loading.
    */
   abstract loadRawChannelData(
-    imageInfo: ImageInfo,
+    imageInfo: ImageInfo2,
     loadSpec: LoadSpec,
-    onUpdateVolumeMetadata: (imageInfo?: ImageInfo, loadSpec?: LoadSpec) => void,
+    onUpdateVolumeMetadata: (imageInfo?: ImageInfo2, loadSpec?: LoadSpec) => void,
     onData: RawChannelDataCallback
   ): Promise<void>;
 
@@ -174,9 +175,9 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
     loadSpecOverride?: LoadSpec,
     onChannelLoaded?: PerChannelCallback
   ): Promise<void> {
-    const onUpdateMetadata = (imageInfo?: ImageInfo, loadSpec?: LoadSpec): void => {
+    const onUpdateMetadata = (imageInfo?: ImageInfo2, loadSpec?: LoadSpec): void => {
       if (imageInfo) {
-        volume.imageInfo = imageInfo;
+        volume.imageInfo = new CImageInfo(imageInfo);
         volume.updateDimensions();
       }
       volume.loadSpec = { ...loadSpec, ...spec };
@@ -198,6 +199,6 @@ export abstract class ThreadableVolumeLoader implements IVolumeLoader {
     };
 
     const spec = { ...volume.loadSpec, ...loadSpecOverride };
-    return this.loadRawChannelData(volume.imageInfo, spec, onUpdateMetadata, onChannelData);
+    return this.loadRawChannelData(volume.imageInfo.imageInfo, spec, onUpdateMetadata, onChannelData);
   }
 }

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -41,6 +41,33 @@ export class VolumeDims {
   timeUnit = "s";
   // TODO make this an enum?
   dataType = "uint8";
+
+  get sizeC(): number {
+    return this.shape[1];
+  }
+  get sizeT(): number {
+    return this.shape[0];
+  }
+  get sizeZ(): number {
+    return this.shape[2];
+  }
+  get sizeY(): number {
+    return this.shape[3];
+  }
+  get sizeX(): number {
+    return this.shape[4];
+  }
+  // returns XYZ order
+  get physicalPixelSize(): Vector3 {
+    return new Vector3(this.spacing[4], this.spacing[3], this.spacing[2]);
+  }
+  get timeScale(): number {
+    return this.spacing[0];
+  }
+  // returns XYZ order
+  get volumeSize(): Vector3 {
+    return new Vector3(this.sizeX, this.sizeY, this.sizeZ);
+  }
 }
 
 export type LoadedVolumeInfo = {

--- a/src/loaders/IVolumeLoader.ts
+++ b/src/loaders/IVolumeLoader.ts
@@ -41,33 +41,6 @@ export class VolumeDims {
   timeUnit = "s";
   // TODO make this an enum?
   dataType = "uint8";
-
-  get sizeC(): number {
-    return this.shape[1];
-  }
-  get sizeT(): number {
-    return this.shape[0];
-  }
-  get sizeZ(): number {
-    return this.shape[2];
-  }
-  get sizeY(): number {
-    return this.shape[3];
-  }
-  get sizeX(): number {
-    return this.shape[4];
-  }
-  // returns XYZ order
-  get physicalPixelSize(): Vector3 {
-    return new Vector3(this.spacing[4], this.spacing[3], this.spacing[2]);
-  }
-  get timeScale(): number {
-    return this.spacing[0];
-  }
-  // returns XYZ order
-  get volumeSize(): Vector3 {
-    return new Vector3(this.sizeX, this.sizeY, this.sizeZ);
-  }
 }
 
 export type LoadedVolumeInfo = {

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -84,24 +84,12 @@ const convertImageInfo = (json: JsonImageInfo): ImageInfo => {
   tr[1] = (tr[1] * json.tile_height) / json.height;
   return {
     name: json.name,
-
-    //originalSize: new Vector3(json.width, json.height, json.tiles),
     atlasTileDims: [json.cols, json.rows],
-    //volumeSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
     subregionSize: [json.tile_width, json.tile_height, json.tiles],
     subregionOffset: [0, 0, 0],
-    //physicalPixelSize: new Vector3(json.pixel_size_x, json.pixel_size_y, json.pixel_size_z),
-    //spatialUnit: json.pixel_size_unit || "μm",
-
     combinedNumChannels: json.channels,
     channelNames: json.channel_names,
     channelColors: json.channel_colors,
-
-    //times: json.times || 1,
-    //timeScale: json.time_scale || 1,
-    //timeUnit: json.time_unit || "s",
-
-    //numMultiscaleLevels: 1,
     multiscaleLevel: 0,
     multiscaleLevelDims: [
       {
@@ -219,8 +207,6 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
     };
     onUpdateMetadata(undefined, adjustedLoadSpec);
 
-    //const w = imageInfo.atlasTileDims.x * imageInfo.volumeSize.x;
-    //const h = imageInfo.atlasTileDims.y * imageInfo.volumeSize.y;
     const [w, h] = computeAtlasSize(imageInfo);
     const wrappedOnData = (
       ch: number[],

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -67,47 +67,46 @@ type JsonImageInfo = {
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 
-const convertImageInfo = (json: JsonImageInfo): ImageInfo =>
-  <ImageInfo>{
-    name: json.name,
+const convertImageInfo = (json: JsonImageInfo): ImageInfo => ({
+  name: json.name,
 
-    originalSize: new Vector3(json.width, json.height, json.tiles),
-    atlasTileDims: new Vector2(json.cols, json.rows),
-    volumeSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
-    subregionSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
-    subregionOffset: new Vector3(0, 0, 0),
-    physicalPixelSize: new Vector3(json.pixel_size_x, json.pixel_size_y, json.pixel_size_z),
-    spatialUnit: json.pixel_size_unit || "μm",
+  originalSize: new Vector3(json.width, json.height, json.tiles),
+  atlasTileDims: new Vector2(json.cols, json.rows),
+  volumeSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
+  subregionSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
+  subregionOffset: new Vector3(0, 0, 0),
+  physicalPixelSize: new Vector3(json.pixel_size_x, json.pixel_size_y, json.pixel_size_z),
+  spatialUnit: json.pixel_size_unit || "μm",
 
-    numChannels: json.channels,
-    channelNames: json.channel_names,
-    channelColors: json.channel_colors,
+  numChannels: json.channels,
+  channelNames: json.channel_names,
+  channelColors: json.channel_colors,
 
-    times: json.times || 1,
-    timeScale: json.time_scale || 1,
-    timeUnit: json.time_unit || "s",
+  times: json.times || 1,
+  timeScale: json.time_scale || 1,
+  timeUnit: json.time_unit || "s",
 
-    numMultiscaleLevels: 1,
-    multiscaleLevel: 0,
-    multiscaleLevelDims: [
-      <VolumeDims>{
-        shape: [json.times || 1, json.channels, json.tiles, json.tile_height, json.tile_width],
-        spacing: [json.time_scale || 1, 1, json.pixel_size_z, json.pixel_size_y, json.pixel_size_x],
-        spaceUnit: json.pixel_size_unit || "μm",
-        timeUnit: json.time_unit || "s",
-        dataType: "uint8",
-      },
-    ],
-
-    transform: {
-      translation: json.transform?.translation
-        ? new Vector3().fromArray(json.transform.translation)
-        : new Vector3(0, 0, 0),
-      rotation: json.transform?.rotation ? new Vector3().fromArray(json.transform.rotation) : new Vector3(0, 0, 0),
+  numMultiscaleLevels: 1,
+  multiscaleLevel: 0,
+  multiscaleLevelDims: [
+    {
+      shape: [json.times || 1, json.channels, json.tiles, json.tile_height, json.tile_width],
+      spacing: [json.time_scale || 1, 1, json.pixel_size_z, json.pixel_size_y, json.pixel_size_x],
+      spaceUnit: json.pixel_size_unit || "μm",
+      timeUnit: json.time_unit || "s",
+      dataType: "uint8",
     },
+  ],
 
-    userData: json.userData,
-  };
+  transform: {
+    translation: json.transform?.translation
+      ? new Vector3().fromArray(json.transform.translation)
+      : new Vector3(0, 0, 0),
+    rotation: json.transform?.rotation ? new Vector3().fromArray(json.transform.rotation) : new Vector3(0, 0, 0),
+  },
+
+  userData: json.userData,
+});
 
 class JsonImageInfoLoader extends ThreadableVolumeLoader {
   urls: string[];

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -159,9 +159,9 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
     const d: VolumeDims = {
       shape: [jsonInfo.times || 1, jsonInfo.channels, jsonInfo.tiles, jsonInfo.tile_height, jsonInfo.tile_width],
       spacing: [1, 1, pz, py, px],
-      spaceUnit: jsonInfo.pixel_size_unit || "μm",
+      spaceUnit: jsonInfo.pixel_size_unit ?? "μm",
       dataType: "uint8",
-      timeUnit: jsonInfo.time_unit || "s",
+      timeUnit: jsonInfo.time_unit ?? "s",
     };
     return [d];
   }

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -104,7 +104,11 @@ const convertImageInfo = (json: JsonImageInfo): ImageInfo2 => ({
     rotation: json.transform?.rotation ? json.transform.rotation : [0, 0, 0],
   },
 
-  userData: json.userData,
+  userData: {
+    ...json.userData,
+    // for metadata display reasons
+    originalVolumeSize: new Vector3(json.width, json.height, json.tiles),
+  },
 });
 
 class JsonImageInfoLoader extends ThreadableVolumeLoader {

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -8,6 +8,7 @@ import {
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
 import type { ImageInfo } from "../Volume.js";
+import { computeAtlasSize, type ImageInfo2 } from "../ImageInfo.js";
 import VolumeCache from "../VolumeCache.js";
 import type { TypedArray, NumberType } from "../types.js";
 import { DATARANGE_UINT8 } from "../types.js";
@@ -67,26 +68,26 @@ type JsonImageInfo = {
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 
-const convertImageInfo = (json: JsonImageInfo): ImageInfo => ({
+const convertImageInfo = (json: JsonImageInfo): ImageInfo2 => ({
   name: json.name,
 
-  originalSize: new Vector3(json.width, json.height, json.tiles),
-  atlasTileDims: new Vector2(json.cols, json.rows),
-  volumeSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
-  subregionSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
-  subregionOffset: new Vector3(0, 0, 0),
-  physicalPixelSize: new Vector3(json.pixel_size_x, json.pixel_size_y, json.pixel_size_z),
-  spatialUnit: json.pixel_size_unit || "μm",
+  //originalSize: new Vector3(json.width, json.height, json.tiles),
+  atlasTileDims: [json.cols, json.rows],
+  //volumeSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
+  subregionSize: [json.tile_width, json.tile_height, json.tiles],
+  subregionOffset: [0, 0, 0],
+  //physicalPixelSize: new Vector3(json.pixel_size_x, json.pixel_size_y, json.pixel_size_z),
+  //spatialUnit: json.pixel_size_unit || "μm",
 
-  numChannels: json.channels,
+  combinedNumChannels: json.channels,
   channelNames: json.channel_names,
   channelColors: json.channel_colors,
 
-  times: json.times || 1,
-  timeScale: json.time_scale || 1,
-  timeUnit: json.time_unit || "s",
+  //times: json.times || 1,
+  //timeScale: json.time_scale || 1,
+  //timeUnit: json.time_unit || "s",
 
-  numMultiscaleLevels: 1,
+  //numMultiscaleLevels: 1,
   multiscaleLevel: 0,
   multiscaleLevelDims: [
     {
@@ -99,10 +100,8 @@ const convertImageInfo = (json: JsonImageInfo): ImageInfo => ({
   ],
 
   transform: {
-    translation: json.transform?.translation
-      ? new Vector3().fromArray(json.transform.translation)
-      : new Vector3(0, 0, 0),
-    rotation: json.transform?.rotation ? new Vector3().fromArray(json.transform.rotation) : new Vector3(0, 0, 0),
+    translation: json.transform?.translation ? json.transform.translation : [0, 0, 0],
+    rotation: json.transform?.rotation ? json.transform.rotation : [0, 0, 0],
   },
 
   userData: json.userData,
@@ -159,7 +158,7 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
   }
 
   async loadRawChannelData(
-    imageInfo: ImageInfo,
+    imageInfo: ImageInfo2,
     loadSpec: LoadSpec,
     onUpdateMetadata: (imageInfo: undefined, loadSpec?: LoadSpec) => void,
     onData: RawChannelDataCallback
@@ -196,8 +195,9 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
     };
     onUpdateMetadata(undefined, adjustedLoadSpec);
 
-    const w = imageInfo.atlasTileDims.x * imageInfo.volumeSize.x;
-    const h = imageInfo.atlasTileDims.y * imageInfo.volumeSize.y;
+    //const w = imageInfo.atlasTileDims.x * imageInfo.volumeSize.x;
+    //const h = imageInfo.atlasTileDims.y * imageInfo.volumeSize.y;
+    const [w, h] = computeAtlasSize(imageInfo);
     const wrappedOnData = (
       ch: number[],
       dtype: NumberType[],

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -81,7 +81,7 @@ const convertImageInfo = (json: JsonImageInfo): ImageInfo => {
   const [px, py, pz] = rescalePixelSize(json);
   // translation is in pixels that are in the space of json.width, json.height.
   // We need to convert this to the space of the tile_width and tile_height.
-  const tr: [number, number, number] = json.transform?.translation ? json.transform.translation : [0, 0, 0];
+  const tr: [number, number, number] = json.transform?.translation ?? [0, 0, 0];
   tr[0] = (tr[0] * json.tile_width) / json.width;
   tr[1] = (tr[1] * json.tile_height) / json.height;
   return {

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -68,6 +68,9 @@ type JsonImageInfo = {
 /* eslint-enable @typescript-eslint/naming-convention */
 
 const rescalePixelSize = (json: JsonImageInfo): [number, number, number] => {
+  // the pixel_size_x/y/z are the physical size of the original pixels represented by
+  // width and height.  We need to get a physical pixel size that is consistent
+  // with the tile_width and tile_height.
   const px = (json.pixel_size_x * json.width) / json.tile_width;
   const py = (json.pixel_size_y * json.height) / json.tile_height;
   const pz = json.pixel_size_z;
@@ -75,10 +78,9 @@ const rescalePixelSize = (json: JsonImageInfo): [number, number, number] => {
 };
 
 const convertImageInfo = (json: JsonImageInfo): ImageInfo => {
-  // original XY pixels are stored in json.width and height.
-  // this is also the coordinates of the translation so we have to scale that too.
   const [px, py, pz] = rescalePixelSize(json);
-  // convert translation to
+  // translation is in pixels that are in the space of json.width, json.height.
+  // We need to convert this to the space of the tile_width and tile_height.
   const tr: [number, number, number] = json.transform?.translation ? json.transform.translation : [0, 0, 0];
   tr[0] = (tr[0] * json.tile_width) / json.width;
   tr[1] = (tr[1] * json.tile_height) / json.height;

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -4,10 +4,10 @@ import {
   ThreadableVolumeLoader,
   type LoadSpec,
   type RawChannelDataCallback,
-  VolumeDims,
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
 import { computeAtlasSize, type ImageInfo } from "../ImageInfo.js";
+import { VolumeDims } from "../VolumeDims.js";
 import VolumeCache from "../VolumeCache.js";
 import type { TypedArray, NumberType } from "../types.js";
 import { DATARANGE_UINT8 } from "../types.js";
@@ -158,11 +158,13 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
   async loadDims(loadSpec: LoadSpec): Promise<VolumeDims[]> {
     const jsonInfo = await this.getJsonImageInfo(loadSpec.time);
 
-    const d = new VolumeDims();
-    d.shape = [jsonInfo.times || 1, jsonInfo.channels, jsonInfo.tiles, jsonInfo.tile_height, jsonInfo.tile_width];
-    d.spacing = [1, 1, jsonInfo.pixel_size_z, jsonInfo.pixel_size_y, jsonInfo.pixel_size_x];
-    d.spaceUnit = jsonInfo.pixel_size_unit || "μm";
-    d.dataType = "uint8";
+    const d: VolumeDims = {
+      shape: [jsonInfo.times || 1, jsonInfo.channels, jsonInfo.tiles, jsonInfo.tile_height, jsonInfo.tile_width],
+      spacing: [1, 1, jsonInfo.pixel_size_z, jsonInfo.pixel_size_y, jsonInfo.pixel_size_x],
+      spaceUnit: jsonInfo.pixel_size_unit || "μm",
+      dataType: "uint8",
+      timeUnit: jsonInfo.time_unit || "s",
+    };
     return [d];
   }
 

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -7,7 +7,7 @@ import {
   VolumeDims,
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
-import { computeAtlasSize, type ImageInfo2 } from "../ImageInfo.js";
+import { computeAtlasSize, type ImageInfo } from "../ImageInfo.js";
 import VolumeCache from "../VolumeCache.js";
 import type { TypedArray, NumberType } from "../types.js";
 import { DATARANGE_UINT8 } from "../types.js";
@@ -67,7 +67,7 @@ type JsonImageInfo = {
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 
-const convertImageInfo = (json: JsonImageInfo): ImageInfo2 => {
+const convertImageInfo = (json: JsonImageInfo): ImageInfo => {
   // original XY pixels are stored in json.width and height.
   // this is also the coordinates of the translation so we have to scale that too.
   const px = (json.pixel_size_x * json.width) / json.tile_width;
@@ -172,7 +172,7 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
   }
 
   async loadRawChannelData(
-    imageInfo: ImageInfo2,
+    imageInfo: ImageInfo,
     loadSpec: LoadSpec,
     onUpdateMetadata: (imageInfo: undefined, loadSpec?: LoadSpec) => void,
     onData: RawChannelDataCallback

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -7,7 +7,7 @@ import {
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
 import { computeAtlasSize, type ImageInfo } from "../ImageInfo.js";
-import { VolumeDims } from "../VolumeDims.js";
+import type { VolumeDims } from "../VolumeDims.js";
 import VolumeCache from "../VolumeCache.js";
 import type { TypedArray, NumberType } from "../types.js";
 import { DATARANGE_UINT8 } from "../types.js";

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -1,4 +1,4 @@
-import { Box3, Vector2, Vector3 } from "three";
+import { Box3, Vector3 } from "three";
 
 import {
   ThreadableVolumeLoader,
@@ -7,7 +7,6 @@ import {
   VolumeDims,
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
-import type { ImageInfo } from "../Volume.js";
 import { computeAtlasSize, type ImageInfo2 } from "../ImageInfo.js";
 import VolumeCache from "../VolumeCache.js";
 import type { TypedArray, NumberType } from "../types.js";

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -67,46 +67,47 @@ type JsonImageInfo = {
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 
-const convertImageInfo = (json: JsonImageInfo): ImageInfo => ({
-  name: json.name,
+const convertImageInfo = (json: JsonImageInfo): ImageInfo =>
+  <ImageInfo>{
+    name: json.name,
 
-  originalSize: new Vector3(json.width, json.height, json.tiles),
-  atlasTileDims: new Vector2(json.cols, json.rows),
-  volumeSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
-  subregionSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
-  subregionOffset: new Vector3(0, 0, 0),
-  physicalPixelSize: new Vector3(json.pixel_size_x, json.pixel_size_y, json.pixel_size_z),
-  spatialUnit: json.pixel_size_unit || "μm",
+    originalSize: new Vector3(json.width, json.height, json.tiles),
+    atlasTileDims: new Vector2(json.cols, json.rows),
+    volumeSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
+    subregionSize: new Vector3(json.tile_width, json.tile_height, json.tiles),
+    subregionOffset: new Vector3(0, 0, 0),
+    physicalPixelSize: new Vector3(json.pixel_size_x, json.pixel_size_y, json.pixel_size_z),
+    spatialUnit: json.pixel_size_unit || "μm",
 
-  numChannels: json.channels,
-  channelNames: json.channel_names,
-  channelColors: json.channel_colors,
+    numChannels: json.channels,
+    channelNames: json.channel_names,
+    channelColors: json.channel_colors,
 
-  times: json.times || 1,
-  timeScale: json.time_scale || 1,
-  timeUnit: json.time_unit || "s",
+    times: json.times || 1,
+    timeScale: json.time_scale || 1,
+    timeUnit: json.time_unit || "s",
 
-  numMultiscaleLevels: 1,
-  multiscaleLevel: 0,
-  multiscaleLevelDims: [
-    {
-      shape: [json.times || 1, json.channels, json.tiles, json.tile_height, json.tile_width],
-      spacing: [json.time_scale || 1, 1, json.pixel_size_z, json.pixel_size_y, json.pixel_size_x],
-      spaceUnit: json.pixel_size_unit || "μm",
-      timeUnit: json.time_unit || "s",
-      dataType: "uint8",
+    numMultiscaleLevels: 1,
+    multiscaleLevel: 0,
+    multiscaleLevelDims: [
+      <VolumeDims>{
+        shape: [json.times || 1, json.channels, json.tiles, json.tile_height, json.tile_width],
+        spacing: [json.time_scale || 1, 1, json.pixel_size_z, json.pixel_size_y, json.pixel_size_x],
+        spaceUnit: json.pixel_size_unit || "μm",
+        timeUnit: json.time_unit || "s",
+        dataType: "uint8",
+      },
+    ],
+
+    transform: {
+      translation: json.transform?.translation
+        ? new Vector3().fromArray(json.transform.translation)
+        : new Vector3(0, 0, 0),
+      rotation: json.transform?.rotation ? new Vector3().fromArray(json.transform.rotation) : new Vector3(0, 0, 0),
     },
-  ],
 
-  transform: {
-    translation: json.transform?.translation
-      ? new Vector3().fromArray(json.transform.translation)
-      : new Vector3(0, 0, 0),
-    rotation: json.transform?.rotation ? new Vector3().fromArray(json.transform.rotation) : new Vector3(0, 0, 0),
-  },
-
-  userData: json.userData,
-});
+    userData: json.userData,
+  };
 
 class JsonImageInfoLoader extends ThreadableVolumeLoader {
   urls: string[];

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -7,8 +7,8 @@ import { AbsolutePath } from "@zarrita/storage";
 // Getting it from the top-level package means we don't get its type. This is also a bug, but it's more acceptable.
 import { FetchStore } from "zarrita";
 
-import { ImageInfo } from "../ImageInfo.js";
-import { VolumeDims } from "../VolumeDims.js";
+import type { ImageInfo } from "../ImageInfo.js";
+import type { VolumeDims } from "../VolumeDims.js";
 import VolumeCache from "../VolumeCache.js";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue.js";
 import {

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -7,7 +7,6 @@ import { AbsolutePath } from "@zarrita/storage";
 // Getting it from the top-level package means we don't get its type. This is also a bug, but it's more acceptable.
 import { FetchStore } from "zarrita";
 
-import { ImageInfo } from "../Volume.js";
 import { ImageInfo2 } from "../ImageInfo.js";
 import { VolumeDims2 } from "../VolumeDims.js";
 import VolumeCache from "../VolumeCache.js";
@@ -331,7 +330,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     const hasT = t > -1;
     const hasZ = z > -1;
 
-    const shape0 = source0.scaleLevels[0].shape;
+    //const shape0 = source0.scaleLevels[0].shape;
     const levelToLoad = pickLevelToLoad(loadSpec, this.getLevelShapesZYX());
     const shapeLv = source0.scaleLevels[levelToLoad].shape;
 
@@ -360,11 +359,11 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     if (!this.maxExtent) {
       this.maxExtent = loadSpec.subregion.clone();
     }
-    const pxDims0 = convertSubregionToPixels(
-      loadSpec.subregion,
-      new Vector3(shape0[x], shape0[y], hasZ ? shape0[z] : 1)
-    );
-    const pxSize0 = pxDims0.getSize(new Vector3());
+    // const pxDims0 = convertSubregionToPixels(
+    //   loadSpec.subregion,
+    //   new Vector3(shape0[x], shape0[y], hasZ ? shape0[z] : 1)
+    // );
+    //const pxSize0 = pxDims0.getSize(new Vector3());
     const pxDimsLv = convertSubregionToPixels(
       loadSpec.subregion,
       new Vector3(shapeLv[x], shapeLv[y], hasZ ? shapeLv[z] : 1)
@@ -405,9 +404,9 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       return dims;
     });
     // for physicalPixelSize, we use the scale of the first level
-    const scale5d: TCZYX<number> = this.getScale(0);
+    //const scale5d: TCZYX<number> = this.getScale(0);
     // assume that ImageInfo wants the timeScale of level 0
-    const timeScale = hasT ? scale5d[0] : 1;
+    //const timeScale = hasT ? scale5d[0] : 1;
 
     const imgdata: ImageInfo2 = {
       name: source0.omeroMetadata?.name || "Volume",
@@ -538,11 +537,11 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     // Derive other image info properties from subregion and level to load
     const subregionSize = regionPx.getSize(new Vector3());
     const atlasTileDims = computePackedAtlasDims(subregionSize.z, subregionSize.x, subregionSize.y);
-    const volumeExtent = convertSubregionToPixels(
-      maxExtent,
-      new Vector3(array0Shape[x], array0Shape[y], z === -1 ? 1 : array0Shape[z])
-    );
-    const volumeSize = volumeExtent.getSize(new Vector3());
+    // const volumeExtent = convertSubregionToPixels(
+    //   maxExtent,
+    //   new Vector3(array0Shape[x], array0Shape[y], z === -1 ? 1 : array0Shape[z])
+    // );
+    //const volumeSize = volumeExtent.getSize(new Vector3());
 
     return {
       ...imageInfo,

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -414,20 +414,12 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     const imgdata: ImageInfo = {
       name: source0.omeroMetadata?.name || "Volume",
 
-      //originalSize: pxSize0,
       atlasTileDims: [atlasTileDims.x, atlasTileDims.y],
-      //volumeSize: pxSizeLv,
       subregionSize: [pxSizeLv.x, pxSizeLv.y, pxSizeLv.z], //pxSizeLv.clone(),
       subregionOffset: [0, 0, 0],
-      //physicalPixelSize: new Vector3(scale5d[4], scale5d[3], hasZ ? scale5d[2] : Math.min(scale5d[4], scale5d[3])),
-      //spatialUnit,
 
       combinedNumChannels: numChannels,
       channelNames,
-      //times,
-      //timeScale,
-      //timeUnit,
-      //numMultiscaleLevels: source0.scaleLevels.length,
       multiscaleLevel: levelToLoad,
       multiscaleLevelDims: alldims,
 
@@ -549,7 +541,6 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     return {
       ...imageInfo,
       atlasTileDims: [atlasTileDims.x, atlasTileDims.y],
-      //volumeSize,
       subregionSize: [subregionSize.x, subregionSize.y, subregionSize.z],
       subregionOffset: [regionPx.min.x, regionPx.min.y, regionPx.min.z],
       multiscaleLevel,

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -392,7 +392,8 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       });
     });
 
-    const alldims: VolumeDims[] = source0.scaleLevels.map((level, i) => {
+    const alldims: VolumeDims[] = [];
+    source0.scaleLevels.map((level, i) => {
       const dims = new VolumeDims();
 
       dims.spaceUnit = spatialUnit;
@@ -401,14 +402,14 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       dims.spacing = this.getScale(i);
       dims.dataType = level.dtype;
 
-      return dims;
+      alldims.push(dims);
     });
     // for physicalPixelSize, we use the scale of the first level
     const scale5d: TCZYX<number> = this.getScale(0);
     // assume that ImageInfo wants the timeScale of level 0
     const timeScale = hasT ? scale5d[0] : 1;
 
-    const imgdata: ImageInfo = <ImageInfo>{
+    const imgdata: ImageInfo = {
       name: source0.omeroMetadata?.name || "Volume",
 
       originalSize: pxSize0,
@@ -543,7 +544,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     );
     const volumeSize = volumeExtent.getSize(new Vector3());
 
-    return <ImageInfo>{
+    return {
       ...imageInfo,
       atlasTileDims,
       volumeSize,

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -330,7 +330,6 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     const hasT = t > -1;
     const hasZ = z > -1;
 
-    //const shape0 = source0.scaleLevels[0].shape;
     const levelToLoad = pickLevelToLoad(loadSpec, this.getLevelShapesZYX());
     const shapeLv = source0.scaleLevels[levelToLoad].shape;
 
@@ -359,12 +358,6 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     if (!this.maxExtent) {
       this.maxExtent = loadSpec.subregion.clone();
     }
-    // TODO IS IT SAFE TO IGNORE THIS SUBREGION STUFF?
-    // const pxDims0 = convertSubregionToPixels(
-    //   loadSpec.subregion,
-    //   new Vector3(shape0[x], shape0[y], hasZ ? shape0[z] : 1)
-    // );
-    //const pxSize0 = pxDims0.getSize(new Vector3());
 
     // from source 0:
     const pxDimsLv = convertSubregionToPixels(
@@ -406,16 +399,12 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       };
       return dims;
     });
-    // for physicalPixelSize, we use the scale of the first level
-    //const scale5d: TCZYX<number> = this.getScale(0);
-    // assume that ImageInfo wants the timeScale of level 0
-    //const timeScale = hasT ? scale5d[0] : 1;
 
     const imgdata: ImageInfo = {
       name: source0.omeroMetadata?.name || "Volume",
 
       atlasTileDims: [atlasTileDims.x, atlasTileDims.y],
-      subregionSize: [pxSizeLv.x, pxSizeLv.y, pxSizeLv.z], //pxSizeLv.clone(),
+      subregionSize: [pxSizeLv.x, pxSizeLv.y, pxSizeLv.z],
       subregionOffset: [0, 0, 0],
 
       combinedNumChannels: numChannels,
@@ -532,11 +521,6 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     // Derive other image info properties from subregion and level to load
     const subregionSize = regionPx.getSize(new Vector3());
     const atlasTileDims = computePackedAtlasDims(subregionSize.z, subregionSize.x, subregionSize.y);
-    // const volumeExtent = convertSubregionToPixels(
-    //   maxExtent,
-    //   new Vector3(array0Shape[x], array0Shape[y], z === -1 ? 1 : array0Shape[z])
-    // );
-    //const volumeSize = volumeExtent.getSize(new Vector3());
 
     return {
       ...imageInfo,

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -392,8 +392,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       });
     });
 
-    const alldims: VolumeDims[] = [];
-    source0.scaleLevels.map((level, i) => {
+    const alldims: VolumeDims[] = source0.scaleLevels.map((level, i) => {
       const dims = new VolumeDims();
 
       dims.spaceUnit = spatialUnit;
@@ -402,14 +401,14 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       dims.spacing = this.getScale(i);
       dims.dataType = level.dtype;
 
-      alldims.push(dims);
+      return dims;
     });
     // for physicalPixelSize, we use the scale of the first level
     const scale5d: TCZYX<number> = this.getScale(0);
     // assume that ImageInfo wants the timeScale of level 0
     const timeScale = hasT ? scale5d[0] : 1;
 
-    const imgdata: ImageInfo = {
+    const imgdata: ImageInfo = <ImageInfo>{
       name: source0.omeroMetadata?.name || "Volume",
 
       originalSize: pxSize0,
@@ -544,7 +543,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     );
     const volumeSize = volumeExtent.getSize(new Vector3());
 
-    return {
+    return <ImageInfo>{
       ...imageInfo,
       atlasTileDims,
       volumeSize,

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -7,7 +7,7 @@ import { AbsolutePath } from "@zarrita/storage";
 // Getting it from the top-level package means we don't get its type. This is also a bug, but it's more acceptable.
 import { FetchStore } from "zarrita";
 
-import { ImageInfo2 } from "../ImageInfo.js";
+import { ImageInfo } from "../ImageInfo.js";
 import { VolumeDims2 } from "../VolumeDims.js";
 import VolumeCache from "../VolumeCache.js";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue.js";
@@ -359,11 +359,14 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     if (!this.maxExtent) {
       this.maxExtent = loadSpec.subregion.clone();
     }
+    // TODO IS IT SAFE TO IGNORE THIS SUBREGION STUFF?
     // const pxDims0 = convertSubregionToPixels(
     //   loadSpec.subregion,
     //   new Vector3(shape0[x], shape0[y], hasZ ? shape0[z] : 1)
     // );
     //const pxSize0 = pxDims0.getSize(new Vector3());
+
+    // from source 0:
     const pxDimsLv = convertSubregionToPixels(
       loadSpec.subregion,
       new Vector3(shapeLv[x], shapeLv[y], hasZ ? shapeLv[z] : 1)
@@ -408,7 +411,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     // assume that ImageInfo wants the timeScale of level 0
     //const timeScale = hasT ? scale5d[0] : 1;
 
-    const imgdata: ImageInfo2 = {
+    const imgdata: ImageInfo = {
       name: source0.omeroMetadata?.name || "Volume",
 
       //originalSize: pxSize0,
@@ -518,7 +521,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
     this.prefetchSubscriber = subscriber;
   }
 
-  private updateImageInfoForLoad(imageInfo: ImageInfo2, loadSpec: LoadSpec): ImageInfo2 {
+  private updateImageInfoForLoad(imageInfo: ImageInfo, loadSpec: LoadSpec): ImageInfo {
     // Apply `this.maxExtent` to subregion, if it exists
     const maxExtent = this.maxExtent ?? new Box3(new Vector3(0, 0, 0), new Vector3(1, 1, 1));
     const subregion = composeSubregion(loadSpec.subregion, maxExtent);
@@ -554,9 +557,9 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
   }
 
   async loadRawChannelData(
-    imageInfo: ImageInfo2,
+    imageInfo: ImageInfo,
     loadSpec: LoadSpec,
-    onUpdateMetadata: (imageInfo: ImageInfo2) => void,
+    onUpdateMetadata: (imageInfo: ImageInfo) => void,
     onData: RawChannelDataCallback
   ): Promise<void> {
     // This seemingly useless line keeps a stable local copy of `syncChannels` which the async closures below capture

--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -8,14 +8,13 @@ import { AbsolutePath } from "@zarrita/storage";
 import { FetchStore } from "zarrita";
 
 import { ImageInfo } from "../ImageInfo.js";
-import { VolumeDims2 } from "../VolumeDims.js";
+import { VolumeDims } from "../VolumeDims.js";
 import VolumeCache from "../VolumeCache.js";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue.js";
 import {
   ThreadableVolumeLoader,
   LoadSpec,
   type RawChannelDataCallback,
-  VolumeDims,
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
 import {
@@ -309,14 +308,15 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
 
     const result = this.sources[0].scaleLevels.map((level, i) => {
       const scale = this.getScale(i);
-      const dims = new VolumeDims();
-
-      dims.spaceUnit = spaceUnit;
-      dims.timeUnit = timeUnit;
-      dims.shape = this.orderByTCZYX(level.shape, 1).map((val, idx) => Math.max(Math.ceil(val * regionArr[idx]), 1));
-      dims.spacing = this.orderByTCZYX(scale, 1);
-      dims.dataType = level.dtype;
-
+      const dims: VolumeDims = {
+        spaceUnit: spaceUnit,
+        timeUnit: timeUnit,
+        shape: this.orderByTCZYX(level.shape, 1).map((val, idx) =>
+          Math.max(Math.ceil(val * regionArr[idx]), 1)
+        ) as TCZYX<number>,
+        spacing: this.orderByTCZYX(scale, 1),
+        dataType: level.dtype,
+      };
       return dims;
     });
 
@@ -396,7 +396,7 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       });
     });
 
-    const alldims: VolumeDims2[] = source0.scaleLevels.map((level, i) => {
+    const alldims: VolumeDims[] = source0.scaleLevels.map((level, i) => {
       const dims = {
         spaceUnit: spatialUnit,
         timeUnit: timeUnit,

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -25,22 +25,11 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     const imgdata: ImageInfo = {
       name: "TEST",
 
-      //originalSize: new Vector3(600, 600, 27),
       atlasTileDims: [27, 1],
-      //volumeSize: new Vector3(600, 600, 27),
       subregionSize: [600, 600, 27],
       subregionOffset: [0, 0, 0],
-      //physicalPixelSize: new Vector3(1, 1, 2),
-      //spatialUnit: "µm",
-
       combinedNumChannels: numChannels,
       channelNames: chnames,
-
-      //times: 1,
-      //timeScale: 1,
-      //timeUnit: "",
-
-      //numMultiscaleLevels: 1,
       multiscaleLevel: 0,
       multiscaleLevelDims: [
         {
@@ -81,8 +70,6 @@ class OpenCellLoader extends ThreadableVolumeLoader {
       },
     ];
 
-    //const w = imageInfo.atlasTileDims[0] * imageInfo.volumeSize.x;
-    //const h = imageInfo.atlasTileDims[1] * imageInfo.volumeSize.y;
     const [w, h] = computeAtlasSize(imageInfo);
     // all data coming from this loader is natively 8-bit
     return JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, dtype, data) =>

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -5,7 +5,7 @@ import {
   VolumeDims,
   LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
-import { computeAtlasSize, ImageInfo2 } from "../ImageInfo.js";
+import { computeAtlasSize, ImageInfo } from "../ImageInfo.js";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader.js";
 import { DATARANGE_UINT8 } from "../types.js";
 
@@ -25,7 +25,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     // we know these are standardized to 600x600, two channels, one channel per jpg.
     const chnames: string[] = ["DNA", "Structure"];
 
-    const imgdata: ImageInfo2 = {
+    const imgdata: ImageInfo = {
       name: "TEST",
 
       //originalSize: new Vector3(600, 600, 27),
@@ -66,7 +66,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
   }
 
   loadRawChannelData(
-    imageInfo: ImageInfo2,
+    imageInfo: ImageInfo,
     _loadSpec: LoadSpec,
     _onUpdateMetadata: () => void,
     onData: RawChannelDataCallback

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -1,6 +1,6 @@
 import { ThreadableVolumeLoader, LoadSpec, RawChannelDataCallback, LoadedVolumeInfo } from "./IVolumeLoader.js";
-import { computeAtlasSize, ImageInfo } from "../ImageInfo.js";
-import { VolumeDims } from "../VolumeDims.js";
+import { computeAtlasSize, type ImageInfo } from "../ImageInfo.js";
+import type { VolumeDims } from "../VolumeDims.js";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader.js";
 import { DATARANGE_UINT8 } from "../types.js";
 

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -27,7 +27,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     // we know these are standardized to 600x600, two channels, one channel per jpg.
     const chnames: string[] = ["DNA", "Structure"];
 
-    const imgdata: ImageInfo = <ImageInfo>{
+    const imgdata: ImageInfo = {
       name: "TEST",
 
       originalSize: new Vector3(600, 600, 27),
@@ -48,7 +48,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
       numMultiscaleLevels: 1,
       multiscaleLevel: 0,
       multiscaleLevelDims: [
-        <VolumeDims>{
+        {
           shape: [1, numChannels, 27, 600, 600],
           spacing: [1, 1, 2, 1, 1],
           spaceUnit: "µm",

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -1,21 +1,18 @@
-import {
-  ThreadableVolumeLoader,
-  LoadSpec,
-  RawChannelDataCallback,
-  VolumeDims,
-  LoadedVolumeInfo,
-} from "./IVolumeLoader.js";
+import { ThreadableVolumeLoader, LoadSpec, RawChannelDataCallback, LoadedVolumeInfo } from "./IVolumeLoader.js";
 import { computeAtlasSize, ImageInfo } from "../ImageInfo.js";
+import { VolumeDims } from "../VolumeDims.js";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader.js";
 import { DATARANGE_UINT8 } from "../types.js";
 
 class OpenCellLoader extends ThreadableVolumeLoader {
   async loadDims(_: LoadSpec): Promise<VolumeDims[]> {
-    const d = new VolumeDims();
-    d.shape = [1, 2, 27, 600, 600];
-    d.spacing = [1, 1, 2, 1, 1];
-    d.spaceUnit = ""; // unknown unit.
-    d.dataType = "uint8";
+    const d: VolumeDims = {
+      shape: [1, 2, 27, 600, 600],
+      spacing: [1, 1, 2, 1, 1],
+      spaceUnit: "", // unknown unit.
+      dataType: "uint8",
+      timeUnit: "",
+    };
     return [d];
   }
 

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -8,6 +8,7 @@ import {
   LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
 import { ImageInfo } from "../Volume.js";
+import { computeAtlasSize, ImageInfo2 } from "../ImageInfo.js";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader.js";
 import { DATARANGE_UINT8 } from "../types.js";
 
@@ -27,25 +28,25 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     // we know these are standardized to 600x600, two channels, one channel per jpg.
     const chnames: string[] = ["DNA", "Structure"];
 
-    const imgdata: ImageInfo = {
+    const imgdata: ImageInfo2 = {
       name: "TEST",
 
-      originalSize: new Vector3(600, 600, 27),
-      atlasTileDims: new Vector2(27, 1),
-      volumeSize: new Vector3(600, 600, 27),
-      subregionSize: new Vector3(600, 600, 27),
-      subregionOffset: new Vector3(0, 0, 0),
-      physicalPixelSize: new Vector3(1, 1, 2),
-      spatialUnit: "µm",
+      //originalSize: new Vector3(600, 600, 27),
+      atlasTileDims: [27, 1],
+      //volumeSize: new Vector3(600, 600, 27),
+      subregionSize: [600, 600, 27],
+      subregionOffset: [0, 0, 0],
+      //physicalPixelSize: new Vector3(1, 1, 2),
+      //spatialUnit: "µm",
 
-      numChannels: numChannels,
+      combinedNumChannels: numChannels,
       channelNames: chnames,
 
-      times: 1,
-      timeScale: 1,
-      timeUnit: "",
+      //times: 1,
+      //timeScale: 1,
+      //timeUnit: "",
 
-      numMultiscaleLevels: 1,
+      //numMultiscaleLevels: 1,
       multiscaleLevel: 0,
       multiscaleLevelDims: [
         {
@@ -58,8 +59,8 @@ class OpenCellLoader extends ThreadableVolumeLoader {
       ],
 
       transform: {
-        translation: new Vector3(0, 0, 0),
-        rotation: new Vector3(0, 0, 0),
+        translation: [0, 0, 0],
+        rotation: [0, 0, 0],
       },
     };
 
@@ -68,7 +69,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
   }
 
   loadRawChannelData(
-    imageInfo: ImageInfo,
+    imageInfo: ImageInfo2,
     _loadSpec: LoadSpec,
     _onUpdateMetadata: () => void,
     onData: RawChannelDataCallback
@@ -86,8 +87,9 @@ class OpenCellLoader extends ThreadableVolumeLoader {
       },
     ];
 
-    const w = imageInfo.atlasTileDims.x * imageInfo.volumeSize.x;
-    const h = imageInfo.atlasTileDims.y * imageInfo.volumeSize.y;
+    //const w = imageInfo.atlasTileDims[0] * imageInfo.volumeSize.x;
+    //const h = imageInfo.atlasTileDims[1] * imageInfo.volumeSize.y;
+    const [w, h] = computeAtlasSize(imageInfo);
     // all data coming from this loader is natively 8-bit
     return JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, dtype, data) =>
       onData(ch, dtype, data, [DATARANGE_UINT8], [w, h])

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -1,5 +1,3 @@
-import { Vector2, Vector3 } from "three";
-
 import {
   ThreadableVolumeLoader,
   LoadSpec,
@@ -7,7 +5,6 @@ import {
   VolumeDims,
   LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
-import { ImageInfo } from "../Volume.js";
 import { computeAtlasSize, ImageInfo2 } from "../ImageInfo.js";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader.js";
 import { DATARANGE_UINT8 } from "../types.js";

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -27,7 +27,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     // we know these are standardized to 600x600, two channels, one channel per jpg.
     const chnames: string[] = ["DNA", "Structure"];
 
-    const imgdata: ImageInfo = {
+    const imgdata: ImageInfo = <ImageInfo>{
       name: "TEST",
 
       originalSize: new Vector3(600, 600, 27),
@@ -48,7 +48,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
       numMultiscaleLevels: 1,
       multiscaleLevel: 0,
       multiscaleLevelDims: [
-        {
+        <VolumeDims>{
           shape: [1, numChannels, 27, 600, 600],
           spacing: [1, 1, 2, 1, 1],
           spaceUnit: "µm",

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -41,46 +41,47 @@ export interface RawArrayLoaderOptions {
   metadata: RawArrayInfo;
 }
 
-const convertImageInfo = (json: RawArrayInfo): ImageInfo => ({
-  name: json.name,
+const convertImageInfo = (json: RawArrayInfo): ImageInfo =>
+  <ImageInfo>{
+    name: json.name,
 
-  // assumption: the data is already sized to fit in our viewer's preferred
-  // memory footprint (a tiled atlas texture as of this writing)
-  originalSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
-  atlasTileDims: computePackedAtlasDims(json.sizeZ, json.sizeX, json.sizeY),
-  volumeSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
-  subregionSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
-  subregionOffset: new Vector3(0, 0, 0),
-  physicalPixelSize: new Vector3(json.physicalPixelSize[0], json.physicalPixelSize[1], json.physicalPixelSize[2]),
-  spatialUnit: json.spatialUnit || "μm",
+    // assumption: the data is already sized to fit in our viewer's preferred
+    // memory footprint (a tiled atlas texture as of this writing)
+    originalSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
+    atlasTileDims: computePackedAtlasDims(json.sizeZ, json.sizeX, json.sizeY),
+    volumeSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
+    subregionSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
+    subregionOffset: new Vector3(0, 0, 0),
+    physicalPixelSize: new Vector3(json.physicalPixelSize[0], json.physicalPixelSize[1], json.physicalPixelSize[2]),
+    spatialUnit: json.spatialUnit || "μm",
 
-  numChannels: json.sizeC,
-  channelNames: json.channelNames,
-  channelColors: undefined, //json.channelColors,
+    numChannels: json.sizeC,
+    channelNames: json.channelNames,
+    channelColors: undefined, //json.channelColors,
 
-  times: 1,
-  timeScale: 1,
-  timeUnit: "s",
+    times: 1,
+    timeScale: 1,
+    timeUnit: "s",
 
-  numMultiscaleLevels: 1,
-  multiscaleLevel: 0,
-  multiscaleLevelDims: [
-    {
-      shape: [1, json.sizeC, json.sizeZ, json.sizeY, json.sizeX],
-      spacing: [1, 1, json.physicalPixelSize[2], json.physicalPixelSize[1], json.physicalPixelSize[0]],
-      spaceUnit: json.spatialUnit || "μm",
-      timeUnit: "s",
-      dataType: "uint8",
+    numMultiscaleLevels: 1,
+    multiscaleLevel: 0,
+    multiscaleLevelDims: [
+      <VolumeDims>{
+        shape: [1, json.sizeC, json.sizeZ, json.sizeY, json.sizeX],
+        spacing: [1, 1, json.physicalPixelSize[2], json.physicalPixelSize[1], json.physicalPixelSize[0]],
+        spaceUnit: json.spatialUnit || "μm",
+        timeUnit: "s",
+        dataType: "uint8",
+      },
+    ],
+
+    transform: {
+      translation: new Vector3(0, 0, 0),
+      rotation: new Vector3(0, 0, 0),
     },
-  ],
 
-  transform: {
-    translation: new Vector3(0, 0, 0),
-    rotation: new Vector3(0, 0, 0),
-  },
-
-  userData: json.userData,
-});
+    userData: json.userData,
+  };
 
 class RawArrayLoader extends ThreadableVolumeLoader {
   data: RawArrayData;

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -7,8 +7,8 @@ import {
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
-import { ImageInfo } from "../ImageInfo.js";
-import { VolumeDims } from "../VolumeDims.js";
+import type { ImageInfo } from "../ImageInfo.js";
+import type { VolumeDims } from "../VolumeDims.js";
 import { DATARANGE_UINT8, Uint8 } from "../types.js";
 
 // this is the form in which a 4D numpy array arrives as converted

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -8,7 +8,6 @@ import {
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
-import { ImageInfo } from "../Volume.js";
 import { ImageInfo2 } from "../ImageInfo.js";
 import { DATARANGE_UINT8, Uint8 } from "../types.js";
 

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -4,11 +4,11 @@ import {
   ThreadableVolumeLoader,
   type LoadSpec,
   type RawChannelDataCallback,
-  VolumeDims,
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
 import { ImageInfo } from "../ImageInfo.js";
+import { VolumeDims } from "../VolumeDims.js";
 import { DATARANGE_UINT8, Uint8 } from "../types.js";
 
 // this is the form in which a 4D numpy array arrives as converted
@@ -107,11 +107,13 @@ class RawArrayLoader extends ThreadableVolumeLoader {
   async loadDims(_loadSpec: LoadSpec): Promise<VolumeDims[]> {
     const jsonInfo = this.jsonInfo;
 
-    const d = new VolumeDims();
-    d.shape = [1, jsonInfo.sizeC, jsonInfo.sizeZ, jsonInfo.sizeY, jsonInfo.sizeX];
-    d.spacing = [1, 1, jsonInfo.physicalPixelSize[2], jsonInfo.physicalPixelSize[1], jsonInfo.physicalPixelSize[0]];
-    d.spaceUnit = jsonInfo.spatialUnit || "μm";
-    d.dataType = "uint8";
+    const d: VolumeDims = {
+      shape: [1, jsonInfo.sizeC, jsonInfo.sizeZ, jsonInfo.sizeY, jsonInfo.sizeX],
+      spacing: [1, 1, jsonInfo.physicalPixelSize[2], jsonInfo.physicalPixelSize[1], jsonInfo.physicalPixelSize[0]],
+      spaceUnit: jsonInfo.spatialUnit || "μm",
+      dataType: "uint8",
+      timeUnit: "s", // time unit not specified
+    };
     return [d];
   }
 

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -8,7 +8,7 @@ import {
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
-import { ImageInfo2 } from "../ImageInfo.js";
+import { ImageInfo } from "../ImageInfo.js";
 import { DATARANGE_UINT8, Uint8 } from "../types.js";
 
 // this is the form in which a 4D numpy array arrives as converted
@@ -41,7 +41,7 @@ export interface RawArrayLoaderOptions {
   metadata: RawArrayInfo;
 }
 
-const convertImageInfo = (json: RawArrayInfo): ImageInfo2 => {
+const convertImageInfo = (json: RawArrayInfo): ImageInfo => {
   const atlasTileDims = computePackedAtlasDims(json.sizeZ, json.sizeX, json.sizeY);
   return {
     name: json.name,
@@ -120,7 +120,7 @@ class RawArrayLoader extends ThreadableVolumeLoader {
   }
 
   loadRawChannelData(
-    imageInfo: ImageInfo2,
+    imageInfo: ImageInfo,
     loadSpec: LoadSpec,
     onUpdateMetadata: (imageInfo: undefined, loadSpec: LoadSpec) => void,
     onData: RawChannelDataCallback

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -48,23 +48,14 @@ const convertImageInfo = (json: RawArrayInfo): ImageInfo => {
 
     // assumption: the data is already sized to fit in our viewer's preferred
     // memory footprint (a tiled atlas texture as of this writing)
-    //originalSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
     atlasTileDims: [atlasTileDims.x, atlasTileDims.y],
-    //volumeSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
     subregionSize: [json.sizeX, json.sizeY, json.sizeZ],
     subregionOffset: [0, 0, 0],
-    //physicalPixelSize: new Vector3(json.physicalPixelSize[0], json.physicalPixelSize[1], json.physicalPixelSize[2]),
-    //spatialUnit: json.spatialUnit || "μm",
 
     combinedNumChannels: json.sizeC,
     channelNames: json.channelNames,
-    channelColors: undefined, //json.channelColors,
+    channelColors: undefined,
 
-    //times: 1,
-    //timeScale: 1,
-    //timeUnit: "s",
-
-    //numMultiscaleLevels: 1,
     multiscaleLevel: 0,
     multiscaleLevelDims: [
       {

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -41,47 +41,46 @@ export interface RawArrayLoaderOptions {
   metadata: RawArrayInfo;
 }
 
-const convertImageInfo = (json: RawArrayInfo): ImageInfo =>
-  <ImageInfo>{
-    name: json.name,
+const convertImageInfo = (json: RawArrayInfo): ImageInfo => ({
+  name: json.name,
 
-    // assumption: the data is already sized to fit in our viewer's preferred
-    // memory footprint (a tiled atlas texture as of this writing)
-    originalSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
-    atlasTileDims: computePackedAtlasDims(json.sizeZ, json.sizeX, json.sizeY),
-    volumeSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
-    subregionSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
-    subregionOffset: new Vector3(0, 0, 0),
-    physicalPixelSize: new Vector3(json.physicalPixelSize[0], json.physicalPixelSize[1], json.physicalPixelSize[2]),
-    spatialUnit: json.spatialUnit || "μm",
+  // assumption: the data is already sized to fit in our viewer's preferred
+  // memory footprint (a tiled atlas texture as of this writing)
+  originalSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
+  atlasTileDims: computePackedAtlasDims(json.sizeZ, json.sizeX, json.sizeY),
+  volumeSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
+  subregionSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
+  subregionOffset: new Vector3(0, 0, 0),
+  physicalPixelSize: new Vector3(json.physicalPixelSize[0], json.physicalPixelSize[1], json.physicalPixelSize[2]),
+  spatialUnit: json.spatialUnit || "μm",
 
-    numChannels: json.sizeC,
-    channelNames: json.channelNames,
-    channelColors: undefined, //json.channelColors,
+  numChannels: json.sizeC,
+  channelNames: json.channelNames,
+  channelColors: undefined, //json.channelColors,
 
-    times: 1,
-    timeScale: 1,
-    timeUnit: "s",
+  times: 1,
+  timeScale: 1,
+  timeUnit: "s",
 
-    numMultiscaleLevels: 1,
-    multiscaleLevel: 0,
-    multiscaleLevelDims: [
-      <VolumeDims>{
-        shape: [1, json.sizeC, json.sizeZ, json.sizeY, json.sizeX],
-        spacing: [1, 1, json.physicalPixelSize[2], json.physicalPixelSize[1], json.physicalPixelSize[0]],
-        spaceUnit: json.spatialUnit || "μm",
-        timeUnit: "s",
-        dataType: "uint8",
-      },
-    ],
-
-    transform: {
-      translation: new Vector3(0, 0, 0),
-      rotation: new Vector3(0, 0, 0),
+  numMultiscaleLevels: 1,
+  multiscaleLevel: 0,
+  multiscaleLevelDims: [
+    {
+      shape: [1, json.sizeC, json.sizeZ, json.sizeY, json.sizeX],
+      spacing: [1, 1, json.physicalPixelSize[2], json.physicalPixelSize[1], json.physicalPixelSize[0]],
+      spaceUnit: json.spatialUnit || "μm",
+      timeUnit: "s",
+      dataType: "uint8",
     },
+  ],
 
-    userData: json.userData,
-  };
+  transform: {
+    translation: new Vector3(0, 0, 0),
+    rotation: new Vector3(0, 0, 0),
+  },
+
+  userData: json.userData,
+});
 
 class RawArrayLoader extends ThreadableVolumeLoader {
   data: RawArrayData;

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -9,6 +9,7 @@ import {
 } from "./IVolumeLoader.js";
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
 import { ImageInfo } from "../Volume.js";
+import { ImageInfo2 } from "../ImageInfo.js";
 import { DATARANGE_UINT8, Uint8 } from "../types.js";
 
 // this is the form in which a 4D numpy array arrives as converted
@@ -41,46 +42,49 @@ export interface RawArrayLoaderOptions {
   metadata: RawArrayInfo;
 }
 
-const convertImageInfo = (json: RawArrayInfo): ImageInfo => ({
-  name: json.name,
+const convertImageInfo = (json: RawArrayInfo): ImageInfo2 => {
+  const atlasTileDims = computePackedAtlasDims(json.sizeZ, json.sizeX, json.sizeY);
+  return {
+    name: json.name,
 
-  // assumption: the data is already sized to fit in our viewer's preferred
-  // memory footprint (a tiled atlas texture as of this writing)
-  originalSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
-  atlasTileDims: computePackedAtlasDims(json.sizeZ, json.sizeX, json.sizeY),
-  volumeSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
-  subregionSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
-  subregionOffset: new Vector3(0, 0, 0),
-  physicalPixelSize: new Vector3(json.physicalPixelSize[0], json.physicalPixelSize[1], json.physicalPixelSize[2]),
-  spatialUnit: json.spatialUnit || "μm",
+    // assumption: the data is already sized to fit in our viewer's preferred
+    // memory footprint (a tiled atlas texture as of this writing)
+    //originalSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
+    atlasTileDims: [atlasTileDims.x, atlasTileDims.y],
+    //volumeSize: new Vector3(json.sizeX, json.sizeY, json.sizeZ),
+    subregionSize: [json.sizeX, json.sizeY, json.sizeZ],
+    subregionOffset: [0, 0, 0],
+    //physicalPixelSize: new Vector3(json.physicalPixelSize[0], json.physicalPixelSize[1], json.physicalPixelSize[2]),
+    //spatialUnit: json.spatialUnit || "μm",
 
-  numChannels: json.sizeC,
-  channelNames: json.channelNames,
-  channelColors: undefined, //json.channelColors,
+    combinedNumChannels: json.sizeC,
+    channelNames: json.channelNames,
+    channelColors: undefined, //json.channelColors,
 
-  times: 1,
-  timeScale: 1,
-  timeUnit: "s",
+    //times: 1,
+    //timeScale: 1,
+    //timeUnit: "s",
 
-  numMultiscaleLevels: 1,
-  multiscaleLevel: 0,
-  multiscaleLevelDims: [
-    {
-      shape: [1, json.sizeC, json.sizeZ, json.sizeY, json.sizeX],
-      spacing: [1, 1, json.physicalPixelSize[2], json.physicalPixelSize[1], json.physicalPixelSize[0]],
-      spaceUnit: json.spatialUnit || "μm",
-      timeUnit: "s",
-      dataType: "uint8",
+    //numMultiscaleLevels: 1,
+    multiscaleLevel: 0,
+    multiscaleLevelDims: [
+      {
+        shape: [1, json.sizeC, json.sizeZ, json.sizeY, json.sizeX],
+        spacing: [1, 1, json.physicalPixelSize[2], json.physicalPixelSize[1], json.physicalPixelSize[0]],
+        spaceUnit: json.spatialUnit || "μm",
+        timeUnit: "s",
+        dataType: "uint8",
+      },
+    ],
+
+    transform: {
+      translation: [0, 0, 0],
+      rotation: [0, 0, 0],
     },
-  ],
 
-  transform: {
-    translation: new Vector3(0, 0, 0),
-    rotation: new Vector3(0, 0, 0),
-  },
-
-  userData: json.userData,
-});
+    userData: json.userData,
+  };
+};
 
 class RawArrayLoader extends ThreadableVolumeLoader {
   data: RawArrayData;
@@ -117,7 +121,7 @@ class RawArrayLoader extends ThreadableVolumeLoader {
   }
 
   loadRawChannelData(
-    imageInfo: ImageInfo,
+    imageInfo: ImageInfo2,
     loadSpec: LoadSpec,
     onUpdateMetadata: (imageInfo: undefined, loadSpec: LoadSpec) => void,
     onData: RawChannelDataCallback
@@ -132,7 +136,7 @@ class RawArrayLoader extends ThreadableVolumeLoader {
     };
     onUpdateMetadata(undefined, adjustedLoadSpec);
 
-    for (let chindex = 0; chindex < imageInfo.numChannels; ++chindex) {
+    for (let chindex = 0; chindex < imageInfo.combinedNumChannels; ++chindex) {
       if (requestedChannels && requestedChannels.length > 0 && !requestedChannels.includes(chindex)) {
         continue;
       }

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -48,6 +48,24 @@ class OMEDims {
   channelnames: string[] = [];
 }
 
+function getDtype(omepixeltype: string): NumberType {
+  const mapping: Record<string, NumberType> = {
+    uint8: "uint8",
+    uint16: "uint16",
+    uint32: "uint32",
+    int8: "int8",
+    int16: "int16",
+    int32: "int32",
+    float: "float32",
+  };
+  const dtype = mapping[omepixeltype];
+  if (dtype === undefined) {
+    // TODO consider throwing an error?
+    return "uint8";
+  }
+  return dtype;
+}
+
 export type TiffWorkerParams = {
   channel: number;
   tilesizex: number;
@@ -143,8 +161,7 @@ class TiffLoader extends ThreadableVolumeLoader {
       shape: [dims.sizet, dims.sizec, dims.sizez, dims.sizey, dims.sizex],
       spacing: [1, 1, dims.pixelsizez, dims.pixelsizey, dims.pixelsizex],
       spaceUnit: dims.unit ? dims.unit : "micron",
-      // TODO reconcile OMEDims pixel type with NumberType
-      dataType: dims.pixeltype ? (dims.pixeltype as NumberType) : "uint8",
+      dataType: getDtype(dims.pixeltype),
       timeUnit: "s",
     };
     return [d];
@@ -192,8 +209,7 @@ class TiffLoader extends ThreadableVolumeLoader {
           spacing: [1, 1, dims.pixelsizez, dims.pixelsizey, dims.pixelsizex],
           spaceUnit: dims.unit || "",
           timeUnit: "",
-          // TODO reconcile NumberType with OMEDims pixel type
-          dataType: (dims.pixeltype as NumberType) || "uint8",
+          dataType: getDtype(dims.pixeltype),
         },
       ],
 

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -10,7 +10,7 @@ import {
 } from "./IVolumeLoader.js";
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
 import { VolumeLoadError, VolumeLoadErrorType, wrapVolumeLoadError } from "./VolumeLoadError.js";
-import { type ImageInfo2, CImageInfo } from "../ImageInfo.js";
+import { type ImageInfo, CImageInfo } from "../ImageInfo.js";
 import { TypedArray, NumberType } from "../types.js";
 
 function prepareXML(xml: string): string {
@@ -163,7 +163,7 @@ class TiffLoader extends ThreadableVolumeLoader {
 
     // load tiff and check metadata
 
-    const imgdata: ImageInfo2 = {
+    const imgdata: ImageInfo = {
       name: "TEST",
 
       //originalSize: new Vector3(dims.sizex, dims.sizey, dims.sizez),
@@ -205,7 +205,7 @@ class TiffLoader extends ThreadableVolumeLoader {
   }
 
   async loadRawChannelData(
-    imageInfo: ImageInfo2,
+    imageInfo: ImageInfo,
     _loadSpec: LoadSpec,
     _onUpdateMetadata: () => void,
     onData: RawChannelDataCallback

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -10,7 +10,7 @@ import {
 import { computePackedAtlasDims, MAX_ATLAS_EDGE } from "./VolumeLoaderUtils.js";
 import { VolumeLoadError, VolumeLoadErrorType, wrapVolumeLoadError } from "./VolumeLoadError.js";
 import { type ImageInfo, CImageInfo } from "../ImageInfo.js";
-import { VolumeDims } from "../VolumeDims.js";
+import type { VolumeDims } from "../VolumeDims.js";
 import { TypedArray, NumberType } from "../types.js";
 
 function prepareXML(xml: string): string {

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -164,7 +164,7 @@ class TiffLoader extends ThreadableVolumeLoader {
 
     // load tiff and check metadata
 
-    const imgdata: ImageInfo = {
+    const imgdata: ImageInfo = <ImageInfo>{
       name: "TEST",
 
       originalSize: new Vector3(dims.sizex, dims.sizey, dims.sizez),
@@ -185,7 +185,7 @@ class TiffLoader extends ThreadableVolumeLoader {
       numMultiscaleLevels: 1,
       multiscaleLevel: 0,
       multiscaleLevelDims: [
-        {
+        <VolumeDims>{
           shape: [dims.sizet, dims.sizec, dims.sizez, dims.sizey, dims.sizex],
           spacing: [1, 1, dims.pixelsizez, dims.pixelsizey, dims.pixelsizex],
           spaceUnit: dims.unit || "",

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -5,12 +5,12 @@ import {
   ThreadableVolumeLoader,
   LoadSpec,
   type RawChannelDataCallback,
-  VolumeDims,
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
 import { VolumeLoadError, VolumeLoadErrorType, wrapVolumeLoadError } from "./VolumeLoadError.js";
 import { type ImageInfo, CImageInfo } from "../ImageInfo.js";
+import { VolumeDims } from "../VolumeDims.js";
 import { TypedArray, NumberType } from "../types.js";
 
 function prepareXML(xml: string): string {
@@ -139,11 +139,14 @@ class TiffLoader extends ThreadableVolumeLoader {
   async loadDims(_loadSpec: LoadSpec): Promise<VolumeDims[]> {
     const dims = await this.loadOmeDims();
 
-    const d = new VolumeDims();
-    d.shape = [dims.sizet, dims.sizec, dims.sizez, dims.sizey, dims.sizex];
-    d.spacing = [1, 1, dims.pixelsizez, dims.pixelsizey, dims.pixelsizex];
-    d.spaceUnit = dims.unit ? dims.unit : "micron";
-    d.dataType = dims.pixeltype ? dims.pixeltype : "uint8";
+    const d: VolumeDims = {
+      shape: [dims.sizet, dims.sizec, dims.sizez, dims.sizey, dims.sizex],
+      spacing: [1, 1, dims.pixelsizez, dims.pixelsizey, dims.pixelsizex],
+      spaceUnit: dims.unit ? dims.unit : "micron",
+      // TODO reconcile OMEDims pixel type with NumberType
+      dataType: dims.pixeltype ? (dims.pixeltype as NumberType) : "uint8",
+      timeUnit: "s",
+    };
     return [d];
   }
 

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -7,7 +7,7 @@ import {
   type RawChannelDataCallback,
   type LoadedVolumeInfo,
 } from "./IVolumeLoader.js";
-import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
+import { computePackedAtlasDims, MAX_ATLAS_EDGE } from "./VolumeLoaderUtils.js";
 import { VolumeLoadError, VolumeLoadErrorType, wrapVolumeLoadError } from "./VolumeLoadError.js";
 import { type ImageInfo, CImageInfo } from "../ImageInfo.js";
 import { VolumeDims } from "../VolumeDims.js";
@@ -157,9 +157,21 @@ class TiffLoader extends ThreadableVolumeLoader {
   async loadDims(_loadSpec: LoadSpec): Promise<VolumeDims[]> {
     const dims = await this.loadOmeDims();
 
+    const atlasDims = computePackedAtlasDims(dims.sizez, dims.sizex, dims.sizey);
+    // fit tiles to max of 2048x2048?
+    const targetSize = MAX_ATLAS_EDGE;
+    const tilesizex = Math.floor(targetSize / atlasDims.x);
+    const tilesizey = Math.floor(targetSize / atlasDims.y);
+
     const d: VolumeDims = {
-      shape: [dims.sizet, dims.sizec, dims.sizez, dims.sizey, dims.sizex],
-      spacing: [1, 1, dims.pixelsizez, dims.pixelsizey, dims.pixelsizex],
+      shape: [dims.sizet, dims.sizec, dims.sizez, tilesizey, tilesizex],
+      spacing: [
+        1,
+        1,
+        dims.pixelsizez,
+        (dims.pixelsizey * dims.sizey) / tilesizey,
+        (dims.pixelsizex * dims.sizex) / tilesizex,
+      ],
       spaceUnit: dims.unit ? dims.unit : "micron",
       dataType: getDtype(dims.pixeltype),
       timeUnit: "s",
@@ -177,7 +189,7 @@ class TiffLoader extends ThreadableVolumeLoader {
     // TODO allow ROI selection: range of x,y,z,c for a given t
     const atlasDims = computePackedAtlasDims(dims.sizez, dims.sizex, dims.sizey);
     // fit tiles to max of 2048x2048?
-    const targetSize = 2048;
+    const targetSize = MAX_ATLAS_EDGE;
     const tilesizex = Math.floor(targetSize / atlasDims.x);
     const tilesizey = Math.floor(targetSize / atlasDims.y);
 
@@ -186,27 +198,22 @@ class TiffLoader extends ThreadableVolumeLoader {
     const imgdata: ImageInfo = {
       name: "TEST",
 
-      //originalSize: new Vector3(dims.sizex, dims.sizey, dims.sizez),
       atlasTileDims: [atlasDims.x, atlasDims.y],
-      //volumeSize: new Vector3(tilesizex, tilesizey, dims.sizez),
       subregionSize: [tilesizex, tilesizey, dims.sizez],
       subregionOffset: [0, 0, 0],
-      //physicalPixelSize: new Vector3(dims.pixelsizex, dims.pixelsizey, dims.pixelsizez),
-      //spatialUnit: dims.unit || "",
-
       combinedNumChannels: dims.sizec,
       channelNames: dims.channelnames,
-
-      //times: dims.sizet,
-      //timeScale: 1,
-      //timeUnit: "",
-
-      //numMultiscaleLevels: 1,
       multiscaleLevel: 0,
       multiscaleLevelDims: [
         {
-          shape: [dims.sizet, dims.sizec, dims.sizez, dims.sizey, dims.sizex],
-          spacing: [1, 1, dims.pixelsizez, dims.pixelsizey, dims.pixelsizex],
+          shape: [dims.sizet, dims.sizec, dims.sizez, tilesizey, tilesizex],
+          spacing: [
+            1,
+            1,
+            dims.pixelsizez,
+            (dims.pixelsizey * dims.sizey) / tilesizey,
+            (dims.pixelsizex * dims.sizex) / tilesizex,
+          ],
           spaceUnit: dims.unit || "",
           timeUnit: "",
           dataType: getDtype(dims.pixeltype),

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -164,7 +164,7 @@ class TiffLoader extends ThreadableVolumeLoader {
 
     // load tiff and check metadata
 
-    const imgdata: ImageInfo = <ImageInfo>{
+    const imgdata: ImageInfo = {
       name: "TEST",
 
       originalSize: new Vector3(dims.sizex, dims.sizey, dims.sizez),
@@ -185,7 +185,7 @@ class TiffLoader extends ThreadableVolumeLoader {
       numMultiscaleLevels: 1,
       multiscaleLevel: 0,
       multiscaleLevelDims: [
-        <VolumeDims>{
+        {
           shape: [dims.sizet, dims.sizec, dims.sizez, dims.sizey, dims.sizex],
           spacing: [1, 1, dims.pixelsizez, dims.pixelsizey, dims.pixelsizex],
           spaceUnit: dims.unit || "",

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -60,7 +60,7 @@ function getDtype(omepixeltype: string): NumberType {
   };
   const dtype = mapping[omepixeltype];
   if (dtype === undefined) {
-    // TODO consider throwing an error?
+    console.warn(`Unsupported OME pixel type ${omepixeltype}; defaulting to uint8`);
     return "uint8";
   }
   return dtype;

--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -1,5 +1,4 @@
 import { fromUrl } from "geotiff";
-import { Vector3 } from "three";
 import { ErrorObject, deserializeError } from "serialize-error";
 
 import {
@@ -11,7 +10,6 @@ import {
 } from "./IVolumeLoader.js";
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
 import { VolumeLoadError, VolumeLoadErrorType, wrapVolumeLoadError } from "./VolumeLoadError.js";
-import type { ImageInfo } from "../Volume.js";
 import { type ImageInfo2, CImageInfo } from "../ImageInfo.js";
 import { TypedArray, NumberType } from "../types.js";
 

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -1,6 +1,7 @@
 import { Box3, Vector2, Vector3 } from "three";
 
 import { ImageInfo } from "../Volume.js";
+import { CImageInfo, ImageInfo2 } from "../ImageInfo.js";
 import { LoadSpec } from "./IVolumeLoader.js";
 
 export const MAX_ATLAS_EDGE = 4096;
@@ -220,7 +221,9 @@ function isEmpty(obj) {
 
 // currently everything needed can come from the imageInfo
 // but in the future each IVolumeLoader could have a completely separate implementation.
-export function buildDefaultMetadata(imageInfo: ImageInfo): Record<string, unknown> {
+export function buildDefaultMetadata(rawImageInfo: ImageInfo2): Record<string, unknown> {
+  // wrap
+  const imageInfo = new CImageInfo(rawImageInfo);
   const physicalSize = imageInfo.volumeSize.clone().multiply(imageInfo.physicalPixelSize);
   const metadata = {};
   metadata["Dimensions"] = { ...imageInfo.subregionSize };
@@ -235,12 +238,13 @@ export function buildDefaultMetadata(imageInfo: ImageInfo): Record<string, unkno
     y: imageInfo.physicalPixelSize.y + imageInfo.spatialUnit,
     z: imageInfo.physicalPixelSize.z + imageInfo.spatialUnit,
   };
-  metadata["Multiresolution levels"] = imageInfo.multiscaleLevelDims;
-  metadata["Channels"] = imageInfo.numChannels;
+  metadata["Multiresolution levels"] = rawImageInfo.multiscaleLevelDims;
+  // TODO decide???? combined or not?
+  metadata["Channels"] = rawImageInfo.combinedNumChannels; //imageInfo.numChannels;
   metadata["Time series frames"] = imageInfo.times || 1;
   // don't add User data if it's empty
-  if (imageInfo.userData && !isEmpty(imageInfo.userData)) {
-    metadata["User data"] = imageInfo.userData;
+  if (rawImageInfo.userData && !isEmpty(rawImageInfo.userData)) {
+    metadata["User data"] = rawImageInfo.userData;
   }
   return metadata;
 }

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -1,6 +1,5 @@
 import { Box3, Vector2, Vector3 } from "three";
 
-import { ImageInfo } from "../Volume.js";
 import { CImageInfo, ImageInfo2 } from "../ImageInfo.js";
 import { LoadSpec } from "./IVolumeLoader.js";
 

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -1,6 +1,6 @@
 import { Box3, Vector2, Vector3 } from "three";
 
-import { CImageInfo, ImageInfo } from "../ImageInfo.js";
+import { CImageInfo, type ImageInfo } from "../ImageInfo.js";
 import { LoadSpec } from "./IVolumeLoader.js";
 
 export const MAX_ATLAS_EDGE = 4096;

--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -1,6 +1,6 @@
 import { Box3, Vector2, Vector3 } from "three";
 
-import { CImageInfo, ImageInfo2 } from "../ImageInfo.js";
+import { CImageInfo, ImageInfo } from "../ImageInfo.js";
 import { LoadSpec } from "./IVolumeLoader.js";
 
 export const MAX_ATLAS_EDGE = 4096;
@@ -220,7 +220,7 @@ function isEmpty(obj) {
 
 // currently everything needed can come from the imageInfo
 // but in the future each IVolumeLoader could have a completely separate implementation.
-export function buildDefaultMetadata(rawImageInfo: ImageInfo2): Record<string, unknown> {
+export function buildDefaultMetadata(rawImageInfo: ImageInfo): Record<string, unknown> {
   // wrap
   const imageInfo = new CImageInfo(rawImageInfo);
   const physicalSize = imageInfo.volumeSize.clone().multiply(imageInfo.physicalPixelSize);

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -6,20 +6,22 @@ import VolumeMaker from "../VolumeMaker";
 import { LUT_ARRAY_LENGTH } from "../Lut";
 import Channel from "../Channel";
 import { DATARANGE_UINT8 } from "../types";
+import { CImageInfo, ImageInfo2 } from "../ImageInfo";
 
 // PREPARE SOME TEST DATA TO TRY TO DISPLAY A VOLUME.
-const testimgdata: ImageInfo = {
+const testimgdata: ImageInfo2 = {
   name: "AICS-10_5_5",
 
-  originalSize: new Vector3(306, 494, 65),
-  atlasTileDims: new Vector2(7, 10),
-  volumeSize: new Vector3(204, 292, 65),
-  subregionSize: new Vector3(204, 292, 65),
-  subregionOffset: new Vector3(0, 0, 0),
-  physicalPixelSize: new Vector3(0.065, 0.065, 0.29),
-  spatialUnit: "",
+  //originalSize: new Vector3(306, 494, 65),
+  atlasTileDims: [7, 10],
+  //volumeSize: new Vector3(204, 292, 65),
+  subregionSize: [204, 292, 65],
+  subregionOffset: [0, 0, 0],
+  //physicalPixelSize: new Vector3(0.065, 0.065, 0.29),
+  //spatialUnit: "",
 
-  numChannels: 9,
+  //numChannels: 9
+  combinedNumChannels: 9,
   channelNames: [
     "DRAQ5",
     "EGFP",
@@ -32,15 +34,15 @@ const testimgdata: ImageInfo = {
     "CON_DNA",
   ],
 
-  times: 1,
-  timeScale: 1,
-  timeUnit: "",
+  //times: 1,
+  //timeScale: 1,
+  //timeUnit: "",
 
-  numMultiscaleLevels: 1,
+  //numMultiscaleLevels: 1,
   multiscaleLevel: 0,
   multiscaleLevelDims: [
     {
-      shape: [1, 1, 65, 494, 306],
+      shape: [1, 9, 65, 494, 306],
       spacing: [1, 1, 0.29, 0.065, 0.065],
       spaceUnit: "",
       timeUnit: "",
@@ -49,32 +51,32 @@ const testimgdata: ImageInfo = {
   ],
 
   transform: {
-    translation: new Vector3(0, 0, 0),
-    rotation: new Vector3(0, 0, 0),
+    translation: [0, 0, 0],
+    rotation: [0, 0, 0],
   },
 };
 
-function checkVolumeConstruction(v: Volume, imgdata: ImageInfo) {
+function checkVolumeConstruction(v: Volume, imgdata: ImageInfo2) {
   expect(v).to.be.a("Object");
   expect(v.isLoaded()).to.not.be.ok;
 
-  const { originalSize, physicalPixelSize } = imgdata;
+  const { originalSize, physicalPixelSize } = new CImageInfo(imgdata);
   const physicalSize = originalSize.clone().multiply(physicalPixelSize);
   expect(v.physicalSize.x).to.equal(physicalSize.x);
   expect(v.physicalSize.y).to.equal(physicalSize.y);
   expect(v.physicalSize.z).to.equal(physicalSize.z);
-  expect(v.channelNames.length).to.equal(imgdata.numChannels);
-  expect(v.channels.length).to.equal(imgdata.numChannels);
+  expect(v.channelNames.length).to.equal(imgdata.combinedNumChannels);
+  expect(v.channels.length).to.equal(imgdata.combinedNumChannels);
 
   const mx = Math.max(Math.max(v.normPhysicalSize.x, v.normPhysicalSize.y), v.normPhysicalSize.z);
   expect(mx).to.equal(1.0);
 }
 
-function checkChannelDataConstruction(c: Channel, index: number, imgdata: ImageInfo) {
+function checkChannelDataConstruction(c: Channel, index: number, imgdata: ImageInfo2) {
   expect(c.loaded).to.be.true;
   expect(c.name).to.equal(imgdata.channelNames[index]);
-  const atlasWidth = imgdata.atlasTileDims.x * imgdata.subregionSize.x;
-  const atlasHeight = imgdata.atlasTileDims.y * imgdata.subregionSize.y;
+  const atlasWidth = imgdata.atlasTileDims[0] * imgdata.subregionSize[0];
+  const atlasHeight = imgdata.atlasTileDims[1] * imgdata.subregionSize[1];
   expect(c.imgData.width).to.equal(atlasWidth);
   expect(c.imgData.height).to.equal(atlasHeight);
   expect(c.imgData.data).to.be.a("Uint8Array");

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -41,8 +41,9 @@ const testimgdata: ImageInfo = {
   multiscaleLevel: 0,
   multiscaleLevelDims: [
     {
-      shape: [1, 9, 65, 494, 306],
-      spacing: [1, 1, 0.29, 0.065, 0.065],
+      shape: [1, 9, 65, 292, 204],
+      // original volume had 0.065 um pixels in x and y, 0.29 um pixels in z, and 65x494x306 voxels
+      spacing: [1, 1, 0.29, (0.065 * 494) / 292, (0.065 * 306) / 204],
       spaceUnit: "",
       timeUnit: "",
       dataType: "uint8",
@@ -120,13 +121,15 @@ describe("test volume", () => {
       // on `scale` and `normPhysicalSize` being equal. With `scale` gone, this test ensures the equality stays.
       const v = new Volume(testimgdata);
       const { originalSize, physicalPixelSize } = v.imageInfo;
-      const sizemax = Math.max(originalSize.x, originalSize.y, originalSize.z);
+      const sizemax = Math.max(
+        originalSize.x * physicalPixelSize.x,
+        originalSize.y * physicalPixelSize.y,
+        originalSize.z * physicalPixelSize.z
+      );
 
-      const pxmin = Math.min(physicalPixelSize.x, physicalPixelSize.y, physicalPixelSize.z);
-
-      const sx = ((physicalPixelSize.x / pxmin) * originalSize.x) / sizemax;
-      const sy = ((physicalPixelSize.y / pxmin) * originalSize.y) / sizemax;
-      const sz = ((physicalPixelSize.z / pxmin) * originalSize.z) / sizemax;
+      const sx = (physicalPixelSize.x * originalSize.x) / sizemax;
+      const sy = (physicalPixelSize.y * originalSize.y) / sizemax;
+      const sz = (physicalPixelSize.z * originalSize.z) / sizemax;
 
       const EPSILON = 0.000000001;
       expect(v.normPhysicalSize.x).to.be.closeTo(sx, EPSILON);

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -6,9 +6,10 @@ import VolumeMaker from "../VolumeMaker";
 import { LUT_ARRAY_LENGTH } from "../Lut";
 import Channel from "../Channel";
 import { DATARANGE_UINT8 } from "../types";
+import { VolumeDims } from "../loaders/IVolumeLoader";
 
 // PREPARE SOME TEST DATA TO TRY TO DISPLAY A VOLUME.
-const testimgdata: ImageInfo = {
+const testimgdata: ImageInfo = <ImageInfo>{
   name: "AICS-10_5_5",
 
   originalSize: new Vector3(306, 494, 65),
@@ -39,7 +40,7 @@ const testimgdata: ImageInfo = {
   numMultiscaleLevels: 1,
   multiscaleLevel: 0,
   multiscaleLevelDims: [
-    {
+    <VolumeDims>{
       shape: [1, 1, 65, 494, 306],
       spacing: [1, 1, 0.29, 0.065, 0.065],
       spaceUnit: "",

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -6,10 +6,9 @@ import VolumeMaker from "../VolumeMaker";
 import { LUT_ARRAY_LENGTH } from "../Lut";
 import Channel from "../Channel";
 import { DATARANGE_UINT8 } from "../types";
-import { VolumeDims } from "../loaders/IVolumeLoader";
 
 // PREPARE SOME TEST DATA TO TRY TO DISPLAY A VOLUME.
-const testimgdata: ImageInfo = <ImageInfo>{
+const testimgdata: ImageInfo = {
   name: "AICS-10_5_5",
 
   originalSize: new Vector3(306, 494, 65),
@@ -40,7 +39,7 @@ const testimgdata: ImageInfo = <ImageInfo>{
   numMultiscaleLevels: 1,
   multiscaleLevel: 0,
   multiscaleLevelDims: [
-    <VolumeDims>{
+    {
       shape: [1, 1, 65, 494, 306],
       spacing: [1, 1, 0.29, 0.065, 0.065],
       spaceUnit: "",

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -5,10 +5,10 @@ import VolumeMaker from "../VolumeMaker";
 import { LUT_ARRAY_LENGTH } from "../Lut";
 import Channel from "../Channel";
 import { DATARANGE_UINT8 } from "../types";
-import { CImageInfo, ImageInfo2 } from "../ImageInfo";
+import { CImageInfo, ImageInfo } from "../ImageInfo";
 
 // PREPARE SOME TEST DATA TO TRY TO DISPLAY A VOLUME.
-const testimgdata: ImageInfo2 = {
+const testimgdata: ImageInfo = {
   name: "AICS-10_5_5",
 
   //originalSize: new Vector3(306, 494, 65),
@@ -55,7 +55,7 @@ const testimgdata: ImageInfo2 = {
   },
 };
 
-function checkVolumeConstruction(v: Volume, imgdata: ImageInfo2) {
+function checkVolumeConstruction(v: Volume, imgdata: ImageInfo) {
   expect(v).to.be.a("Object");
   expect(v.isLoaded()).to.not.be.ok;
 
@@ -71,7 +71,7 @@ function checkVolumeConstruction(v: Volume, imgdata: ImageInfo2) {
   expect(mx).to.equal(1.0);
 }
 
-function checkChannelDataConstruction(c: Channel, index: number, imgdata: ImageInfo2) {
+function checkChannelDataConstruction(c: Channel, index: number, imgdata: ImageInfo) {
   expect(c.loaded).to.be.true;
   expect(c.name).to.equal(imgdata.channelNames[index]);
   const atlasWidth = imgdata.atlasTileDims[0] * imgdata.subregionSize[0];

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
-import { Vector2, Vector3 } from "three";
 
-import Volume, { ImageInfo } from "../Volume";
+import Volume from "../Volume";
 import VolumeMaker from "../VolumeMaker";
 import { LUT_ARRAY_LENGTH } from "../Lut";
 import Channel from "../Channel";

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -11,15 +11,9 @@ import { CImageInfo, ImageInfo } from "../ImageInfo";
 const testimgdata: ImageInfo = {
   name: "AICS-10_5_5",
 
-  //originalSize: new Vector3(306, 494, 65),
   atlasTileDims: [7, 10],
-  //volumeSize: new Vector3(204, 292, 65),
   subregionSize: [204, 292, 65],
   subregionOffset: [0, 0, 0],
-  //physicalPixelSize: new Vector3(0.065, 0.065, 0.29),
-  //spatialUnit: "",
-
-  //numChannels: 9
   combinedNumChannels: 9,
   channelNames: [
     "DRAQ5",
@@ -32,12 +26,6 @@ const testimgdata: ImageInfo = {
     "CON_Memb",
     "CON_DNA",
   ],
-
-  //times: 1,
-  //timeScale: 1,
-  //timeUnit: "",
-
-  //numMultiscaleLevels: 1,
   multiscaleLevel: 0,
   multiscaleLevelDims: [
     {

--- a/src/workers/VolumeLoadWorker.ts
+++ b/src/workers/VolumeLoadWorker.ts
@@ -8,7 +8,7 @@ import RequestQueue from "../utils/RequestQueue.js";
 import SubscribableRequestQueue from "../utils/SubscribableRequestQueue.js";
 import type { WorkerRequest, WorkerRequestPayload, WorkerResponse, WorkerResponsePayload } from "./types.js";
 import { WorkerEventType, WorkerMsgType, WorkerResponseResult } from "./types.js";
-import { rebuildImageInfo, rebuildLoadSpec } from "./util.js";
+import { rebuildLoadSpec } from "./util.js";
 
 let cache: VolumeCache | undefined = undefined;
 let queue: RequestQueue | undefined = undefined;
@@ -59,7 +59,7 @@ const messageHandlers: { [T in WorkerMsgType]: MessageHandler<T> } = {
     }
 
     return loader.loadRawChannelData(
-      rebuildImageInfo(imageInfo),
+      imageInfo,
       rebuildLoadSpec(loadSpec),
       (imageInfo, loadSpec) => {
         const message: WorkerResponse<WorkerMsgType> = {

--- a/src/workers/VolumeLoaderContext.ts
+++ b/src/workers/VolumeLoaderContext.ts
@@ -1,7 +1,6 @@
 import { deserializeError } from "serialize-error";
 import throttledQueue from "throttled-queue";
 
-import { ImageInfo } from "../Volume.js";
 import { ImageInfo2 } from "../ImageInfo.js";
 import { CreateLoaderOptions, PrefetchDirection, VolumeFileFormat, pathToFileType } from "../loaders/index.js";
 import {

--- a/src/workers/VolumeLoaderContext.ts
+++ b/src/workers/VolumeLoaderContext.ts
@@ -272,7 +272,7 @@ class WorkerLoader extends ThreadableVolumeLoader {
       WorkerMsgType.CREATE_VOLUME,
       loadSpec
     );
-    return { imageInfo: imageInfo, loadSpec: rebuildLoadSpec(adjustedLoadSpec) };
+    return { imageInfo, loadSpec: rebuildLoadSpec(adjustedLoadSpec) };
   }
 
   loadRawChannelData(

--- a/src/workers/VolumeLoaderContext.ts
+++ b/src/workers/VolumeLoaderContext.ts
@@ -2,6 +2,7 @@ import { deserializeError } from "serialize-error";
 import throttledQueue from "throttled-queue";
 
 import { ImageInfo } from "../Volume.js";
+import { ImageInfo2 } from "../ImageInfo.js";
 import { CreateLoaderOptions, PrefetchDirection, VolumeFileFormat, pathToFileType } from "../loaders/index.js";
 import {
   ThreadableVolumeLoader,
@@ -226,7 +227,8 @@ class WorkerLoader extends ThreadableVolumeLoader {
   private isOpen = true;
   private currentLoadId = -1;
   private currentLoadCallback: RawChannelDataCallback | undefined = undefined;
-  private currentMetadataUpdateCallback: ((imageInfo?: ImageInfo, loadSpec?: LoadSpec) => void) | undefined = undefined;
+  private currentMetadataUpdateCallback: ((imageInfo?: ImageInfo2, loadSpec?: LoadSpec) => void) | undefined =
+    undefined;
 
   constructor(private loaderId: number, private workerHandle: SharedLoadWorkerHandle) {
     super();
@@ -276,9 +278,9 @@ class WorkerLoader extends ThreadableVolumeLoader {
   }
 
   loadRawChannelData(
-    imageInfo: ImageInfo,
+    imageInfo: ImageInfo2,
     loadSpec: LoadSpec,
-    onUpdateMetadata: (imageInfo?: ImageInfo, loadSpec?: LoadSpec) => void,
+    onUpdateMetadata: (imageInfo?: ImageInfo2, loadSpec?: LoadSpec) => void,
     onData: RawChannelDataCallback
   ): Promise<void> {
     this.checkIsOpen();

--- a/src/workers/VolumeLoaderContext.ts
+++ b/src/workers/VolumeLoaderContext.ts
@@ -22,7 +22,7 @@ import type {
 } from "./types.js";
 import type { ZarrLoaderFetchOptions } from "../loaders/OmeZarrLoader.js";
 import { WorkerMsgType, WorkerResponseResult, WorkerEventType } from "./types.js";
-import { rebuildImageInfo, rebuildLoadSpec } from "./util.js";
+import { rebuildLoadSpec } from "./util.js";
 
 type StoredPromise<T extends WorkerMsgType> = {
   type: T;
@@ -272,7 +272,7 @@ class WorkerLoader extends ThreadableVolumeLoader {
       WorkerMsgType.CREATE_VOLUME,
       loadSpec
     );
-    return { imageInfo: rebuildImageInfo(imageInfo), loadSpec: rebuildLoadSpec(adjustedLoadSpec) };
+    return { imageInfo: imageInfo, loadSpec: rebuildLoadSpec(adjustedLoadSpec) };
   }
 
   loadRawChannelData(
@@ -308,7 +308,7 @@ class WorkerLoader extends ThreadableVolumeLoader {
       return;
     }
 
-    const imageInfo = e.imageInfo && rebuildImageInfo(e.imageInfo);
+    const imageInfo = e.imageInfo;
     const loadSpec = e.loadSpec && rebuildLoadSpec(e.loadSpec);
     this.currentMetadataUpdateCallback?.(imageInfo, loadSpec);
   }

--- a/src/workers/VolumeLoaderContext.ts
+++ b/src/workers/VolumeLoaderContext.ts
@@ -2,12 +2,12 @@ import { deserializeError } from "serialize-error";
 import throttledQueue from "throttled-queue";
 
 import { ImageInfo } from "../ImageInfo.js";
+import { VolumeDims } from "../VolumeDims.js";
 import { CreateLoaderOptions, PrefetchDirection, VolumeFileFormat, pathToFileType } from "../loaders/index.js";
 import {
   ThreadableVolumeLoader,
   LoadSpec,
   RawChannelDataCallback,
-  VolumeDims,
   LoadedVolumeInfo,
 } from "../loaders/IVolumeLoader.js";
 import { RawArrayLoader } from "../loaders/RawArrayLoader.js";

--- a/src/workers/VolumeLoaderContext.ts
+++ b/src/workers/VolumeLoaderContext.ts
@@ -1,7 +1,7 @@
 import { deserializeError } from "serialize-error";
 import throttledQueue from "throttled-queue";
 
-import { ImageInfo2 } from "../ImageInfo.js";
+import { ImageInfo } from "../ImageInfo.js";
 import { CreateLoaderOptions, PrefetchDirection, VolumeFileFormat, pathToFileType } from "../loaders/index.js";
 import {
   ThreadableVolumeLoader,
@@ -226,8 +226,7 @@ class WorkerLoader extends ThreadableVolumeLoader {
   private isOpen = true;
   private currentLoadId = -1;
   private currentLoadCallback: RawChannelDataCallback | undefined = undefined;
-  private currentMetadataUpdateCallback: ((imageInfo?: ImageInfo2, loadSpec?: LoadSpec) => void) | undefined =
-    undefined;
+  private currentMetadataUpdateCallback: ((imageInfo?: ImageInfo, loadSpec?: LoadSpec) => void) | undefined = undefined;
 
   constructor(private loaderId: number, private workerHandle: SharedLoadWorkerHandle) {
     super();
@@ -277,9 +276,9 @@ class WorkerLoader extends ThreadableVolumeLoader {
   }
 
   loadRawChannelData(
-    imageInfo: ImageInfo2,
+    imageInfo: ImageInfo,
     loadSpec: LoadSpec,
-    onUpdateMetadata: (imageInfo?: ImageInfo2, loadSpec?: LoadSpec) => void,
+    onUpdateMetadata: (imageInfo?: ImageInfo, loadSpec?: LoadSpec) => void,
     onData: RawChannelDataCallback
   ): Promise<void> {
     this.checkIsOpen();

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -1,6 +1,5 @@
 import type { ErrorObject } from "serialize-error";
 
-import type { ImageInfo } from "../Volume.js";
 import type { ImageInfo2 } from "../ImageInfo.js";
 import type { CreateLoaderOptions, PrefetchDirection } from "../loaders/index.js";
 import type { LoadSpec, LoadedVolumeInfo, VolumeDims } from "../loaders/IVolumeLoader.js";

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -1,6 +1,7 @@
 import type { ErrorObject } from "serialize-error";
 
 import type { ImageInfo } from "../Volume.js";
+import type { ImageInfo2 } from "../ImageInfo.js";
 import type { CreateLoaderOptions, PrefetchDirection } from "../loaders/index.js";
 import type { LoadSpec, LoadedVolumeInfo, VolumeDims } from "../loaders/IVolumeLoader.js";
 import type { TypedArray, NumberType } from "../types.js";
@@ -54,7 +55,7 @@ export type WorkerRequestPayload<T extends WorkerMsgType> = {
   [WorkerMsgType.CREATE_VOLUME]: LoadSpec;
   [WorkerMsgType.LOAD_DIMS]: LoadSpec;
   [WorkerMsgType.LOAD_VOLUME_DATA]: {
-    imageInfo: ImageInfo;
+    imageInfo: ImageInfo2;
     loadSpec: LoadSpec;
     loaderId: number;
     loadId: number;
@@ -93,7 +94,7 @@ export type MetadataUpdateEvent = {
   eventType: WorkerEventType.METADATA_UPDATE;
   loaderId: number;
   loadId: number;
-  imageInfo?: ImageInfo;
+  imageInfo?: ImageInfo2;
   loadSpec?: LoadSpec;
 };
 

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -1,6 +1,6 @@
 import type { ErrorObject } from "serialize-error";
 
-import type { ImageInfo2 } from "../ImageInfo.js";
+import type { ImageInfo } from "../ImageInfo.js";
 import type { CreateLoaderOptions, PrefetchDirection } from "../loaders/index.js";
 import type { LoadSpec, LoadedVolumeInfo, VolumeDims } from "../loaders/IVolumeLoader.js";
 import type { TypedArray, NumberType } from "../types.js";
@@ -54,7 +54,7 @@ export type WorkerRequestPayload<T extends WorkerMsgType> = {
   [WorkerMsgType.CREATE_VOLUME]: LoadSpec;
   [WorkerMsgType.LOAD_DIMS]: LoadSpec;
   [WorkerMsgType.LOAD_VOLUME_DATA]: {
-    imageInfo: ImageInfo2;
+    imageInfo: ImageInfo;
     loadSpec: LoadSpec;
     loaderId: number;
     loadId: number;
@@ -93,7 +93,7 @@ export type MetadataUpdateEvent = {
   eventType: WorkerEventType.METADATA_UPDATE;
   loaderId: number;
   loadId: number;
-  imageInfo?: ImageInfo2;
+  imageInfo?: ImageInfo;
   loadSpec?: LoadSpec;
 };
 

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -1,8 +1,9 @@
 import type { ErrorObject } from "serialize-error";
 
 import type { ImageInfo } from "../ImageInfo.js";
+import type { VolumeDims } from "../VolumeDims.js";
 import type { CreateLoaderOptions, PrefetchDirection } from "../loaders/index.js";
-import type { LoadSpec, LoadedVolumeInfo, VolumeDims } from "../loaders/IVolumeLoader.js";
+import type { LoadSpec, LoadedVolumeInfo } from "../loaders/IVolumeLoader.js";
 import type { TypedArray, NumberType } from "../types.js";
 import type { ZarrLoaderFetchOptions } from "../loaders/OmeZarrLoader.js";
 

--- a/src/workers/util.ts
+++ b/src/workers/util.ts
@@ -1,28 +1,10 @@
 import { Box3, Vector3 } from "three";
 import { LoadSpec } from "../loaders/IVolumeLoader";
-import { ImageInfo } from "../ImageInfo";
 
 /** Recreates a `LoadSpec` that has just been sent to/from a worker to restore three.js object prototypes */
 export function rebuildLoadSpec(spec: LoadSpec): LoadSpec {
   return {
     ...spec,
     subregion: new Box3(new Vector3().copy(spec.subregion.min), new Vector3().copy(spec.subregion.max)),
-  };
-}
-
-/** Recreates an `ImageInfo` that has just been sent to/from a worker to restore three.js object prototypes */
-export function rebuildImageInfo(imageInfo: ImageInfo): ImageInfo {
-  return {
-    ...imageInfo,
-    //originalSize: new Vector3().copy(imageInfo.originalSize),
-    //atlasTileDims: new Vector2().copy(imageInfo.atlasTileDims),
-    //volumeSize: new Vector3().copy(imageInfo.volumeSize),
-    //subregionSize: new Vector3().copy(imageInfo.subregionSize),
-    //subregionOffset: new Vector3().copy(imageInfo.subregionOffset),
-    //physicalPixelSize: new Vector3().copy(imageInfo.physicalPixelSize),
-    //transform: {
-    //  translation: new Vector3().copy(imageInfo.transform.translation),
-    //  rotation: new Vector3().copy(imageInfo.transform.rotation),
-    //},
   };
 }

--- a/src/workers/util.ts
+++ b/src/workers/util.ts
@@ -12,14 +12,11 @@ export function rebuildLoadSpec(spec: LoadSpec): LoadSpec {
 
 /** Recreates an `ImageInfo` that has just been sent to/from a worker to restore three.js object prototypes */
 export function rebuildImageInfo(imageInfo: ImageInfo): ImageInfo {
-  return {
+  return <ImageInfo>{
     ...imageInfo,
-    originalSize: new Vector3().copy(imageInfo.originalSize),
     atlasTileDims: new Vector2().copy(imageInfo.atlasTileDims),
-    volumeSize: new Vector3().copy(imageInfo.volumeSize),
     subregionSize: new Vector3().copy(imageInfo.subregionSize),
     subregionOffset: new Vector3().copy(imageInfo.subregionOffset),
-    physicalPixelSize: new Vector3().copy(imageInfo.physicalPixelSize),
     transform: {
       translation: new Vector3().copy(imageInfo.transform.translation),
       rotation: new Vector3().copy(imageInfo.transform.rotation),

--- a/src/workers/util.ts
+++ b/src/workers/util.ts
@@ -1,6 +1,6 @@
 import { Box3, Vector3 } from "three";
 import { LoadSpec } from "../loaders/IVolumeLoader";
-import { ImageInfo2 } from "../ImageInfo";
+import { ImageInfo } from "../ImageInfo";
 
 /** Recreates a `LoadSpec` that has just been sent to/from a worker to restore three.js object prototypes */
 export function rebuildLoadSpec(spec: LoadSpec): LoadSpec {
@@ -11,7 +11,7 @@ export function rebuildLoadSpec(spec: LoadSpec): LoadSpec {
 }
 
 /** Recreates an `ImageInfo` that has just been sent to/from a worker to restore three.js object prototypes */
-export function rebuildImageInfo(imageInfo: ImageInfo2): ImageInfo2 {
+export function rebuildImageInfo(imageInfo: ImageInfo): ImageInfo {
   return {
     ...imageInfo,
     //originalSize: new Vector3().copy(imageInfo.originalSize),

--- a/src/workers/util.ts
+++ b/src/workers/util.ts
@@ -1,6 +1,5 @@
-import { Box3, Vector2, Vector3 } from "three";
+import { Box3, Vector3 } from "three";
 import { LoadSpec } from "../loaders/IVolumeLoader";
-import { ImageInfo } from "../Volume";
 import { ImageInfo2 } from "../ImageInfo";
 
 /** Recreates a `LoadSpec` that has just been sent to/from a worker to restore three.js object prototypes */

--- a/src/workers/util.ts
+++ b/src/workers/util.ts
@@ -1,6 +1,7 @@
 import { Box3, Vector2, Vector3 } from "three";
 import { LoadSpec } from "../loaders/IVolumeLoader";
 import { ImageInfo } from "../Volume";
+import { ImageInfo2 } from "../ImageInfo";
 
 /** Recreates a `LoadSpec` that has just been sent to/from a worker to restore three.js object prototypes */
 export function rebuildLoadSpec(spec: LoadSpec): LoadSpec {
@@ -11,18 +12,18 @@ export function rebuildLoadSpec(spec: LoadSpec): LoadSpec {
 }
 
 /** Recreates an `ImageInfo` that has just been sent to/from a worker to restore three.js object prototypes */
-export function rebuildImageInfo(imageInfo: ImageInfo): ImageInfo {
+export function rebuildImageInfo(imageInfo: ImageInfo2): ImageInfo2 {
   return {
     ...imageInfo,
-    originalSize: new Vector3().copy(imageInfo.originalSize),
-    atlasTileDims: new Vector2().copy(imageInfo.atlasTileDims),
-    volumeSize: new Vector3().copy(imageInfo.volumeSize),
-    subregionSize: new Vector3().copy(imageInfo.subregionSize),
-    subregionOffset: new Vector3().copy(imageInfo.subregionOffset),
-    physicalPixelSize: new Vector3().copy(imageInfo.physicalPixelSize),
-    transform: {
-      translation: new Vector3().copy(imageInfo.transform.translation),
-      rotation: new Vector3().copy(imageInfo.transform.rotation),
-    },
+    //originalSize: new Vector3().copy(imageInfo.originalSize),
+    //atlasTileDims: new Vector2().copy(imageInfo.atlasTileDims),
+    //volumeSize: new Vector3().copy(imageInfo.volumeSize),
+    //subregionSize: new Vector3().copy(imageInfo.subregionSize),
+    //subregionOffset: new Vector3().copy(imageInfo.subregionOffset),
+    //physicalPixelSize: new Vector3().copy(imageInfo.physicalPixelSize),
+    //transform: {
+    //  translation: new Vector3().copy(imageInfo.transform.translation),
+    //  rotation: new Vector3().copy(imageInfo.transform.rotation),
+    //},
   };
 }

--- a/src/workers/util.ts
+++ b/src/workers/util.ts
@@ -12,11 +12,14 @@ export function rebuildLoadSpec(spec: LoadSpec): LoadSpec {
 
 /** Recreates an `ImageInfo` that has just been sent to/from a worker to restore three.js object prototypes */
 export function rebuildImageInfo(imageInfo: ImageInfo): ImageInfo {
-  return <ImageInfo>{
+  return {
     ...imageInfo,
+    originalSize: new Vector3().copy(imageInfo.originalSize),
     atlasTileDims: new Vector2().copy(imageInfo.atlasTileDims),
+    volumeSize: new Vector3().copy(imageInfo.volumeSize),
     subregionSize: new Vector3().copy(imageInfo.subregionSize),
     subregionOffset: new Vector3().copy(imageInfo.subregionOffset),
+    physicalPixelSize: new Vector3().copy(imageInfo.physicalPixelSize),
     transform: {
       translation: new Vector3().copy(imageInfo.transform.translation),
       rotation: new Vector3().copy(imageInfo.transform.rotation),


### PR DESCRIPTION
REFACTOR:  resolves #251 in which after adding multiscaleLevelDims, several fields in ImageInfo were totally redundant.

This should not change any behaviors in usage of the viewer.

Changes:

* Move `ImageInfo` and `VolumeDims` into their own modules.
* Remove redundant fields from `ImageInfo` and use convenience functions in a wrapper class to return the relevant data back out.
* the dtype in `VolumeDims` gets better typechecking.
* New `ImageInfo` uses only array types instead of Vector2/Vector3.  Note that the `transform` falls under that group.  This is really useful for effectively and efficiently passing the ImageInfo object across worker boundaries.

Aside/discussion:

This shows that even though there is one single `ImageInfo` per `Volume`, that doesn't take into account the following:
* multiple data sources
* subregion selection (See commented-out code in omezarrloader)
* some of the physical size variables stored in Volume seem redundant or unnecessary
So there is still some thinking to do with respect to what ImageInfo really is supposed to contain, and whether it should be split apart, perhaps along the lines of read-only info from the data sources vs app-selections of what to load.

Tested for compatibility with main branch of website-3d-cell-viewer.

