### PR TITLE
Volume-mesh intersections with view position texture

### DIFF
--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -16,6 +16,7 @@ import {
   PerspectiveCamera,
   ShaderMaterial,
   ShapeGeometry,
+  Texture,
   Vector2,
   Vector3,
   WebGLRenderer,
@@ -325,7 +326,7 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
   public doRender(
     renderer: WebGLRenderer,
     camera: PerspectiveCamera | OrthographicCamera,
-    depthTexture?: DepthTexture
+    depthTexture?: DepthTexture | Texture
   ): void {
     if (!this.geometryMesh.visible) {
       return;
@@ -336,6 +337,7 @@ export default class RayMarchedAtlasVolume implements VolumeRenderImpl {
     }
 
     this.setUniform("textureDepth", depthTexture ?? this.emptyDepthTex);
+    this.setUniform("usingPositionTexture", (depthTexture as DepthTexture)?.isDepthTexture ? 0 : 1);
     this.setUniform("CLIP_NEAR", camera.near);
     this.setUniform("CLIP_FAR", camera.far);
 

--- a/src/constants/shaders/raymarch.frag
+++ b/src/constants/shaders/raymarch.frag
@@ -21,6 +21,7 @@ uniform float CLIP_FAR;
 uniform sampler2D textureAtlas;
 uniform sampler2D textureAtlasMask;
 uniform sampler2D textureDepth;
+uniform int usingPositionTexture;
 uniform int BREAK_STEPS;
 uniform float SLICES;
 uniform float isOrtho;

--- a/src/constants/shaders/raymarch.frag
+++ b/src/constants/shaders/raymarch.frag
@@ -280,28 +280,28 @@ void main() {
   float clipNear = 0.0;//-(dot(eyeRay_o.xyz, eyeNorm) + dNear) / dot(eyeRay_d.xyz, eyeNorm);
   float clipFar  = 10000.0;//-(dot(eyeRay_o.xyz,-eyeNorm) + dFar ) / dot(eyeRay_d.xyz,-eyeNorm);
 
-  // Sample the depth texture
-  vec4 depthSample = texture2D(textureDepth, vUv);
-  // If there's a depth-contributing mesh at this fragment, we may need to terminate the ray early
-  if (usingPositionTexture == 1) {
-    if (depthSample.a > 0.0) {
-      gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
-      return;
-    }
-  } else {
-    if (depthSample.r < 1.0) {
-      // Get a projection space position from depth and uv, and unproject back to object space
-      vec4 meshProj = vec4(vUv * 2.0 - 1.0, depthSample.r * 2.0 - 1.0, 1.0);
-      vec4 meshView = inverseProjMatrix * meshProj;
-      vec4 meshObj = inverseModelViewMatrix * vec4(meshView.xyz / meshView.w, 1.0);
+  // Sample the depth/position texture
+  vec4 meshViewPos = texture2D(textureDepth, vUv);
+  bool hasDepthValue = usingPositionTexture == 0 && meshViewPos.r < 1.0;
 
-      // Derive a t value for the mesh intersection
-      // NOTE: divides by 0 when `eyeRay_d.z` is 0. Could be mitigated by picking another component
-      //   to derive with when z is 0, but I found this was rare enough in practice to be acceptable.
-      float tMesh = (meshObj.z - eyeRay_o.z) / eyeRay_d.z;
-      if (tMesh < tfar) {
-        clipFar = tMesh - tnear;
-      }
+  // If there's a depth-contributing mesh at this fragment, we may need to terminate the ray early
+  if (hasDepthValue || (usingPositionTexture == 1 && meshViewPos.a > 0.0)) {
+    if (hasDepthValue) {
+      // Working from just a depth value requires a bit of extra work
+      // Get a projection space position from depth and uv, and unproject back to view space
+      vec4 meshProj = vec4(vUv * 2.0 - 1.0, meshViewPos.r * 2.0 - 1.0, 1.0);
+      vec4 meshView = inverseProjMatrix * meshProj;
+      meshViewPos = vec4(meshView.xyz / meshView.w, 1.0);
+    }
+    // Transform the mesh position to object space
+    vec4 meshObj = inverseModelViewMatrix * meshViewPos;
+
+    // Derive a t value for the mesh intersection
+    // NOTE: divides by 0 when `eyeRay_d.z` is 0. Could be mitigated by picking another component
+    //   to derive with when z is 0, but I found this was rare enough in practice to be acceptable.
+    float tMesh = (meshObj.z - eyeRay_o.z) / eyeRay_d.z;
+    if (tMesh < tfar) {
+      clipFar = tMesh - tnear;
     }
   }
 

--- a/src/constants/shaders/raymarch.frag
+++ b/src/constants/shaders/raymarch.frag
@@ -281,20 +281,27 @@ void main() {
   float clipFar  = 10000.0;//-(dot(eyeRay_o.xyz,-eyeNorm) + dFar ) / dot(eyeRay_d.xyz,-eyeNorm);
 
   // Sample the depth texture
-  float depth = texture2D(textureDepth, vUv).r;
+  vec4 depthSample = texture2D(textureDepth, vUv);
   // If there's a depth-contributing mesh at this fragment, we may need to terminate the ray early
-  if (depth < 1.0) {
-    // Get a projection space position from depth and uv, and unproject back to object space
-    vec4 meshProj = vec4(vUv * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
-    vec4 meshView = inverseProjMatrix * meshProj;
-    vec4 meshObj = inverseModelViewMatrix * vec4(meshView.xyz / meshView.w, 1.0);
+  if (usingPositionTexture == 1) {
+    if (depthSample.a > 0.0) {
+      gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+      return;
+    }
+  } else {
+    if (depthSample.r < 1.0) {
+      // Get a projection space position from depth and uv, and unproject back to object space
+      vec4 meshProj = vec4(vUv * 2.0 - 1.0, depthSample.r * 2.0 - 1.0, 1.0);
+      vec4 meshView = inverseProjMatrix * meshProj;
+      vec4 meshObj = inverseModelViewMatrix * vec4(meshView.xyz / meshView.w, 1.0);
 
-    // Derive a t value for the mesh intersection
-    // NOTE: divides by 0 when `eyeRay_d.z` is 0. Could be mitigated by picking another component
-    //   to derive with when z is 0, but I found this was rare enough in practice to be acceptable.
-    float tMesh = (meshObj.z - eyeRay_o.z) / eyeRay_d.z;
-    if (tMesh < tfar) {
-      clipFar = tMesh - tnear;
+      // Derive a t value for the mesh intersection
+      // NOTE: divides by 0 when `eyeRay_d.z` is 0. Could be mitigated by picking another component
+      //   to derive with when z is 0, but I found this was rare enough in practice to be acceptable.
+      float tMesh = (meshObj.z - eyeRay_o.z) / eyeRay_d.z;
+      if (tMesh < tfar) {
+        clipFar = tMesh - tnear;
+      }
     }
   }
 

--- a/src/constants/shaders/raymarch.frag
+++ b/src/constants/shaders/raymarch.frag
@@ -281,13 +281,14 @@ void main() {
   float clipFar  = 10000.0;//-(dot(eyeRay_o.xyz,-eyeNorm) + dFar ) / dot(eyeRay_d.xyz,-eyeNorm);
 
   // Sample the depth/position texture
+  // This is EITHER a view space position or a depth value we'll convert to a view space position
   vec4 meshViewPos = texture2D(textureDepth, vUv);
   bool hasDepthValue = usingPositionTexture == 0 && meshViewPos.r < 1.0;
 
   // If there's a depth-contributing mesh at this fragment, we may need to terminate the ray early
   if (hasDepthValue || (usingPositionTexture == 1 && meshViewPos.a > 0.0)) {
     if (hasDepthValue) {
-      // Working from just a depth value requires a bit of extra work
+      // We're working with a depth value, so we need to convert back to view space position
       // Get a projection space position from depth and uv, and unproject back to view space
       vec4 meshProj = vec4(vUv * 2.0 - 1.0, meshViewPos.r * 2.0 - 1.0, 1.0);
       vec4 meshView = inverseProjMatrix * meshProj;

--- a/src/constants/volumeRayMarchShader.ts
+++ b/src/constants/volumeRayMarchShader.ts
@@ -95,6 +95,10 @@ export const rayMarchingShaderUniforms = () => {
       type: "t",
       value: new Texture(),
     },
+    usingPositionTexture: {
+      type: "i",
+      value: 0,
+    },
     maxProject: {
       type: "i",
       value: 0,


### PR DESCRIPTION
review time: small (~5min)

#237 added proper intersections between volumes and meshes. This works in the fragment shader by:

1. sampling the depth buffer
2. converting the depth value and uv to a position in view space
3. converting that position back to object space
4. terminating a ray early if it would run past that object space position

Getting volume-mesh intersections right was motivated in part by plans to incorporate volume rendering into Simularium. But Simularium's initial render pass generates a buffer of view space positions, which let us skip the first two steps above. This change adds support for using that view space buffer.