### PR TITLE
don't try to fuse if no channel data is available

### DIFF
--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -207,15 +207,17 @@ export default class FusedChannelData {
         this.fuseScene.add(new Mesh(this.fuseGeometry, mat));
       }
     }
-    renderer.setRenderTarget(this.fuseRenderTarget);
-    renderer.autoClearColor = true;
-    const prevClearColor = new Color();
-    renderer.getClearColor(prevClearColor);
-    const prevClearAlpha = renderer.getClearAlpha();
-    renderer.setClearColor(0x000000, 0);
-    renderer.render(this.fuseScene, this.quadCamera);
-    renderer.setRenderTarget(null);
-    renderer.setClearColor(prevClearColor, prevClearAlpha);
+    if (this.fuseScene.children.length > 0) {
+      renderer.setRenderTarget(this.fuseRenderTarget);
+      renderer.autoClearColor = true;
+      const prevClearColor = new Color();
+      renderer.getClearColor(prevClearColor);
+      const prevClearAlpha = renderer.getClearAlpha();
+      renderer.setClearColor(0x000000, 0);
+      renderer.render(this.fuseScene, this.quadCamera);
+      renderer.setRenderTarget(null);
+      renderer.setClearColor(prevClearColor, prevClearAlpha);
+    }
     // "dirty flag"
     this.fuseRequested = null;
   }


### PR DESCRIPTION
time to review : < 5 min

Fuse can get into a situation where it's trying to fuse but none of the channels have loaded=true.  It then will totally clear the buffer but render nothing into it.  This is "bad".  Don't do anything if there are no loaded channels.