### PR TITLE
fix: Mask channels are now loaded when switching between volumes in XY mode

### DIFF
--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -123,7 +123,7 @@ export default class VolumeDrawable {
    */
   private updateChannelDataRequired(channelIndex: number): void {
     const { enabled, isosurfaceEnabled } = this.channelOptions[channelIndex];
-    const channelIsRequired = enabled || isosurfaceEnabled;
+    const channelIsRequired = enabled || isosurfaceEnabled || channelIndex === this.settings.maskChannelIndex;
     const requiredChannels = this.volume.loadSpecRequired.channels;
 
     if (requiredChannels.includes(channelIndex)) {
@@ -597,6 +597,7 @@ export default class VolumeDrawable {
       return;
     }
     this.settings.maskChannelIndex = channelIndex;
+    this.updateChannelDataRequired(channelIndex);
     this.volumeRendering.updateSettings(this.settings, SettingsFlags.MASK_DATA);
   }
 


### PR DESCRIPTION
Fixes https://github.com/allen-cell-animated/cell-feature-explorer/issues/216.

*Estimated review size: tiny, <3 minutes*

The channel used for masking was not being marked as a channel that needed to be loaded. This change adds an exception for it in the `updateChannelDataRequired` and an additional check when the mask channel is set.