### PR TITLE
update actions/cache and node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 
 name: Node.js CI
 env:
-  NODE_VERSION: "18"
+  NODE_VERSION: "20"
 
 on: [push]
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 name: github pages
 
 env:
-  NODE_VERSION: "18"
+  NODE_VERSION: "20"
 
 on:
   schedule:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Cache dependencies
 
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@
 
 name: NPM Package
 env:
-  NODE_VERSION: "18"
+  NODE_VERSION: "20"
 on:
   push:
     # Sequence of patterns matched against refs/tags


### PR DESCRIPTION
`actions/cache` v1 is deprecated and notices are going out.  This PR updates it to v4 and also bumps our node version for all our CI actions.

For info about the deprecation see https://github.com/actions/toolkit/discussions/1890
