### PR TITLE
fix: Default range causes volumes to have incorrect LUT values

### DIFF
--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -21,11 +21,11 @@ export default class Histogram {
   private min: number;
   /** Max value in the original raw data. */
   private max: number;
-  /** Size of each histogram bin in the scale of the original raw data. */
+  /** Size of each histogram bin in the scale of the original data. */
   private binSize: number;
-  /** Index of the first nonzero bin with at least 1 sample */
+  /** Index of the first bin (other than 0) with at least 1 value. */
   private dataMinBin: number;
-  /** Index of the last nonzero bin with at least 1 sample */
+  /** Index of the last bin (other than 0) with at least 1 value. */
   private dataMaxBin: number;
   private pixelCount: number;
   public maxBin: number;
@@ -47,6 +47,8 @@ export default class Histogram {
     this.binSize = hinfo.binSize;
 
     // track the first and last nonzero bins with at least 1 sample
+    // TODO: If `this.min` is not 0, should `this.dataMinBin` be `0` (instead of starting at 1)
+    // since the first bin doesn't represent zero values?
     for (let i = 1; i < this.bins.length; i++) {
       if (this.bins[i] > 0) {
         this.dataMinBin = i;
@@ -105,20 +107,19 @@ export default class Histogram {
   }
 
   /**
-   * Returns the minimum bin index with a non-zero value.
+   * Returns the first bin index with at least 1 value, other than the 0th bin.
    * @return {number}
    */
   getMin(): number {
-    // Note that this will currently always return 0, unless NBINS changes.
     return this.dataMinBin;
   }
 
   /**
-   * Returns the maximum bin index with a non-zero value.
+   * Returns the last bin index with at least 1 value, other than the 0th bin.
    * @return {number}
    */
   getMax(): number {
-    // Note that this will always return 255, unless NBINS changes.
+    // Note that this will always return `NBINS - 1`.
     return this.dataMaxBin;
   }
 

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -21,18 +21,12 @@ export default class Histogram {
   private min: number;
   /** Max value in the original raw data. */
   private max: number;
-  /** Size of each histogram bin in the scale of the original raw data. */
+  /** Size of each histogram bin in the scale of the original data. */
   private binSize: number;
-  /** Index of the first nonzero bin with at least 1 sample */
-  private dataMinBin: number;
-  /** Index of the last nonzero bin with at least 1 sample */
-  private dataMaxBin: number;
   private pixelCount: number;
   public maxBin: number;
 
   constructor(data: TypedArray<NumberType>) {
-    this.dataMinBin = 0;
-    this.dataMaxBin = 0;
     this.maxBin = 0;
     this.bins = new Uint32Array();
     this.min = 0;
@@ -45,20 +39,6 @@ export default class Histogram {
     this.min = hinfo.min;
     this.max = hinfo.max;
     this.binSize = hinfo.binSize;
-
-    // track the first and last nonzero bins with at least 1 sample
-    for (let i = 1; i < this.bins.length; i++) {
-      if (this.bins[i] > 0) {
-        this.dataMinBin = i;
-        break;
-      }
-    }
-    for (let i = this.bins.length - 1; i >= 1; i--) {
-      if (this.bins[i] > 0) {
-        this.dataMaxBin = i;
-        break;
-      }
-    }
 
     this.pixelCount = data.length;
 
@@ -105,21 +85,19 @@ export default class Histogram {
   }
 
   /**
-   * Returns the minimum bin index with a non-zero value.
+   * Returns the minimum bin index.
    * @return {number}
    */
   getMin(): number {
-    // Note that this will currently always return 0, unless NBINS changes.
-    return this.dataMinBin;
+    return 0;
   }
 
   /**
-   * Returns the maximum bin index with a non-zero value.
+   * Returns the maximum bin index.
    * @return {number}
    */
   getMax(): number {
-    // Note that this will always return 255, unless NBINS changes.
-    return this.dataMaxBin;
+    return NBINS - 1;
   }
 
   getNumBins(): number {

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -46,16 +46,15 @@ export default class Histogram {
     this.max = hinfo.max;
     this.binSize = hinfo.binSize;
 
-    // track the first and last nonzero bins with at least 1 sample
-    // TODO: If `this.min` is not 0, should `this.dataMinBin` be `0` (instead of starting at 1)
-    // since the first bin doesn't represent zero values?
-    for (let i = 1; i < this.bins.length; i++) {
+    // TODO: These should always return 0 and NBINS - 1, respectively. Test if these
+    // can be removed.
+    for (let i = 0; i < this.bins.length; i++) {
       if (this.bins[i] > 0) {
         this.dataMinBin = i;
         break;
       }
     }
-    for (let i = this.bins.length - 1; i >= 1; i--) {
+    for (let i = this.bins.length - 1; i >= 0; i--) {
       if (this.bins[i] > 0) {
         this.dataMaxBin = i;
         break;

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -17,10 +17,15 @@ type HistogramData = {
 export default class Histogram {
   // no more than 2^32 pixels of any one intensity in the data!?!?!
   private bins: Uint32Array;
+  /** Min value in the original raw data. */
   private min: number;
+  /** Max value in the original raw data. */
   private max: number;
+  /** Size of each histogram bin in the scale of the original raw data. */
   private binSize: number;
+  /** Index of the first nonzero bin with at least 1 sample */
   private dataMinBin: number;
+  /** Index of the last nonzero bin with at least 1 sample */
   private dataMaxBin: number;
   private pixelCount: number;
   public maxBin: number;
@@ -83,27 +88,37 @@ export default class Histogram {
     return Histogram.findBin(value, this.min, this.binSize, NBINS);
   }
 
-  getDataMin(): number {
-    return this.min;
-  }
-
-  getDataMax(): number {
-    return this.max;
-  }
-
   /**
    * Return the min data value
    * @return {number}
    */
-  getMin(): number {
-    return this.dataMinBin;
+  getDataMin(): number {
+    return this.min;
   }
 
   /**
    * Return the max data value
    * @return {number}
    */
+  getDataMax(): number {
+    return this.max;
+  }
+
+  /**
+   * Returns the minimum bin index with a non-zero value.
+   * @return {number}
+   */
+  getMin(): number {
+    // Note that this will currently always return 0, unless NBINS changes.
+    return this.dataMinBin;
+  }
+
+  /**
+   * Returns the maximum bin index with a non-zero value.
+   * @return {number}
+   */
   getMax(): number {
+    // Note that this will always return 255, unless NBINS changes.
     return this.dataMaxBin;
   }
 

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -21,12 +21,18 @@ export default class Histogram {
   private min: number;
   /** Max value in the original raw data. */
   private max: number;
-  /** Size of each histogram bin in the scale of the original data. */
+  /** Size of each histogram bin in the scale of the original raw data. */
   private binSize: number;
+  /** Index of the first nonzero bin with at least 1 sample */
+  private dataMinBin: number;
+  /** Index of the last nonzero bin with at least 1 sample */
+  private dataMaxBin: number;
   private pixelCount: number;
   public maxBin: number;
 
   constructor(data: TypedArray<NumberType>) {
+    this.dataMinBin = 0;
+    this.dataMaxBin = 0;
     this.maxBin = 0;
     this.bins = new Uint32Array();
     this.min = 0;
@@ -39,6 +45,20 @@ export default class Histogram {
     this.min = hinfo.min;
     this.max = hinfo.max;
     this.binSize = hinfo.binSize;
+
+    // track the first and last nonzero bins with at least 1 sample
+    for (let i = 1; i < this.bins.length; i++) {
+      if (this.bins[i] > 0) {
+        this.dataMinBin = i;
+        break;
+      }
+    }
+    for (let i = this.bins.length - 1; i >= 1; i--) {
+      if (this.bins[i] > 0) {
+        this.dataMaxBin = i;
+        break;
+      }
+    }
 
     this.pixelCount = data.length;
 
@@ -85,19 +105,21 @@ export default class Histogram {
   }
 
   /**
-   * Returns the minimum bin index.
+   * Returns the minimum bin index with a non-zero value.
    * @return {number}
    */
   getMin(): number {
-    return 0;
+    // Note that this will currently always return 0, unless NBINS changes.
+    return this.dataMinBin;
   }
 
   /**
-   * Returns the maximum bin index.
+   * Returns the maximum bin index with a non-zero value.
    * @return {number}
    */
   getMax(): number {
-    return NBINS - 1;
+    // Note that this will always return 255, unless NBINS changes.
+    return this.dataMaxBin;
   }
 
   getNumBins(): number {

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -492,11 +492,11 @@ export default class PathTracedVolume implements VolumeRenderImpl {
       // TODO expand to 16-bpp raw intensities?
       this.pathTracingUniforms.gIntensityMax.value.setComponent(
         i,
-        this.volume.channels[channel].histogram.getDataMax() / 255.0
+        this.volume.channels[channel].histogram.getMax() / 255.0
       );
       this.pathTracingUniforms.gIntensityMin.value.setComponent(
         i,
-        this.volume.channels[channel].histogram.getDataMin() / 255.0
+        this.volume.channels[channel].histogram.getMin() / 255.0
       );
     }
     this.pathTracingUniforms.gLutTexture.value.needsUpdate = true;

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -492,11 +492,11 @@ export default class PathTracedVolume implements VolumeRenderImpl {
       // TODO expand to 16-bpp raw intensities?
       this.pathTracingUniforms.gIntensityMax.value.setComponent(
         i,
-        this.volume.channels[channel].histogram.getMax() / 255.0
+        this.volume.channels[channel].histogram.getDataMax() / 255.0
       );
       this.pathTracingUniforms.gIntensityMin.value.setComponent(
         i,
-        this.volume.channels[channel].histogram.getMin() / 255.0
+        this.volume.channels[channel].histogram.getDataMin() / 255.0
       );
     }
     this.pathTracingUniforms.gLutTexture.value.needsUpdate = true;

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -270,7 +270,7 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
             resultChannelData.push(channelData);
             resultChannelRanges.push(getDataRange(channelData));
           } else {
-            onData([chindex], ["uint8"], [new Uint8Array(cacheResult)], [getDataRange(channelData)]);
+            onData([chindex], ["uint8"], [channelData], [getDataRange(channelData)]);
           }
         } else {
           cacheHit = false;

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -309,7 +309,7 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
       }
 
       // extract the data
-      let rawRange: [number, number][] = [];
+      const rawRange: [number, number][] = [];
       for (let j = 0; j < Math.min(image.channels.length, 4); ++j) {
         let rawMin = Infinity;
         let rawMax = -Infinity;

--- a/src/loaders/JsonImageInfoLoader.ts
+++ b/src/loaders/JsonImageInfoLoader.ts
@@ -309,7 +309,7 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
       }
 
       // extract the data
-      const rawRange: [number, number][] = [];
+      const channelRange: [number, number][] = [];
       for (let j = 0; j < Math.min(image.channels.length, 4); ++j) {
         let rawMin = Infinity;
         let rawMax = -Infinity;
@@ -318,7 +318,7 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
           rawMin = Math.min(rawMin, channelsBits[j][px]);
           rawMax = Math.max(rawMax, channelsBits[j][px]);
         }
-        rawRange[j] = [rawMin, rawMax];
+        channelRange[j] = [rawMin, rawMax];
       }
 
       // done with `iData` and `canvas` now.
@@ -332,9 +332,9 @@ class JsonImageInfoLoader extends ThreadableVolumeLoader {
           resultChannelIndices.push(chindex);
           resultChannelDtype.push("uint8");
           resultChannelData.push(channelsBits[ch]);
-          resultChannelRanges.push(rawRange[ch]);
+          resultChannelRanges.push(channelRange[ch]);
         } else {
-          onData([chindex], ["uint8"], [channelsBits[ch]], [rawRange[ch]], [bitmap.width, bitmap.height]);
+          onData([chindex], ["uint8"], [channelsBits[ch]], [channelRange[ch]], [bitmap.width, bitmap.height]);
         }
       }
     });

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -74,13 +74,7 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     const [w, h] = computeAtlasSize(imageInfo);
     // all data coming from this loader is natively 8-bit
     return JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, dtype, data) =>
-      onData(
-        ch,
-        dtype,
-        data,
-        data.map((arr) => getDataRange(arr)),
-        [w, h]
-      )
+      onData(ch, dtype, data, data.map(getDataRange), [w, h])
     );
   }
 }

--- a/src/loaders/OpenCellLoader.ts
+++ b/src/loaders/OpenCellLoader.ts
@@ -2,7 +2,7 @@ import { ThreadableVolumeLoader, LoadSpec, RawChannelDataCallback, LoadedVolumeI
 import { computeAtlasSize, type ImageInfo } from "../ImageInfo.js";
 import type { VolumeDims } from "../VolumeDims.js";
 import { JsonImageInfoLoader } from "./JsonImageInfoLoader.js";
-import { DATARANGE_UINT8 } from "../types.js";
+import { getDataRange } from "../utils/num_utils.js";
 
 class OpenCellLoader extends ThreadableVolumeLoader {
   async loadDims(_: LoadSpec): Promise<VolumeDims[]> {
@@ -74,7 +74,13 @@ class OpenCellLoader extends ThreadableVolumeLoader {
     const [w, h] = computeAtlasSize(imageInfo);
     // all data coming from this loader is natively 8-bit
     return JsonImageInfoLoader.loadVolumeAtlasData(urls, (ch, dtype, data) =>
-      onData(ch, dtype, data, [DATARANGE_UINT8], [w, h])
+      onData(
+        ch,
+        dtype,
+        data,
+        data.map((arr) => getDataRange(arr)),
+        [w, h]
+      )
     );
   }
 }

--- a/src/loaders/RawArrayLoader.ts
+++ b/src/loaders/RawArrayLoader.ts
@@ -9,7 +9,8 @@ import {
 import { computePackedAtlasDims } from "./VolumeLoaderUtils.js";
 import type { ImageInfo } from "../ImageInfo.js";
 import type { VolumeDims } from "../VolumeDims.js";
-import { DATARANGE_UINT8, Uint8 } from "../types.js";
+import { Uint8 } from "../types.js";
+import { getDataRange } from "../utils/num_utils.js";
 
 // this is the form in which a 4D numpy array arrives as converted
 // by jupyterlab into a js object.
@@ -135,8 +136,9 @@ class RawArrayLoader extends ThreadableVolumeLoader {
       }
       const volSizeBytes = this.data.shape[3] * this.data.shape[2] * this.data.shape[1]; // x*y*z pixels * 1 byte/pixel
       const channelData = new Uint8Array(this.data.buffer.buffer, chindex * volSizeBytes, volSizeBytes);
+      const range = getDataRange(channelData);
       // all data coming from this loader is natively 8-bit
-      onData([chindex], ["uint8"], [channelData], [DATARANGE_UINT8]);
+      onData([chindex], ["uint8"], [channelData], [range]);
     }
 
     return Promise.resolve();

--- a/src/test/lut.test.ts
+++ b/src/test/lut.test.ts
@@ -14,9 +14,8 @@ describe("test histogram", () => {
   const histogram = new Histogram(conedata);
 
   describe("binary volume data", () => {
-    it("has a min of 255", () => {
-      // histogram dataMin is the min nonzero value
-      expect(histogram.getMin()).to.equal(255);
+    it("has a min of 0", () => {
+      expect(histogram.getMin()).to.equal(0);
     });
     it("has a max of 255", () => {
       expect(histogram.getMax()).to.equal(255);

--- a/src/test/volume.test.ts
+++ b/src/test/volume.test.ts
@@ -4,8 +4,8 @@ import Volume from "../Volume";
 import VolumeMaker from "../VolumeMaker";
 import { LUT_ARRAY_LENGTH } from "../Lut";
 import Channel from "../Channel";
-import { DATARANGE_UINT8 } from "../types";
 import { CImageInfo, ImageInfo } from "../ImageInfo";
+import { getDataRange } from "../utils/num_utils";
 
 // PREPARE SOME TEST DATA TO TRY TO DISPLAY A VOLUME.
 const testimgdata: ImageInfo = {
@@ -87,14 +87,14 @@ describe("test volume", () => {
 
       const conedata = VolumeMaker.createCone(size.x, size.y, size.z, size.x / 8, size.z);
 
-      v.setChannelDataFromVolume(0, conedata, DATARANGE_UINT8);
+      v.setChannelDataFromVolume(0, conedata, getDataRange(conedata));
 
       const c0 = v.getChannel(0);
       checkChannelDataConstruction(c0, 0, testimgdata);
 
       const spheredata = VolumeMaker.createSphere(size.x, size.y, size.z, size.z / 4);
 
-      v.setChannelDataFromVolume(1, spheredata, DATARANGE_UINT8);
+      v.setChannelDataFromVolume(1, spheredata, getDataRange(spheredata));
 
       const c1 = v.getChannel(1);
       checkChannelDataConstruction(c1, 1, testimgdata);

--- a/src/utils/num_utils.ts
+++ b/src/utils/num_utils.ts
@@ -230,3 +230,13 @@ export function constrainToAxis(
       return [...src];
   }
 }
+
+export function getDataRange(data: ArrayLike<number>): [number, number] {
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < data.length; i++) {
+    min = Math.min(min, data[i]);
+    max = Math.max(max, data[i]);
+  }
+  return [min, max];
+}

--- a/src/utils/num_utils.ts
+++ b/src/utils/num_utils.ts
@@ -232,9 +232,9 @@ export function constrainToAxis(
 }
 
 export function getDataRange(data: ArrayLike<number>): [number, number] {
-  let min = Infinity;
-  let max = -Infinity;
-  for (let i = 0; i < data.length; i++) {
+  let min = data[0];
+  let max = data[0];
+  for (let i = 1; i < data.length; i++) {
     min = Math.min(min, data[i]);
     max = Math.max(max, data[i]);
   }


### PR DESCRIPTION
Fix for https://github.com/allen-cell-animated/cell-feature-explorer/issues/223, "Volume channels are sometimes very blown out when switching to Full Field mode."

The bug was being caused by the array loaders always assuming a value range from 0 to 255 for uint8 value types. This no longer matched changes to behavior made in #197, where the Lut and Histogram were changed to be relative to a range of min/max value for the raw data. 

This meant that volumes where there were no values for certain numbers would have a mismatch between the onscreen histogram and the actual rendered values. In the case of the described bugged volume, there were no pixels with values from 0-18, which resulted in the rendered ranges looking incorrect.

*Estimated review size: small, 10 minutes*

## Changes
- Changed all array loaders previously depending on `DATARANGE_UINT8` to use `getDataRange()`, a new helper method.
- Added explanatory comments to `Histogram.ts`.

Before:
![image](https://github.com/user-attachments/assets/d9b5b6e9-9bfa-43a0-9ad7-0bf2f3092928)

After:
![image](https://github.com/user-attachments/assets/6c7e4997-c6ac-4b32-98ea-ac65adfb2f73)
