### PR TITLE
naive first attempt not working due to need for range requests

### DIFF
--- a/src/loaders/zarr_utils/WrappedStore.ts
+++ b/src/loaders/zarr_utils/WrappedStore.ts
@@ -1,5 +1,5 @@
 import { FetchStore } from "zarrita";
-import { AbsolutePath, AsyncMutable, Readable } from "@zarrita/storage";
+import { AbsolutePath, AsyncMutable, RangeQuery, Readable } from "@zarrita/storage";
 
 import SubscribableRequestQueue from "../../utils/SubscribableRequestQueue";
 import VolumeCache from "../../VolumeCache";
@@ -24,12 +24,65 @@ class WrappedStore<Opts, S extends Readable<Opts> = Readable<Opts>> implements A
     return Promise.resolve();
   }
 
-  private async getAndCache(key: AbsolutePath, cacheKey: string, opts?: Opts): Promise<Uint8Array | undefined> {
-    const result = await this.baseStore.get(key, opts);
+  private async getAndCache(
+    key: AbsolutePath,
+    cacheKey: string,
+    opts?: Opts,
+    range?: RangeQuery
+  ): Promise<Uint8Array | undefined> {
+    const result =
+      range && this.baseStore.getRange
+        ? await this.baseStore.getRange(key, range, opts)
+        : await this.baseStore.get(key, opts);
     if (this.cache && result) {
       this.cache.insert(cacheKey, result);
     }
     return result;
+  }
+
+  async getRange(
+    key: AbsolutePath,
+    range: RangeQuery,
+    opts?: WrappedStoreOpts<Opts> | undefined
+  ): Promise<Uint8Array | undefined> {
+    const ZARR_EXTS = [".zarray", ".zgroup", ".zattrs", "zarr.json"];
+    // don't do range queries for zarr metadata files?
+    if (ZARR_EXTS.some((s) => key.endsWith(s))) {
+      return undefined;
+    }
+    // what to do if the base store doesn't support range queries?
+    if (!this.cache) {
+      return this.baseStore.getRange ? this.baseStore.getRange(key, range, opts?.options) : undefined;
+    }
+    if (opts?.reportKey) {
+      opts.reportKey(key, opts.subscriber);
+    }
+
+    let keyPrefix = (this.baseStore as FetchStore).url ?? "";
+    if (keyPrefix !== "" && !(keyPrefix instanceof URL) && !keyPrefix.endsWith("/")) {
+      keyPrefix += "/";
+    }
+
+    const fullKey = keyPrefix + key.slice(1);
+
+    // Check the cache
+    const cacheResult = this.cache.get(fullKey);
+    if (cacheResult) {
+      return new Uint8Array(cacheResult);
+    }
+
+    // Not in cache; load the chunk and cache it
+    if (this.queue && opts) {
+      return this.queue.addRequest(
+        fullKey,
+        opts.subscriber,
+        () => this.getAndCache(key, fullKey, opts?.options, range),
+        opts.isPrefetch
+      );
+    } else {
+      // Should we ever hit this code?  We should always have a request queue.
+      return this.getAndCache(key, fullKey, opts?.options, range);
+    }
   }
 
   async get(key: AbsolutePath, opts?: WrappedStoreOpts<Opts> | undefined): Promise<Uint8Array | undefined> {


### PR DESCRIPTION
@frasercl FYI for ome-zarr-0.5 (including zarrv3)

I tried updating the metadata parsing code only, and zarrita complained that our WrappedStore doesn't support range requests.  Did a very naive attempt to just add getRange but things are still broken.   At least the metadata does load properly.